### PR TITLE
Add dashboard with left nav and queue structure

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 #
-# pre-push: run test suites before pushing.
+# pre-push: run test suites and frontend build verification before pushing.
 # Install: make install-hooks
 # Bypass:  git push --no-verify
 #
@@ -22,6 +22,11 @@ fi
 if [ -f frontend/package.json ] && command -v npx >/dev/null 2>&1; then
 	echo "== Frontend tests =="
 	if ! (cd frontend && npx --no-install vitest run 2>/dev/null) ; then
+		failed=1
+	fi
+
+	echo "== Frontend build =="
+	if ! (cd frontend && npm run build) ; then
 		failed=1
 	fi
 else

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,7 +19,7 @@ else
 fi
 
 # ── Frontend ─────────────────────────────────────────────────────────────────
-if [ -f frontend/package.json ] && command -v npx >/dev/null 2>&1; then
+if [ -f frontend/package.json ] && command -v npx >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
 	echo "== Frontend tests =="
 	if ! (cd frontend && npx --no-install vitest run 2>/dev/null) ; then
 		failed=1
@@ -30,7 +30,7 @@ if [ -f frontend/package.json ] && command -v npx >/dev/null 2>&1; then
 		failed=1
 	fi
 else
-	echo "== Frontend tests (skipped: npx not found or no package.json) =="
+	echo "== Frontend checks (skipped: npm/npx not found or no package.json) =="
 fi
 
 # ── Result ───────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ This sets `core.hooksPath` for this clone. Hooks are `#!/usr/bin/env sh` and wor
 | `pre-commit` | `git commit`     | `gofmt` auto-fix and staging, `go vet`, `golangci-lint`, ESLint, swagger doc regeneration  | Seconds |
 | `pre-push`   | `git push`       | `go test ./...`, `vitest run`, `npm run build`                        | Minutes |
 
-Both hooks gracefully skip checks when the required tool is not installed.
+Both hooks gracefully skip checks when the required tools are not installed.
 
 ### Bypass
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ This sets `core.hooksPath` for this clone. Hooks are `#!/usr/bin/env sh` and wor
 | Hook         | When             | What                                                                  | Speed   |
 |--------------|------------------|-----------------------------------------------------------------------|---------|
 | `pre-commit` | `git commit`     | `gofmt` auto-fix and staging, `go vet`, `golangci-lint`, ESLint, swagger doc regeneration  | Seconds |
-| `pre-push`   | `git push`       | `go test ./...`, `vitest run`                                         | Minutes |
+| `pre-push`   | `git push`       | `go test ./...`, `vitest run`, `npm run build`                        | Minutes |
 
 Both hooks gracefully skip checks when the required tool is not installed.
 

--- a/frontend/src/components/BuildActivityList.test.tsx
+++ b/frontend/src/components/BuildActivityList.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { BuildActivityList } from "./BuildActivityList";
+
+describe("BuildActivityList", () => {
+  it("renders the empty state when no activity exists", () => {
+    render(
+      <MemoryRouter>
+        <BuildActivityList
+          title="Queue activity"
+          items={[]}
+          emptyMessage="Nothing running"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Queue activity" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Nothing running")).toBeTruthy();
+  });
+
+  it("renders queue entries using slug and created-at fallbacks", () => {
+    render(
+      <MemoryRouter>
+        <BuildActivityList
+          title="Queue activity"
+          emptyMessage="Nothing running"
+          items={[
+            {
+              kind: "queue",
+              entry: {
+                build_id: "build-1",
+                build_number: 14,
+                project_id: "project-1",
+                project_slug: "platform",
+                priority: 1,
+                status: "queued",
+                created_at: "2026-05-01T00:00:00Z",
+              },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Build #14" })).toHaveAttribute(
+      "href",
+      "/builds/build-1",
+    );
+    expect(screen.getByRole("link", { name: "platform" })).toHaveAttribute(
+      "href",
+      "/projects/project-1",
+    );
+    expect(screen.queryByText(/·/)).toBeNull();
+  });
+
+  it("renders queue entries with the job name when available", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <BuildActivityList
+          title="Queue activity"
+          emptyMessage="Nothing running"
+          items={[
+            {
+              kind: "queue",
+              entry: {
+                build_id: "build-2",
+                build_number: 15,
+                project_id: "project-2",
+                project_name: "Platform",
+                job_name: "release",
+                priority: 1,
+                status: "running",
+                created_at: "2026-05-01T00:00:00Z",
+                queued_at: "2026-05-01T00:00:10Z",
+              },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      container.querySelector(".activity-list-main .subtle-text")?.textContent,
+    ).toContain("Platform · release");
+  });
+
+  it("renders builds using id and project-id fallbacks plus trigger ref", () => {
+    render(
+      <MemoryRouter>
+        <BuildActivityList
+          title="Recent builds"
+          emptyMessage="No builds"
+          items={[
+            {
+              kind: "build",
+              build: {
+                id: "1234567890abcdef",
+                project_id: "project-9",
+                priority: 1,
+                status: "failed",
+                created_at: "2026-05-01T00:00:00Z",
+                queued_at: null,
+                started_at: null,
+                finished_at: null,
+                current_step_index: 0,
+                error_message: null,
+                trigger_ref: "release/1.0",
+              },
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Build 12345678" }),
+    ).toHaveAttribute("href", "/builds/1234567890abcdef");
+    expect(screen.getByRole("link", { name: "project-9" })).toHaveAttribute(
+      "href",
+      "/projects/project-9",
+    );
+    expect(screen.getByText(/release\/1.0/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/BuildActivityList.tsx
+++ b/frontend/src/components/BuildActivityList.tsx
@@ -1,0 +1,102 @@
+import { Link } from "react-router-dom";
+import { StatusBadge } from "./StatusBadge";
+import type { Build, QueueEntry } from "../types/build";
+import { formatTime } from "../utils/time";
+
+type ActivityItem =
+  | { kind: "queue"; entry: QueueEntry }
+  | { kind: "build"; build: Build };
+
+export function BuildActivityList({
+  title,
+  items,
+  emptyMessage,
+}: {
+  title: string;
+  items: ActivityItem[];
+  emptyMessage: string;
+}) {
+  return (
+    <section className="panel dashboard-panel">
+      <div className="dashboard-panel-header">
+        <h3>{title}</h3>
+      </div>
+      {items.length === 0 ? (
+        <div className="empty-state">
+          <p className="empty">{emptyMessage}</p>
+        </div>
+      ) : (
+        <ul className="activity-list">
+          {items.map((item) => {
+            if (item.kind === "queue") {
+              const entry = item.entry;
+              return (
+                <li
+                  key={`queue-${entry.build_id}`}
+                  className="activity-list-item"
+                >
+                  <div className="activity-list-main">
+                    <div className="activity-list-title-row">
+                      <Link to={`/builds/${entry.build_id}`}>
+                        Build #{entry.build_number}
+                      </Link>
+                      <StatusBadge status={entry.status} />
+                    </div>
+                    <p className="subtle-text">
+                      <Link to={`/projects/${entry.project_id}`}>
+                        {entry.project_name?.trim() ||
+                          entry.project_slug?.trim() ||
+                          entry.project_id}
+                      </Link>
+                      {entry.job_name?.trim() ? ` · ${entry.job_name}` : ""}
+                    </p>
+                  </div>
+                  <div className="activity-list-meta subtle-text">
+                    {formatTime(
+                      entry.started_at ?? entry.queued_at ?? entry.created_at,
+                    )}
+                  </div>
+                </li>
+              );
+            }
+
+            const build = item.build;
+            return (
+              <li key={`build-${build.id}`} className="activity-list-item">
+                <div className="activity-list-main">
+                  <div className="activity-list-title-row">
+                    <Link to={`/builds/${build.id}`}>
+                      Build{" "}
+                      {build.build_number
+                        ? `#${build.build_number}`
+                        : build.id.slice(0, 8)}
+                    </Link>
+                    <StatusBadge status={build.status} />
+                  </div>
+                  <p className="subtle-text">
+                    <Link to={`/projects/${build.project_id}`}>
+                      {build.project_name?.trim() ||
+                        build.project_slug?.trim() ||
+                        build.project_id}
+                    </Link>
+                    {build.trigger_ref?.trim()
+                      ? ` · ${build.trigger_ref.trim()}`
+                      : ""}
+                  </p>
+                </div>
+                <div className="activity-list-meta subtle-text">
+                  {formatTime(
+                    build.finished_at ??
+                      build.started_at ??
+                      build.queued_at ??
+                      build.created_at,
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -196,4 +196,23 @@ describe("Layout", () => {
       expect(mockedGetMe.mock.calls.length).toBeGreaterThan(initialCalls);
     });
   });
+
+  it("shows the logout control for authenticated oidc users", async () => {
+    mockedGetMe.mockResolvedValue({
+      auth_mode: "oidc",
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+        display_name: "User Example",
+        global_role: "admin",
+      },
+    });
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByText("User Example")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Logout" })).toBeTruthy();
+    });
+  });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,22 @@ import { NavLink, Outlet } from "react-router-dom";
 import { useAuth } from "../auth-context";
 import { useTheme } from "../theme-context";
 
+type NavigationItem = {
+  to: string;
+  label: string;
+  matchPrefix?: string;
+  visible?: boolean;
+};
+
+const primaryNavigation: NavigationItem[] = [
+  { to: "/dashboard", label: "Dashboard" },
+  { to: "/projects", label: "Projects" },
+  { to: "/jobs", label: "Jobs" },
+  { to: "/builds", label: "Builds" },
+  { to: "/queue", label: "Queue" },
+  { to: "/artifacts", label: "Artifacts" },
+];
+
 export function Layout() {
   const { theme, toggleTheme } = useTheme();
   const {
@@ -19,6 +35,11 @@ export function Layout() {
   const showUsersLink = authMode === "disabled" || isGlobalAdmin;
   const showTokensLink = authMode !== "disabled";
   const displayName = currentUser?.display_name || currentUser?.email;
+  const settingsNavigation: NavigationItem[] = [
+    { to: "/settings/credentials", label: "Credentials" },
+    { to: "/settings/tokens", label: "Tokens", visible: showTokensLink },
+    { to: "/settings/users", label: "Users", visible: showUsersLink },
+  ];
 
   return (
     <div className="app">
@@ -28,78 +49,6 @@ export function Layout() {
             Coyote CI
           </NavLink>
           <div className="header-actions">
-            {showNavigation && (
-              <nav className="main-nav" aria-label="Primary">
-                <NavLink
-                  to="/projects"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Projects
-                </NavLink>
-                <NavLink
-                  to="/jobs"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Jobs
-                </NavLink>
-                <NavLink
-                  to="/builds"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Builds
-                </NavLink>
-                <NavLink
-                  to="/queue"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Queue
-                </NavLink>
-                <NavLink
-                  to="/artifacts"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Artifacts
-                </NavLink>
-                {showUsersLink && (
-                  <NavLink
-                    to="/settings/users"
-                    className={({ isActive }) =>
-                      isActive ? "main-nav-link is-active" : "main-nav-link"
-                    }
-                  >
-                    Users
-                  </NavLink>
-                )}
-                {showTokensLink && (
-                  <NavLink
-                    to="/settings/tokens"
-                    className={({ isActive }) =>
-                      isActive ? "main-nav-link is-active" : "main-nav-link"
-                    }
-                  >
-                    Tokens
-                  </NavLink>
-                )}
-                <NavLink
-                  to="/settings/credentials"
-                  className={({ isActive }) =>
-                    isActive ? "main-nav-link is-active" : "main-nav-link"
-                  }
-                >
-                  Credentials
-                </NavLink>
-              </nav>
-            )}
             {authStatus === "authenticated" && displayName && (
               <div className="identity-chip">
                 <span>{displayName}</span>
@@ -160,9 +109,58 @@ export function Layout() {
             onAction={() => void refreshCurrentUser()}
           />
         )}
-        {authStatus === "authenticated" && <Outlet />}
+        {authStatus === "authenticated" && (
+          <div className="app-shell">
+            {showNavigation ? (
+              <aside className="sidebar" aria-label="Application navigation">
+                <nav className="sidebar-nav" aria-label="Primary">
+                  <div className="sidebar-section">
+                    <p className="sidebar-section-label">Overview</p>
+                    {primaryNavigation.map((item) => (
+                      <SidebarLink
+                        key={item.to}
+                        to={item.to}
+                        label={item.label}
+                      />
+                    ))}
+                  </div>
+                  <div className="sidebar-section">
+                    <p className="sidebar-section-label">Settings</p>
+                    {settingsNavigation
+                      .filter((item) => item.visible ?? true)
+                      .map((item) => (
+                        <SidebarLink
+                          key={item.to}
+                          to={item.to}
+                          label={item.label}
+                        />
+                      ))}
+                  </div>
+                </nav>
+              </aside>
+            ) : null}
+            <section className="content-shell">
+              <div className="page-container">
+                <Outlet />
+              </div>
+            </section>
+          </div>
+        )}
       </main>
     </div>
+  );
+}
+
+function SidebarLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        isActive ? "sidebar-link is-active" : "sidebar-link"
+      }
+    >
+      {label}
+    </NavLink>
   );
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,7 +5,6 @@ import { useTheme } from "../theme-context";
 type NavigationItem = {
   to: string;
   label: string;
-  matchPrefix?: string;
   visible?: boolean;
 };
 
@@ -78,36 +77,42 @@ export function Layout() {
       </header>
       <main className="main">
         {authStatus === "loading" && (
-          <AuthStatePanel
-            title="Loading session"
-            message="Checking your Coyote CI session."
-          />
+          <div className="auth-panel-shell">
+            <AuthStatePanel
+              title="Loading session"
+              message="Checking your Coyote CI session."
+            />
+          </div>
         )}
         {authStatus === "unauthenticated" && (
-          <AuthStatePanel
-            title={
-              authMode === "header"
-                ? "External authentication required"
-                : "Sign in to Coyote CI"
-            }
-            message={
-              authMode === "header"
-                ? "Coyote CI is configured for trusted proxy authentication. Sign in through the configured gateway or proxy, then retry."
-                : "Use your configured identity provider to continue."
-            }
-            actionLabel={loginAvailable ? "Sign in" : undefined}
-            onAction={loginAvailable ? login : undefined}
-          />
+          <div className="auth-panel-shell">
+            <AuthStatePanel
+              title={
+                authMode === "header"
+                  ? "External authentication required"
+                  : "Sign in to Coyote CI"
+              }
+              message={
+                authMode === "header"
+                  ? "Coyote CI is configured for trusted proxy authentication. Sign in through the configured gateway or proxy, then retry."
+                  : "Use your configured identity provider to continue."
+              }
+              actionLabel={loginAvailable ? "Sign in" : undefined}
+              onAction={loginAvailable ? login : undefined}
+            />
+          </div>
         )}
         {authStatus === "error" && (
-          <AuthStatePanel
-            title="Unable to load session"
-            message={
-              error?.message ?? "The current session could not be loaded."
-            }
-            actionLabel="Retry"
-            onAction={() => void refreshCurrentUser()}
-          />
+          <div className="auth-panel-shell">
+            <AuthStatePanel
+              title="Unable to load session"
+              message={
+                error?.message ?? "The current session could not be loaded."
+              }
+              actionLabel="Retry"
+              onAction={() => void refreshCurrentUser()}
+            />
+          </div>
         )}
         {authStatus === "authenticated" && (
           <div className="app-shell">

--- a/frontend/src/components/PageHeader.test.tsx
+++ b/frontend/src/components/PageHeader.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PageHeader } from "./PageHeader";
+
+describe("PageHeader", () => {
+  it("renders all optional sections when provided", () => {
+    render(
+      <MemoryRouter>
+        <PageHeader
+          eyebrow="Dashboard"
+          title="Overview"
+          description="Current activity"
+          actions={<a href="/projects">Projects</a>}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Dashboard")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.getByText("Current activity")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Projects" })).toBeTruthy();
+  });
+
+  it("omits optional sections when not provided", () => {
+    const { container } = render(<PageHeader title="Builds" />);
+
+    expect(screen.getByRole("heading", { name: "Builds" })).toBeTruthy();
+    expect(container.querySelector(".page-eyebrow")).toBeNull();
+    expect(container.querySelector(".page-header-actions")).toBeNull();
+    expect(container.querySelector(".subtle-text")).toBeNull();
+  });
+});

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+  eyebrow,
+}: {
+  title: string;
+  description?: ReactNode;
+  actions?: ReactNode;
+  eyebrow?: ReactNode;
+}) {
+  return (
+    <div className="page-header-row">
+      <div>
+        {eyebrow ? <div className="page-eyebrow">{eyebrow}</div> : null}
+        <h2>{title}</h2>
+        {description ? <div className="subtle-text">{description}</div> : null}
+      </div>
+      {actions ? <div className="page-header-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectList.test.tsx
+++ b/frontend/src/components/ProjectList.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ProjectList } from "./ProjectList";
+
+describe("ProjectList", () => {
+  it("renders project cards and falls back when description is blank", () => {
+    render(
+      <MemoryRouter>
+        <ProjectList
+          projects={[
+            {
+              id: "project/one",
+              name: "Platform",
+              slug: "platform",
+              description: "   ",
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-01T00:00:00Z",
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Platform" })).toHaveAttribute(
+      "href",
+      "/projects/project/one",
+    );
+    expect(screen.getByText("No project description yet.")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View builds" })).toHaveAttribute(
+      "href",
+      "/builds?project_id=project%2Fone",
+    );
+  });
+});

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+import type { Project } from "../types/project";
+import { formatTime } from "../utils/time";
+
+export function ProjectList({ projects }: { projects: Project[] }) {
+  return (
+    <div className="project-card-grid">
+      {projects.map((project) => (
+        <article key={project.id} className="project-card">
+          <div className="project-card-header">
+            <div>
+              <h3>
+                <Link to={`/projects/${project.id}`}>{project.name}</Link>
+              </h3>
+              <p className="subtle-text">{project.slug}</p>
+            </div>
+            <Link className="secondary-button" to={`/projects/${project.id}`}>
+              Open
+            </Link>
+          </div>
+          <p className="project-card-description">
+            {project.description?.trim() || "No project description yet."}
+          </p>
+          <div className="project-card-footer">
+            <span className="subtle-text">
+              Updated {formatTime(project.updated_at)}
+            </span>
+            <Link to={`/builds?project_id=${encodeURIComponent(project.id)}`}>
+              View builds
+            </Link>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/SummaryCard.test.tsx
+++ b/frontend/src/components/SummaryCard.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SummaryCard } from "./SummaryCard";
+
+describe("SummaryCard", () => {
+  it("uses the default tone and hides optional sections when omitted", () => {
+    const { container } = render(<SummaryCard title="Builds" value="12" />);
+
+    expect(screen.getByText("Builds")).toBeTruthy();
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(container.querySelector(".summary-card-default")).toBeTruthy();
+    expect(container.querySelector(".summary-card-description")).toBeNull();
+    expect(container.querySelector(".summary-card-footer")).toBeNull();
+  });
+
+  it("renders custom tone, description, and footer", () => {
+    const { container } = render(
+      <SummaryCard
+        title="Failures"
+        value="2"
+        tone="danger"
+        description="Needs attention"
+        footer={<span>Open builds</span>}
+      />,
+    );
+
+    expect(container.querySelector(".summary-card-danger")).toBeTruthy();
+    expect(screen.getByText("Needs attention")).toBeTruthy();
+    expect(screen.getByText("Open builds")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+export function SummaryCard({
+  title,
+  value,
+  tone = "default",
+  description,
+  footer,
+}: {
+  title: string;
+  value: ReactNode;
+  tone?: "default" | "info" | "warning" | "danger" | "success";
+  description?: ReactNode;
+  footer?: ReactNode;
+}) {
+  return (
+    <section className={`summary-card summary-card-${tone}`}>
+      <p className="summary-card-title">{title}</p>
+      <p className="summary-card-value">{value}</p>
+      {description ? (
+        <p className="summary-card-description">{description}</p>
+      ) : null}
+      {footer ? <div className="summary-card-footer">{footer}</div> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { DashboardPage } from "./DashboardPage";
+import { listBuilds, listProjects, listQueue } from "../api";
+
+vi.mock("../api", () => ({
+  listProjects: vi.fn(),
+  listQueue: vi.fn(),
+  listBuilds: vi.fn(),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DashboardPage", () => {
+  const mockedListProjects = vi.mocked(listProjects);
+  const mockedListQueue = vi.mocked(listQueue);
+  const mockedListBuilds = vi.mocked(listBuilds);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedListProjects.mockResolvedValue([
+      {
+        id: "project-1",
+        name: "Platform",
+        slug: "platform",
+        description: "Core platform pipelines",
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    mockedListQueue.mockResolvedValue([
+      {
+        build_id: "build-1",
+        build_number: 12,
+        project_id: "project-1",
+        project_name: "Platform",
+        job_id: "job-1",
+        job_name: "main",
+        priority: 5,
+        status: "running",
+        created_at: "2026-05-01T00:00:00Z",
+        queued_at: "2026-05-01T00:00:10Z",
+        started_at: "2026-05-01T00:00:15Z",
+      },
+    ]);
+    mockedListBuilds.mockResolvedValue([
+      {
+        id: "build-2",
+        build_number: 11,
+        priority: 5,
+        project_id: "project-1",
+        project_name: "Platform",
+        project_slug: "platform",
+        status: "failed",
+        created_at: "2026-05-01T00:00:00Z",
+        queued_at: "2026-05-01T00:00:05Z",
+        started_at: "2026-05-01T00:00:07Z",
+        finished_at: "2026-05-01T00:01:00Z",
+        current_step_index: 2,
+        error_message: "boom",
+        trigger_ref: "main",
+      },
+    ]);
+  });
+
+  it("renders accessible projects and recent activity", async () => {
+    renderPage();
+
+    expect(screen.getByText("Where should I look right now?")).toBeTruthy();
+
+    await waitFor(() => {
+      const projectLinks = screen.getAllByRole("link", { name: "Platform" });
+
+      expect(projectLinks.length).toBeGreaterThan(0);
+      expect(
+        projectLinks.some(
+          (link) => link.getAttribute("href") === "/projects/project-1",
+        ),
+      ).toBe(true);
+      expect(screen.getByRole("link", { name: "Build #12" })).toHaveAttribute(
+        "href",
+        "/builds/build-1",
+      );
+      expect(screen.getByRole("link", { name: "Build #11" })).toHaveAttribute(
+        "href",
+        "/builds/build-2",
+      );
+      expect(screen.getByText("Recent failures")).toBeTruthy();
+      expect(screen.getByText("Core platform pipelines")).toBeTruthy();
+    });
+  });
+
+  it("shows empty states when only project data is available", async () => {
+    mockedListQueue.mockResolvedValue([]);
+    mockedListBuilds.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Platform")).toBeTruthy();
+      expect(
+        screen.getByText("No queued or running builds right now."),
+      ).toBeTruthy();
+      expect(screen.getByText("No recent builds yet.")).toBeTruthy();
+    });
+  });
+
+  it("shows project error state when projects cannot be loaded", async () => {
+    mockedListProjects.mockRejectedValue(new Error("no access"));
+    mockedListQueue.mockResolvedValue([]);
+    mockedListBuilds.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load projects: Error: no access"),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { DashboardPage } from "./DashboardPage";
@@ -132,6 +132,128 @@ describe("DashboardPage", () => {
       expect(
         screen.getByText("Failed to load projects: Error: no access"),
       ).toBeTruthy();
+    });
+  });
+
+  it("shows the empty projects state and the non-failure summary copy", async () => {
+    mockedListProjects.mockResolvedValue([]);
+    mockedListQueue.mockResolvedValue([]);
+    mockedListBuilds.mockResolvedValue([
+      {
+        id: "build-3",
+        build_number: 9,
+        priority: 1,
+        project_id: "project-2",
+        status: "success",
+        created_at: "2026-05-01T00:00:00Z",
+        queued_at: null,
+        started_at: null,
+        finished_at: null,
+        current_step_index: 1,
+        error_message: null,
+      },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("No projects available yet.")).toBeTruthy();
+      expect(
+        screen.getByText("No recent failed builds in the current result set."),
+      ).toBeTruthy();
+    });
+  });
+
+  it("shows queue and build error states independently", async () => {
+    mockedListQueue.mockRejectedValue(new Error("queue unavailable"));
+    mockedListBuilds.mockRejectedValue(new Error("builds unavailable"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load queue: Error: queue unavailable"),
+      ).toBeTruthy();
+      expect(
+        screen.getByText("Failed to load builds: Error: builds unavailable"),
+      ).toBeTruthy();
+      expect(
+        screen.getByText("Unable to load queue: Error: queue unavailable"),
+      ).toBeTruthy();
+      expect(
+        screen.getByText(
+          "Unable to load recent builds: Error: builds unavailable",
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  it("shows loading states while queries are pending", () => {
+    mockedListProjects.mockImplementation(
+      () => new Promise(() => undefined) as Promise<never>,
+    );
+    mockedListQueue.mockImplementation(
+      () => new Promise(() => undefined) as Promise<never>,
+    );
+    mockedListBuilds.mockImplementation(
+      () => new Promise(() => undefined) as Promise<never>,
+    );
+
+    renderPage();
+
+    expect(screen.getAllByText("Loading…")).toHaveLength(3);
+    expect(screen.getByText("Loading projects…")).toBeTruthy();
+    expect(screen.getByText("Loading queue…")).toBeTruthy();
+    expect(screen.getByText("Loading recent builds…")).toBeTruthy();
+  });
+
+  it("sorts recent builds by newest available lifecycle timestamp", async () => {
+    mockedListBuilds.mockResolvedValue([
+      {
+        id: "build-old",
+        build_number: 1,
+        priority: 1,
+        project_id: "project-1",
+        project_name: "Platform",
+        status: "success",
+        created_at: "2026-05-01T00:00:00Z",
+        queued_at: "2026-05-01T00:00:05Z",
+        started_at: null,
+        finished_at: null,
+        current_step_index: 1,
+        error_message: null,
+      },
+      {
+        id: "build-new",
+        build_number: 2,
+        priority: 1,
+        project_id: "project-1",
+        project_name: "Platform",
+        status: "success",
+        created_at: "2026-05-01T00:00:00Z",
+        queued_at: "2026-05-01T00:00:05Z",
+        started_at: "2026-05-01T00:02:00Z",
+        finished_at: null,
+        current_step_index: 1,
+        error_message: null,
+      },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      const recentBuildSection = screen
+        .getByRole("heading", { name: "Recent builds" })
+        .closest("section");
+
+      expect(recentBuildSection).toBeTruthy();
+      const links = within(recentBuildSection as HTMLElement).getAllByRole(
+        "link",
+        { name: /Build #/ },
+      );
+
+      expect(links[0]).toHaveAttribute("href", "/builds/build-new");
+      expect(links[1]).toHaveAttribute("href", "/builds/build-old");
     });
   });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,217 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { listBuilds, listProjects, listQueue } from "../api";
+import { BuildActivityList } from "../components/BuildActivityList";
+import { PageHeader } from "../components/PageHeader";
+import { ProjectList } from "../components/ProjectList";
+import { SummaryCard } from "../components/SummaryCard";
+import type { Build } from "../types/build";
+
+const DASHBOARD_RECENT_LIMIT = 6;
+const DASHBOARD_PROJECT_LIMIT = 6;
+
+function sortByNewest(builds: Build[]): Build[] {
+  return [...builds].sort((left, right) => {
+    const leftTime = Date.parse(
+      left.finished_at ?? left.started_at ?? left.queued_at ?? left.created_at,
+    );
+    const rightTime = Date.parse(
+      right.finished_at ??
+        right.started_at ??
+        right.queued_at ??
+        right.created_at,
+    );
+
+    return rightTime - leftTime;
+  });
+}
+
+export function DashboardPage() {
+  const {
+    data: projects,
+    isLoading: projectsLoading,
+    error: projectsError,
+  } = useQuery({
+    queryKey: ["projects"],
+    queryFn: listProjects,
+  });
+
+  const {
+    data: queueEntries,
+    isLoading: queueLoading,
+    error: queueError,
+  } = useQuery({
+    queryKey: ["dashboardQueue"],
+    queryFn: () => listQueue(),
+  });
+
+  const {
+    data: builds,
+    isLoading: buildsLoading,
+    error: buildsError,
+  } = useQuery({
+    queryKey: ["dashboardBuilds"],
+    queryFn: () => listBuilds(),
+  });
+
+  const recentBuilds = sortByNewest(builds ?? []).slice(
+    0,
+    DASHBOARD_RECENT_LIMIT,
+  );
+  const failedBuilds = (builds ?? []).filter(
+    (build) => build.status === "failed",
+  );
+  const visibleProjects = (projects ?? []).slice(0, DASHBOARD_PROJECT_LIMIT);
+
+  return (
+    <div className="page-content page-dashboard">
+      <PageHeader
+        eyebrow="Dashboard"
+        title="Where should I look right now?"
+        description="Projects are the main entry point. Queue activity and recent builds surface the work that needs attention next."
+        actions={
+          <>
+            <Link className="secondary-button" to="/projects">
+              View all projects
+            </Link>
+            <Link className="action-link" to="/jobs/new">
+              Create job
+            </Link>
+          </>
+        }
+      />
+
+      <section
+        className="dashboard-summary-grid"
+        aria-label="Dashboard summary"
+      >
+        <SummaryCard
+          title="Accessible projects"
+          value={projectsLoading ? "Loading…" : String(projects?.length ?? 0)}
+          description={
+            projectsError
+              ? `Unable to load projects: ${String(projectsError)}`
+              : "Projects group jobs, builds, and artifact history."
+          }
+        />
+        <SummaryCard
+          title="Queued or running"
+          value={queueLoading ? "Loading…" : String(queueEntries?.length ?? 0)}
+          tone={queueEntries && queueEntries.length > 0 ? "warning" : "info"}
+          description={
+            queueError
+              ? `Unable to load queue: ${String(queueError)}`
+              : "Current work in dispatch or execution."
+          }
+          footer={<Link to="/queue">Open queue</Link>}
+        />
+        <SummaryCard
+          title="Recent failures"
+          value={buildsLoading ? "Loading…" : String(failedBuilds.length)}
+          tone={failedBuilds.length > 0 ? "danger" : "success"}
+          description={
+            buildsError
+              ? `Unable to load recent builds: ${String(buildsError)}`
+              : failedBuilds.length > 0
+                ? "Recent builds that need attention."
+                : "No recent failed builds in the current result set."
+          }
+          footer={<Link to="/builds">Open builds</Link>}
+        />
+      </section>
+
+      <div className="dashboard-layout-grid">
+        <section className="panel dashboard-panel">
+          <div className="dashboard-panel-header">
+            <div>
+              <h3>Projects</h3>
+              <p className="subtle-text">Projects you can access right now.</p>
+            </div>
+          </div>
+          {projectsLoading ? <p>Loading projects…</p> : null}
+          {projectsError ? (
+            <div className="empty-state">
+              <p className="error-text">
+                Failed to load projects: {String(projectsError)}
+              </p>
+            </div>
+          ) : null}
+          {!projectsLoading &&
+          !projectsError &&
+          (!projects || projects.length === 0) ? (
+            <div className="empty-state">
+              <p className="empty">No projects available yet.</p>
+              <p className="subtle-text">
+                Create a project before grouping jobs and durable build history.
+              </p>
+            </div>
+          ) : null}
+          {!projectsLoading &&
+          !projectsError &&
+          projects &&
+          projects.length > 0 ? (
+            <ProjectList projects={visibleProjects} />
+          ) : null}
+        </section>
+
+        <div className="dashboard-activity-column">
+          {queueLoading ? (
+            <section className="panel dashboard-panel">
+              <div className="dashboard-panel-header">
+                <h3>Queue activity</h3>
+              </div>
+              <p>Loading queue…</p>
+            </section>
+          ) : queueError ? (
+            <section className="panel dashboard-panel">
+              <div className="dashboard-panel-header">
+                <h3>Queue activity</h3>
+              </div>
+              <p className="error-text">
+                Failed to load queue: {String(queueError)}
+              </p>
+            </section>
+          ) : (
+            <BuildActivityList
+              title="Queue activity"
+              items={(queueEntries ?? [])
+                .slice(0, DASHBOARD_RECENT_LIMIT)
+                .map((entry) => ({
+                  kind: "queue" as const,
+                  entry,
+                }))}
+              emptyMessage="No queued or running builds right now."
+            />
+          )}
+
+          {buildsLoading ? (
+            <section className="panel dashboard-panel">
+              <div className="dashboard-panel-header">
+                <h3>Recent builds</h3>
+              </div>
+              <p>Loading recent builds…</p>
+            </section>
+          ) : buildsError ? (
+            <section className="panel dashboard-panel">
+              <div className="dashboard-panel-header">
+                <h3>Recent builds</h3>
+              </div>
+              <p className="error-text">
+                Failed to load builds: {String(buildsError)}
+              </p>
+            </section>
+          ) : (
+            <BuildActivityList
+              title="Recent builds"
+              items={recentBuilds.map((build) => ({
+                kind: "build" as const,
+                build,
+              }))}
+              emptyMessage="No recent builds yet."
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/router.test.tsx
+++ b/frontend/src/routes/router.test.tsx
@@ -49,12 +49,9 @@ function renderRouter(initialEntries: string[]) {
       queries: { retry: false },
     },
   });
-  const router = createMemoryRouter(
-    appRoutes as Parameters<typeof createMemoryRouter>[0],
-    {
-      initialEntries,
-    },
-  );
+  const router = createMemoryRouter(appRoutes, {
+    initialEntries,
+  });
 
   return render(
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/routes/router.test.tsx
+++ b/frontend/src/routes/router.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "../theme";
+import { AuthProvider } from "../auth";
+import { appRoutes } from "./router";
+import {
+  getAuthConfig,
+  getMe,
+  listBuilds,
+  listProjects,
+  listQueue,
+} from "../api";
+import { installMockLocalStorage } from "../test/browserMocks";
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    getAuthConfig: vi.fn(),
+    getMe: vi.fn(),
+    listProjects: vi.fn(),
+    listQueue: vi.fn(),
+    listBuilds: vi.fn(),
+  };
+});
+
+function installMatchMedia(initialMatches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: initialMatches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function renderRouter(initialEntries: string[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  const router = createMemoryRouter(
+    appRoutes as Parameters<typeof createMemoryRouter>[0],
+    {
+      initialEntries,
+    },
+  );
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("router dashboard home", () => {
+  const mockedGetAuthConfig = vi.mocked(getAuthConfig);
+  const mockedGetMe = vi.mocked(getMe);
+  const mockedListProjects = vi.mocked(listProjects);
+  const mockedListQueue = vi.mocked(listQueue);
+  const mockedListBuilds = vi.mocked(listBuilds);
+
+  beforeEach(() => {
+    installMockLocalStorage();
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+    installMatchMedia(false);
+    mockedGetAuthConfig.mockResolvedValue({
+      auth_mode: "disabled",
+      login_url: null,
+    });
+    mockedGetMe.mockResolvedValue({
+      auth_mode: "disabled",
+      user: {
+        id: "disabled-mode-user",
+        email: "dev@local.coyote-ci",
+        global_role: "admin",
+      },
+    });
+    mockedListProjects.mockResolvedValue([]);
+    mockedListQueue.mockResolvedValue([]);
+    mockedListBuilds.mockResolvedValue([]);
+  });
+
+  it("redirects the home route to the dashboard", async () => {
+    renderRouter(["/"]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Dashboard" })).toHaveClass(
+        "is-active",
+      );
+      expect(screen.getByText("Where should I look right now?")).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,4 +1,8 @@
-import { createBrowserRouter, Navigate } from "react-router-dom";
+import {
+  createBrowserRouter,
+  Navigate,
+  type RouteObject,
+} from "react-router-dom";
 import { Layout } from "../components/Layout";
 import { BuildsListPage } from "../pages/BuildsListPage";
 import { BuildDetailPage } from "../pages/BuildDetailPage";
@@ -16,7 +20,7 @@ import { ProjectsListPage } from "../pages/ProjectsListPage";
 import { ProjectDetailPage } from "../pages/ProjectDetailPage";
 import { DashboardPage } from "../pages/DashboardPage";
 
-export const appRoutes = [
+export const appRoutes: RouteObject[] = [
   {
     element: <Layout />,
     children: [
@@ -38,6 +42,6 @@ export const appRoutes = [
       { path: "/settings/credentials", element: <CredentialsPage /> },
     ],
   },
-] as const;
+];
 
 export const router = createBrowserRouter(appRoutes);

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -14,12 +14,14 @@ import { APITokensPage } from "../pages/APITokensPage";
 import { UsersPage } from "../pages/UsersPage";
 import { ProjectsListPage } from "../pages/ProjectsListPage";
 import { ProjectDetailPage } from "../pages/ProjectDetailPage";
+import { DashboardPage } from "../pages/DashboardPage";
 
-export const router = createBrowserRouter([
+export const appRoutes = [
   {
     element: <Layout />,
     children: [
-      { path: "/", element: <Navigate to="/jobs" replace /> },
+      { path: "/", element: <Navigate to="/dashboard" replace /> },
+      { path: "/dashboard", element: <DashboardPage /> },
       { path: "/builds", element: <BuildsListPage /> },
       { path: "/builds/:id", element: <BuildDetailPage /> },
       { path: "/queue", element: <QueuePage /> },
@@ -36,4 +38,6 @@ export const router = createBrowserRouter([
       { path: "/settings/credentials", element: <CredentialsPage /> },
     ],
   },
-]);
+] as const;
+
+export const router = createBrowserRouter(appRoutes);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -426,9 +426,92 @@ input[type="radio"] {
 }
 
 .main {
-  max-width: 1200px;
-  margin: 0 auto;
   padding: 24px;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+  max-width: 1360px;
+  margin: 0 auto;
+}
+
+.sidebar {
+  position: sticky;
+  top: 88px;
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 18px;
+}
+
+.sidebar-section {
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  background: var(--color-surface-inset);
+  box-shadow: var(--color-shadow-soft);
+}
+
+.sidebar-section-label,
+.page-eyebrow,
+.summary-card-title {
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+}
+
+.sidebar-section-label {
+  margin-bottom: 10px;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  transition:
+    background-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.sidebar-link:hover {
+  background: var(--color-surface);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.sidebar-link.is-active {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.content-shell {
+  min-width: 0;
+}
+
+.page-container,
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.page-container {
+  min-width: 0;
+}
+
+.page-eyebrow {
+  margin-bottom: 6px;
 }
 
 .page-shell {
@@ -457,6 +540,12 @@ fieldset {
   width: min(560px, 100%);
   padding: 24px;
   border-radius: 18px;
+}
+
+.dashboard-panel,
+.summary-card,
+.project-card {
+  width: 100%;
 }
 
 .auth-state-panel {
@@ -515,6 +604,144 @@ fieldset {
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
+}
+
+.dashboard-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.summary-card {
+  padding: 18px;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  background: linear-gradient(
+    180deg,
+    var(--color-surface-raised) 0%,
+    var(--color-surface) 100%
+  );
+  box-shadow: var(--color-shadow-soft);
+}
+
+.summary-card-value {
+  margin-top: 8px;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.summary-card-description,
+.summary-card-footer,
+.project-card-description,
+.project-card-footer,
+.activity-list-meta {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.summary-card-description {
+  margin-top: 8px;
+}
+
+.summary-card-footer {
+  margin-top: 10px;
+}
+
+.summary-card-info {
+  border-color: var(--color-info-border);
+}
+
+.summary-card-warning {
+  border-color: var(--color-warning-border);
+}
+
+.summary-card-danger {
+  border-color: var(--color-error-border);
+}
+
+.summary-card-success {
+  border-color: var(--color-success-border);
+}
+
+.dashboard-layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.9fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.dashboard-activity-column {
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-panel {
+  padding: 20px;
+}
+
+.dashboard-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.dashboard-panel-header h3,
+.project-card h3 {
+  margin: 0;
+}
+
+.project-card-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.project-card {
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background: var(--color-surface-raised);
+}
+
+.project-card-header,
+.project-card-footer,
+.activity-list-item,
+.activity-list-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.project-card-description {
+  margin: 12px 0;
+}
+
+.activity-list {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+}
+
+.activity-list-item {
+  align-items: flex-start;
+  padding: 12px 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.activity-list-item:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.activity-list-main {
+  min-width: 0;
+}
+
+.activity-list-title-row {
+  justify-content: flex-start;
 }
 
 .artifact-copy-status {
@@ -1361,6 +1588,9 @@ h3 {
 }
 
 @media (max-width: 900px) {
+  .app-shell,
+  .dashboard-layout-grid,
+  .dashboard-summary-grid,
   .settings-grid,
   .artifact-filters-panel,
   .artifact-detail-grid,
@@ -1368,14 +1598,22 @@ h3 {
     grid-template-columns: 1fr;
   }
 
+  .sidebar {
+    position: static;
+  }
+
   .artifact-card-heading,
   .artifact-version-header,
-  .page-header-row {
+  .page-header-row,
+  .project-card-header,
+  .project-card-footer,
+  .activity-list-item {
     flex-direction: column;
   }
 
   .artifact-card-summary,
-  .page-header-actions {
+  .page-header-actions,
+  .activity-list-title-row {
     align-items: flex-start;
   }
 
@@ -1412,16 +1650,17 @@ h3 {
     padding: 20px 16px 32px;
   }
 
+  .sidebar-nav {
+    gap: 12px;
+  }
+
   .theme-toggle,
-  .main-nav,
-  .main-nav-link,
   .queue-build-form,
   .api-token-created-value,
   .job-form-actions {
     width: 100%;
   }
 
-  .main-nav-link,
   .theme-toggle,
   .api-token-created-value {
     justify-content: center;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -521,6 +521,11 @@ input[type="radio"] {
   padding: 32px 20px;
 }
 
+.auth-panel-shell {
+  display: grid;
+  justify-items: center;
+}
+
 .panel,
 .settings-panel,
 .detail-grid,
@@ -722,6 +727,8 @@ fieldset {
 .activity-list {
   display: grid;
   gap: 12px;
+  margin: 0;
+  padding: 0;
   list-style: none;
 }
 


### PR DESCRIPTION
Adds a new authenticated “Dashboard” landing page and refactors the frontend layout into a left-nav app shell, with supporting UI components and tests. This aligns the UI toward a more “control plane” feel by surfacing project access, queue activity, and recent build outcomes up-front.

Changes:

Introduces /dashboard as the new home route, plus a new DashboardPage with summary cards, project cards, and activity lists.
Replaces the top navigation with a sticky left sidebar (app-shell) and adds new reusable UI components (PageHeader, SummaryCard, ProjectList, BuildActivityList).
Updates pre-push tooling/docs to also run a frontend build check.
