### PR TITLE
Propagate sidebar & topnav to all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Actionlint](https://github.com/radiation/coyote-ci/actions/workflows/actionlint.yml/badge.svg)](https://github.com/radiation/coyote-ci/actions/workflows/actionlint.yml)
 [![codecov](https://codecov.io/gh/radiation/coyote-ci/branch/main/graph/badge.svg)](https://codecov.io/gh/radiation/coyote-ci)
 [![Go 1.26](https://img.shields.io/badge/go-1.26-00ADD8.svg)](backend/go.mod)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-yellow)](LICENSE)
 
 Coyote CI is a greenfield CI/orchestration system focused on a small, correct, and understandable core.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - /tmp/coyote-builds:/tmp/coyote-builds
 
   frontend:
-    image: node:22-alpine
+    image: node:22
     container_name: coyote-ci-frontend
     working_dir: /app
     depends_on:

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from "react-router-dom";
+import type { ReactNode } from "react";
+
+export type AppShellNavigationItem = {
+  to: string;
+  label: string;
+  visible?: boolean;
+};
+
+export function AppShell({
+  primaryNavigation,
+  settingsNavigation,
+  children,
+}: {
+  primaryNavigation: AppShellNavigationItem[];
+  settingsNavigation: AppShellNavigationItem[];
+  children: ReactNode;
+}) {
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" aria-label="Application navigation">
+        <nav className="sidebar-nav" aria-label="Primary">
+          <div className="sidebar-section">
+            <p className="sidebar-section-label">Overview</p>
+            {primaryNavigation.map((item) => (
+              <SidebarLink key={item.to} to={item.to} label={item.label} />
+            ))}
+          </div>
+          <div className="sidebar-section">
+            <p className="sidebar-section-label">Settings</p>
+            {settingsNavigation
+              .filter((item) => item.visible ?? true)
+              .map((item) => (
+                <SidebarLink key={item.to} to={item.to} label={item.label} />
+              ))}
+          </div>
+        </nav>
+      </aside>
+      <section className="content-shell">
+        <div className="page-container">{children}</div>
+      </section>
+    </div>
+  );
+}
+
+function SidebarLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        isActive ? "sidebar-link is-active" : "sidebar-link"
+      }
+    >
+      {label}
+    </NavLink>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,14 +1,9 @@
 import { NavLink, Outlet } from "react-router-dom";
+import { AppShell, type AppShellNavigationItem } from "./AppShell";
 import { useAuth } from "../auth-context";
 import { useTheme } from "../theme-context";
 
-type NavigationItem = {
-  to: string;
-  label: string;
-  visible?: boolean;
-};
-
-const primaryNavigation: NavigationItem[] = [
+const primaryNavigation: AppShellNavigationItem[] = [
   { to: "/dashboard", label: "Dashboard" },
   { to: "/projects", label: "Projects" },
   { to: "/jobs", label: "Jobs" },
@@ -34,7 +29,7 @@ export function Layout() {
   const showUsersLink = authMode === "disabled" || isGlobalAdmin;
   const showTokensLink = authMode !== "disabled";
   const displayName = currentUser?.display_name || currentUser?.email;
-  const settingsNavigation: NavigationItem[] = [
+  const settingsNavigation: AppShellNavigationItem[] = [
     { to: "/settings/credentials", label: "Credentials" },
     { to: "/settings/tokens", label: "Tokens", visible: showTokensLink },
     { to: "/settings/users", label: "Users", visible: showUsersLink },
@@ -115,57 +110,15 @@ export function Layout() {
           </div>
         )}
         {authStatus === "authenticated" && (
-          <div className="app-shell">
-            {showNavigation ? (
-              <aside className="sidebar" aria-label="Application navigation">
-                <nav className="sidebar-nav" aria-label="Primary">
-                  <div className="sidebar-section">
-                    <p className="sidebar-section-label">Overview</p>
-                    {primaryNavigation.map((item) => (
-                      <SidebarLink
-                        key={item.to}
-                        to={item.to}
-                        label={item.label}
-                      />
-                    ))}
-                  </div>
-                  <div className="sidebar-section">
-                    <p className="sidebar-section-label">Settings</p>
-                    {settingsNavigation
-                      .filter((item) => item.visible ?? true)
-                      .map((item) => (
-                        <SidebarLink
-                          key={item.to}
-                          to={item.to}
-                          label={item.label}
-                        />
-                      ))}
-                  </div>
-                </nav>
-              </aside>
-            ) : null}
-            <section className="content-shell">
-              <div className="page-container">
-                <Outlet />
-              </div>
-            </section>
-          </div>
+          <AppShell
+            primaryNavigation={showNavigation ? primaryNavigation : []}
+            settingsNavigation={showNavigation ? settingsNavigation : []}
+          >
+            <Outlet />
+          </AppShell>
         )}
       </main>
     </div>
-  );
-}
-
-function SidebarLink({ to, label }: { to: string; label: string }) {
-  return (
-    <NavLink
-      to={to}
-      className={({ isActive }) =>
-        isActive ? "sidebar-link is-active" : "sidebar-link"
-      }
-    >
-      {label}
-    </NavLink>
   );
 }
 

--- a/frontend/src/pages/ArtifactsPage.test.tsx
+++ b/frontend/src/pages/ArtifactsPage.test.tsx
@@ -181,6 +181,25 @@ describe("ArtifactsPage", () => {
     expect(scope.getByText("pkg-sha")).toBeTruthy();
   });
 
+  it("truncates long checksum display and keeps full checksum in title", async () => {
+    mockedListArtifactCatalog.mockResolvedValueOnce([
+      {
+        ...buildArtifact(1),
+        checksum_sha256:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      },
+    ]);
+
+    renderPage();
+
+    const checksum =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const truncated = "0123456789ab…89abcdef";
+
+    const checksumDisplay = await screen.findByText(truncated);
+    expect(checksumDisplay).toHaveAttribute("title", checksum);
+  });
+
   it("shows an empty state when the catalog has no artifacts", async () => {
     mockedListArtifactCatalog.mockResolvedValueOnce([]);
 

--- a/frontend/src/pages/ArtifactsPage.tsx
+++ b/frontend/src/pages/ArtifactsPage.tsx
@@ -102,6 +102,14 @@ function stepLabel(artifact: ArtifactCatalogItem): string {
   return "Build-level artifact";
 }
 
+function formatChecksumDisplay(checksum: string): string {
+  const trimmed = checksum.trim();
+  if (trimmed.length <= 24) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 12)}…${trimmed.slice(-8)}`;
+}
+
 export function ArtifactsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const search = searchParams.get("q") ?? "";
@@ -393,7 +401,7 @@ export function ArtifactsPage() {
           </p>
         </div>
       ) : (
-        <section className="panel">
+        <section className="panel artifacts-catalog-panel">
           <table className="table artifacts-table artifact-catalog-table">
             <thead>
               <tr>
@@ -443,8 +451,17 @@ export function ArtifactsPage() {
                   </td>
                   <td>{stepLabel(artifact)}</td>
                   <td>{formatFileSize(artifact.size_bytes)}</td>
-                  <td className="artifact-mono">
-                    {artifact.checksum_sha256 ?? "—"}
+                  <td className="artifact-mono artifact-checksum-cell">
+                    {artifact.checksum_sha256 ? (
+                      <span
+                        className="artifact-checksum-value"
+                        title={artifact.checksum_sha256}
+                      >
+                        {formatChecksumDisplay(artifact.checksum_sha256)}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
                   </td>
                   <td>{formatTime(artifact.created_at)}</td>
                   <td>

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -82,7 +82,7 @@ describe("DashboardPage", () => {
   it("renders accessible projects and recent activity", async () => {
     renderPage();
 
-    expect(screen.getByText("Where should I look right now?")).toBeTruthy();
+    expect(screen.getByText("Dashboard")).toBeTruthy();
 
     await waitFor(() => {
       const projectLinks = screen.getAllByRole("link", { name: "Platform" });
@@ -114,10 +114,8 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Platform")).toBeTruthy();
-      expect(
-        screen.getByText("No queued or running builds right now."),
-      ).toBeTruthy();
-      expect(screen.getByText("No recent builds yet.")).toBeTruthy();
+      expect(screen.getByText("No builds in queue.")).toBeTruthy();
+      expect(screen.getByText("No recent build activity.")).toBeTruthy();
     });
   });
 
@@ -158,9 +156,7 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("No projects available yet.")).toBeTruthy();
-      expect(
-        screen.getByText("No recent failed builds in the current result set."),
-      ).toBeTruthy();
+      expect(screen.getByText("No recent failures.")).toBeTruthy();
     });
   });
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -66,9 +66,8 @@ export function DashboardPage() {
   return (
     <div className="page-content page-dashboard">
       <PageHeader
-        eyebrow="Dashboard"
-        title="Where should I look right now?"
-        description="Projects are the main entry point. Queue activity and recent builds surface the work that needs attention next."
+        title="Dashboard"
+        description="Queue, failures, and recent activity across your projects."
         actions={
           <>
             <Link className="secondary-button" to="/projects">
@@ -91,7 +90,7 @@ export function DashboardPage() {
           description={
             projectsError
               ? `Unable to load projects: ${String(projectsError)}`
-              : "Projects group jobs, builds, and artifact history."
+              : "Projects in scope."
           }
         />
         <SummaryCard
@@ -101,7 +100,7 @@ export function DashboardPage() {
           description={
             queueError
               ? `Unable to load queue: ${String(queueError)}`
-              : "Current work in dispatch or execution."
+              : "Builds currently queued or running."
           }
           footer={<Link to="/queue">Open queue</Link>}
         />
@@ -113,8 +112,8 @@ export function DashboardPage() {
             buildsError
               ? `Unable to load recent builds: ${String(buildsError)}`
               : failedBuilds.length > 0
-                ? "Recent builds that need attention."
-                : "No recent failed builds in the current result set."
+                ? "Failures in recent activity."
+                : "No recent failures."
           }
           footer={<Link to="/builds">Open builds</Link>}
         />
@@ -125,7 +124,7 @@ export function DashboardPage() {
           <div className="dashboard-panel-header">
             <div>
               <h3>Projects</h3>
-              <p className="subtle-text">Projects you can access right now.</p>
+              <p className="subtle-text">Projects in scope.</p>
             </div>
           </div>
           {projectsLoading ? <p>Loading projects…</p> : null}
@@ -142,7 +141,7 @@ export function DashboardPage() {
             <div className="empty-state">
               <p className="empty">No projects available yet.</p>
               <p className="subtle-text">
-                Create a project before grouping jobs and durable build history.
+                Create a project to organize jobs and build history.
               </p>
             </div>
           ) : null}
@@ -180,7 +179,7 @@ export function DashboardPage() {
                   kind: "queue" as const,
                   entry,
                 }))}
-              emptyMessage="No queued or running builds right now."
+              emptyMessage="No builds in queue."
             />
           )}
 
@@ -207,7 +206,7 @@ export function DashboardPage() {
                 kind: "build" as const,
                 build,
               }))}
-              emptyMessage="No recent builds yet."
+              emptyMessage="No recent build activity."
             />
           )}
         </div>

--- a/frontend/src/routes/router.test.tsx
+++ b/frontend/src/routes/router.test.tsx
@@ -101,7 +101,23 @@ describe("router dashboard home", () => {
       expect(screen.getByRole("link", { name: "Dashboard" })).toHaveClass(
         "is-active",
       );
-      expect(screen.getByText("Where should I look right now?")).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Dashboard" })).toBeTruthy();
+    });
+  });
+
+  it("renders the projects route inside the shared shell", async () => {
+    renderRouter(["/projects"]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Projects" })).toHaveClass(
+        "is-active",
+      );
+      expect(
+        screen.getByRole("complementary", {
+          name: "Application navigation",
+        }),
+      ).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Projects" })).toBeTruthy();
     });
   });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1498,8 +1498,31 @@ h3 {
   gap: 4px;
 }
 
+.artifacts-catalog-panel {
+  width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.artifact-catalog-table {
+  min-width: 980px;
+}
+
 .artifact-catalog-table td {
   vertical-align: top;
+}
+
+.artifact-checksum-cell {
+  max-width: 260px;
+}
+
+.artifact-checksum-value {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 .artifact-actions {


### PR DESCRIPTION
This PR refactors the frontend layout so the shared application chrome (top header + sidebar shell) is consistently applied across routed pages, while also making a couple of UI polish improvements (dashboard copy + artifact catalog table usability).

Changes:

Extracted the sidebar/content wrapper into a reusable AppShell component and updated Layout to use it.
Updated router tests to assert non-dashboard routes render inside the shared shell.
Improved artifact catalog table UX (horizontal scrolling container + truncated checksum with full value in title) and refreshed dashboard header/empty-state copy.