### PR TITLE
Add CLI build inspection commands

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4211,14 +4211,40 @@ const docTemplate = `{
         "api.BuildLogResponse": {
             "type": "object",
             "properties": {
+                "line": {
+                    "type": "string"
+                },
                 "message": {
                     "type": "string"
+                },
+                "step_index": {
+                    "type": "integer"
                 },
                 "step_name": {
                     "type": "string"
                 },
+                "stream": {
+                    "type": "string"
+                },
                 "timestamp": {
                     "type": "string"
+                }
+            }
+        },
+        "api.BuildLogSelectedStepResponse": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "step_index": {
+                    "type": "integer"
                 }
             }
         },
@@ -4241,6 +4267,12 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/api.BuildLogResponse"
                     }
+                },
+                "selected_step": {
+                    "$ref": "#/definitions/api.BuildLogSelectedStepResponse"
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -844,6 +844,24 @@ const docTemplate = `{
                         "name": "buildID",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit logs to one step index",
+                        "name": "step",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Select the failed step when exactly one step failed",
+                        "name": "failed",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Show only the last N log entries",
+                        "name": "tail",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4207,14 +4207,40 @@
         "api.BuildLogResponse": {
             "type": "object",
             "properties": {
+                "line": {
+                    "type": "string"
+                },
                 "message": {
                     "type": "string"
+                },
+                "step_index": {
+                    "type": "integer"
                 },
                 "step_name": {
                     "type": "string"
                 },
+                "stream": {
+                    "type": "string"
+                },
                 "timestamp": {
                     "type": "string"
+                }
+            }
+        },
+        "api.BuildLogSelectedStepResponse": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "step_index": {
+                    "type": "integer"
                 }
             }
         },
@@ -4237,6 +4263,12 @@
                     "items": {
                         "$ref": "#/definitions/api.BuildLogResponse"
                     }
+                },
+                "selected_step": {
+                    "$ref": "#/definitions/api.BuildLogSelectedStepResponse"
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -840,6 +840,24 @@
                         "name": "buildID",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit logs to one step index",
+                        "name": "step",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Select the failed step when exactly one step failed",
+                        "name": "failed",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Show only the last N log entries",
+                        "name": "tail",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2049,6 +2049,18 @@ paths:
         name: buildID
         required: true
         type: string
+      - description: Limit logs to one step index
+        in: query
+        name: step
+        type: integer
+      - description: Select the failed step when exactly one step failed
+        in: query
+        name: failed
+        type: boolean
+      - description: Show only the last N log entries
+        in: query
+        name: tail
+        type: integer
       produces:
       - application/json
       responses:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -338,12 +338,29 @@ definitions:
     type: object
   api.BuildLogResponse:
     properties:
+      line:
+        type: string
       message:
         type: string
+      step_index:
+        type: integer
       step_name:
+        type: string
+      stream:
         type: string
       timestamp:
         type: string
+    type: object
+  api.BuildLogSelectedStepResponse:
+    properties:
+      exit_code:
+        type: integer
+      name:
+        type: string
+      status:
+        type: string
+      step_index:
+        type: integer
     type: object
   api.BuildLogsEnvelope:
     properties:
@@ -358,6 +375,10 @@ definitions:
         items:
           $ref: '#/definitions/api.BuildLogResponse'
         type: array
+      selected_step:
+        $ref: '#/definitions/api.BuildLogSelectedStepResponse'
+      truncated:
+        type: boolean
     type: object
   api.BuildResponse:
     properties:

--- a/backend/internal/api/build_dto.go
+++ b/backend/internal/api/build_dto.go
@@ -260,14 +260,26 @@ type RetryJobResponse struct {
 }
 
 type BuildLogResponse struct {
+	StepIndex int    `json:"step_index"`
 	StepName  string `json:"step_name"`
 	Timestamp string `json:"timestamp"`
+	Stream    string `json:"stream,omitempty"`
+	Line      string `json:"line"`
 	Message   string `json:"message"`
 }
 
+type BuildLogSelectedStepResponse struct {
+	StepIndex int    `json:"step_index"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+}
+
 type BuildLogsResponse struct {
-	BuildID string             `json:"build_id"`
-	Logs    []BuildLogResponse `json:"logs"`
+	BuildID      string                        `json:"build_id"`
+	SelectedStep *BuildLogSelectedStepResponse `json:"selected_step,omitempty"`
+	Logs         []BuildLogResponse            `json:"logs"`
+	Truncated    bool                          `json:"truncated"`
 }
 
 type StepLogChunkResponse struct {

--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -98,6 +99,51 @@ func (c *Client) GetServerInfo(ctx context.Context) (api.ServerInfoResponse, err
 	var envelope api.ServerInfoEnvelope
 	if err := c.doJSON(ctx, http.MethodGet, "api/info", nil, &envelope); err != nil {
 		return api.ServerInfoResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
+func (c *Client) GetBuild(ctx context.Context, buildID string) (api.BuildResponse, error) {
+	var envelope api.BuildEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, ""), nil, &envelope); err != nil {
+		return api.BuildResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
+func (c *Client) GetBuildSteps(ctx context.Context, buildID string) ([]api.BuildStepResponse, error) {
+	var envelope api.BuildStepsEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, "/steps"), nil, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Data.Steps, nil
+}
+
+type BuildLogsOptions struct {
+	Step   *int
+	Failed bool
+	Tail   int
+}
+
+func (c *Client) GetBuildLogs(ctx context.Context, buildID string, options BuildLogsOptions) (api.BuildLogsResponse, error) {
+	requestPath := buildResourcePath(buildID, "/logs")
+	params := url.Values{}
+	if options.Step != nil {
+		params.Set("step", strconv.Itoa(*options.Step))
+	}
+	if options.Failed {
+		params.Set("failed", "true")
+	}
+	if options.Tail > 0 {
+		params.Set("tail", strconv.Itoa(options.Tail))
+	}
+	if encoded := params.Encode(); encoded != "" {
+		requestPath += "?" + encoded
+	}
+
+	var envelope api.BuildLogsEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, requestPath, nil, &envelope); err != nil {
+		return api.BuildLogsResponse{}, err
 	}
 	return envelope.Data, nil
 }
@@ -199,6 +245,10 @@ func resolveRequestURL(baseURL *url.URL, requestPath string) (*url.URL, error) {
 		baseCopy.Path = "/"
 	}
 	return baseCopy.ResolveReference(relative), nil
+}
+
+func buildResourcePath(buildID string, suffix string) string {
+	return "api/builds/" + url.PathEscape(strings.TrimSpace(buildID)) + suffix
 }
 
 func decodeErrorResponse(response *http.Response, requestID string) error {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -49,6 +49,74 @@ func TestClient_GetMeSendsBearerAndUserAgent(t *testing.T) {
 	}
 }
 
+func TestClient_BuildInspectionMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1":
+			_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote","job_id":"job-1","status":"failed","created_at":"2026-07-04T00:00:00Z","queued_at":null,"started_at":"2026-07-04T00:00:10Z","finished_at":"2026-07-04T00:01:10Z","current_step_index":1,"attempt_number":1,"error_message":null,"trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"}}}`))
+		case "/api/builds/build-1/steps":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":1,"name":"test","command":"go test ./...","status":"failed","image":{"source_kind":"external"},"job":{"id":"job-exec-1","build_id":"build-1","step_id":"step-1","name":"test","step_index":1,"attempt_number":1,"status":"failed","image":"golang:1.24","working_dir":"/workspace","command":["go","test","./..."],"command_preview":"go test ./...","environment":{},"spec_version":1,"created_at":"2026-07-04T00:00:00Z","outputs":[]},"worker_id":null,"started_at":"2026-07-04T00:00:10Z","finished_at":"2026-07-04T00:01:10Z","exit_code":1,"stdout":null,"stderr":null,"error_message":null}]}}`))
+		case "/api/builds/build-1/logs?failed=true&tail=5":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","selected_step":{"step_index":1,"name":"test","status":"failed","exit_code":1},"logs":[{"step_index":1,"step_name":"test","timestamp":"2026-07-04T00:01:00Z","stream":"stderr","line":"FAIL","message":"FAIL"}],"truncated":false}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	build, buildErr := client.GetBuild(context.Background(), "build-1")
+	if buildErr != nil {
+		t.Fatalf("get build: %v", buildErr)
+	}
+	steps, stepsErr := client.GetBuildSteps(context.Background(), "build-1")
+	if stepsErr != nil {
+		t.Fatalf("get build steps: %v", stepsErr)
+	}
+	tail := 5
+	logs, logsErr := client.GetBuildLogs(context.Background(), "build-1", BuildLogsOptions{Failed: true, Tail: tail})
+	if logsErr != nil {
+		t.Fatalf("get build logs: %v", logsErr)
+	}
+
+	if build.ID != "build-1" || build.ProjectID != "project-1" {
+		t.Fatalf("unexpected build response: %+v", build)
+	}
+	if len(steps) != 1 || steps[0].Job == nil || steps[0].Job.Name != "test" {
+		t.Fatalf("unexpected step response: %+v", steps)
+	}
+	if logs.BuildID != "build-1" || logs.SelectedStep == nil || logs.SelectedStep.Name != "test" || len(logs.Logs) != 1 {
+		t.Fatalf("unexpected logs response: %+v", logs)
+	}
+}
+
+func TestClient_GetBuildLogsWithoutExplicitTailUsesServerDefaultBehavior(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/api/builds/build-1/logs" {
+			t.Fatalf("unexpected request path %q", r.URL.String())
+		}
+		_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","logs":[],"truncated":true}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	logs, getErr := client.GetBuildLogs(context.Background(), "build-1", BuildLogsOptions{})
+	if getErr != nil {
+		t.Fatalf("get build logs: %v", getErr)
+	}
+	if !logs.Truncated {
+		t.Fatalf("expected truncated flag to round-trip, got %+v", logs)
+	}
+}
+
 func TestClient_RequestURLPreservesPathPrefixAndQuery(t *testing.T) {
 	baseURL, err := normalizeBaseURL("https://example.com/platform/coyote/")
 	if err != nil {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -117,6 +117,25 @@ func TestClient_GetBuildLogsWithoutExplicitTailUsesServerDefaultBehavior(t *test
 	}
 }
 
+func TestClient_GetBuildLogs_WithStepSelection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/api/builds/build-1/logs?step=3&tail=2" {
+			t.Fatalf("unexpected request path %q", r.URL.String())
+		}
+		_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","logs":[],"truncated":false}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	step := 3
+	if _, getErr := client.GetBuildLogs(context.Background(), "build-1", BuildLogsOptions{Step: &step, Tail: 2}); getErr != nil {
+		t.Fatalf("get build logs: %v", getErr)
+	}
+}
+
 func TestClient_RequestURLPreservesPathPrefixAndQuery(t *testing.T) {
 	baseURL, err := normalizeBaseURL("https://example.com/platform/coyote/")
 	if err != nil {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -98,7 +98,7 @@ func (a *app) newBuildLogsCommand() *cobra.Command {
 		Long:  "Fetch a snapshot of current build logs. Re-run the command to fetch newer logs. Live log following is deferred.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options, err := parseBuildLogsOptions(stepRaw, failed, tail)
+			options, err := parseBuildLogsOptions(stepRaw, failed, tail, cmd.Flags().Changed("tail"))
 			if err != nil {
 				return &ExitError{Code: 2, Err: err}
 			}
@@ -128,7 +128,7 @@ func (a *app) newBuildLogsCommand() *cobra.Command {
 	return command
 }
 
-func parseBuildLogsOptions(stepRaw string, failed bool, tail int) (apiclient.BuildLogsOptions, error) {
+func parseBuildLogsOptions(stepRaw string, failed bool, tail int, tailSet bool) (apiclient.BuildLogsOptions, error) {
 	var options apiclient.BuildLogsOptions
 	trimmedStep := strings.TrimSpace(stepRaw)
 	if trimmedStep != "" {
@@ -141,7 +141,7 @@ func parseBuildLogsOptions(stepRaw string, failed bool, tail int) (apiclient.Bui
 	if options.Step != nil && failed {
 		return apiclient.BuildLogsOptions{}, fmt.Errorf("step and failed cannot be used together")
 	}
-	if tail < 0 {
+	if tail < 0 || (tailSet && tail == 0) {
 		return apiclient.BuildLogsOptions{}, fmt.Errorf("tail must be a positive integer")
 	}
 	options.Failed = failed

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -1,0 +1,401 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/apiclient"
+	"github.com/radiation/coyote-ci/backend/internal/cli/output"
+)
+
+type buildStatusPayload struct {
+	Build      buildStatusView      `json:"build"`
+	FailedStep *buildFailedStepView `json:"failed_step,omitempty"`
+}
+
+type buildStatusView struct {
+	ID          string  `json:"id"`
+	BuildNumber int64   `json:"build_number,omitempty"`
+	ProjectID   string  `json:"project_id"`
+	ProjectName *string `json:"project_name,omitempty"`
+	JobID       *string `json:"job_id,omitempty"`
+	JobName     *string `json:"job_name,omitempty"`
+	Status      string  `json:"status"`
+	Ref         *string `json:"ref,omitempty"`
+	SHA         *string `json:"sha,omitempty"`
+	Author      *string `json:"author,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	StartedAt   *string `json:"started_at,omitempty"`
+	FinishedAt  *string `json:"finished_at,omitempty"`
+	DurationMS  *int64  `json:"duration_ms,omitempty"`
+	WebURL      string  `json:"web_url"`
+	Error       *string `json:"error_message,omitempty"`
+	Pipeline    *string `json:"pipeline_name,omitempty"`
+}
+
+type buildFailedStepView struct {
+	Index    int    `json:"index"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	ExitCode *int   `json:"exit_code,omitempty"`
+}
+
+func (a *app) newBuildCommand() *cobra.Command {
+	command := &cobra.Command{Use: "build", Short: "Inspect builds"}
+	command.AddCommand(a.newBuildStatusCommand())
+	command.AddCommand(a.newBuildLogsCommand())
+	return command
+}
+
+func (a *app) newBuildStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <build-id>",
+		Short: "Show build status and metadata",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			build, buildErr := client.GetBuild(cmd.Context(), args[0])
+			if buildErr != nil {
+				return mapCommandError(buildErr)
+			}
+			steps, stepsErr := client.GetBuildSteps(cmd.Context(), args[0])
+			if stepsErr != nil {
+				return mapCommandError(stepsErr)
+			}
+
+			payload := makeBuildStatusPayload(resolved.ServerURL, build, steps)
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildStatusHuman(w, payload)
+			}, payload)
+		},
+	}
+}
+
+func (a *app) newBuildLogsCommand() *cobra.Command {
+	var stepRaw string
+	var failed bool
+	var tail int
+
+	command := &cobra.Command{
+		Use:   "logs <build-id>",
+		Short: "Show build logs",
+		Long:  "Fetch a snapshot of current build logs. Re-run the command to fetch newer logs. Live log following is deferred.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options, err := parseBuildLogsOptions(stepRaw, failed, tail)
+			if err != nil {
+				return &ExitError{Code: 2, Err: err}
+			}
+
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			logsResponse, logsErr := client.GetBuildLogs(cmd.Context(), args[0], options)
+			if logsErr != nil {
+				return mapCommandError(logsErr)
+			}
+
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildLogsHuman(w, logsResponse)
+			}, logsResponse)
+		},
+	}
+	command.Flags().StringVar(&stepRaw, "step", "", "Limit logs to one step index")
+	command.Flags().BoolVar(&failed, "failed", false, "Select the failed step when exactly one step failed")
+	command.Flags().IntVar(&tail, "tail", 0, "Show only the last N log entries")
+	return command
+}
+
+func parseBuildLogsOptions(stepRaw string, failed bool, tail int) (apiclient.BuildLogsOptions, error) {
+	var options apiclient.BuildLogsOptions
+	trimmedStep := strings.TrimSpace(stepRaw)
+	if trimmedStep != "" {
+		stepIndex, err := strconv.Atoi(trimmedStep)
+		if err != nil || stepIndex < 0 {
+			return apiclient.BuildLogsOptions{}, fmt.Errorf("step must be a non-negative integer")
+		}
+		options.Step = &stepIndex
+	}
+	if options.Step != nil && failed {
+		return apiclient.BuildLogsOptions{}, fmt.Errorf("step and failed cannot be used together")
+	}
+	if tail < 0 {
+		return apiclient.BuildLogsOptions{}, fmt.Errorf("tail must be a positive integer")
+	}
+	options.Failed = failed
+	options.Tail = tail
+	return options, nil
+}
+
+func makeBuildStatusPayload(serverURL string, build api.BuildResponse, steps []api.BuildStepResponse) buildStatusPayload {
+	jobName := firstJobName(steps)
+	refValue := firstNonEmptyPtr(build.SourceRef, build.TriggerRef)
+	shaValue := firstNonEmptyPtr(build.SourceCommitSHA, build.SourceSHA, build.TriggerCommitSHA)
+	authorValue := firstNonEmptyPtr(build.SourceAuthorName, build.TriggeredBy, build.Actor)
+	failedStep := firstFailedStep(steps)
+	durationMS := buildDurationMS(build.StartedAt, build.FinishedAt)
+	webURL := buildWebURL(serverURL, build.ID, failedStep)
+
+	payload := buildStatusPayload{
+		Build: buildStatusView{
+			ID:          build.ID,
+			BuildNumber: build.BuildNumber,
+			ProjectID:   build.ProjectID,
+			ProjectName: build.ProjectName,
+			JobID:       build.JobID,
+			JobName:     jobName,
+			Status:      build.Status,
+			Ref:         refValue,
+			SHA:         shaValue,
+			Author:      authorValue,
+			CreatedAt:   build.CreatedAt,
+			StartedAt:   build.StartedAt,
+			FinishedAt:  build.FinishedAt,
+			DurationMS:  durationMS,
+			WebURL:      webURL,
+			Error:       build.ErrorMessage,
+			Pipeline:    build.PipelineName,
+		},
+		FailedStep: failedStep,
+	}
+	return payload
+}
+
+func writeBuildStatusHuman(w io.Writer, payload buildStatusPayload) error {
+	build := payload.Build
+	if _, err := fmt.Fprintf(w, "Build:   %s\n", build.ID); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Project: %s\n", displayProjectLabel(build.ProjectName, build.ProjectID)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Job:     %s\n", displayJobLabel(build.JobName, build.JobID)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Status:  %s\n", build.Status); err != nil {
+		return err
+	}
+	if build.Ref != nil {
+		if _, err := fmt.Fprintf(w, "Ref:     %s\n", *build.Ref); err != nil {
+			return err
+		}
+	}
+	if build.SHA != nil {
+		if _, err := fmt.Fprintf(w, "Commit:  %s\n", shortSHA(*build.SHA)); err != nil {
+			return err
+		}
+	}
+	if build.Author != nil {
+		if _, err := fmt.Fprintf(w, "Author:  %s\n", *build.Author); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "Created: %s\n", build.CreatedAt); err != nil {
+		return err
+	}
+	if build.StartedAt != nil {
+		if _, err := fmt.Fprintf(w, "Started: %s\n", *build.StartedAt); err != nil {
+			return err
+		}
+	}
+	if build.FinishedAt != nil {
+		if _, err := fmt.Fprintf(w, "Finished:%s%s\n", strings.Repeat(" ", 1), *build.FinishedAt); err != nil {
+			return err
+		}
+	}
+	if build.DurationMS != nil {
+		if _, err := fmt.Fprintf(w, "Duration:%s%s\n", strings.Repeat(" ", 1), formatDurationMS(*build.DurationMS)); err != nil {
+			return err
+		}
+	}
+	if payload.FailedStep != nil {
+		failedSummary := fmt.Sprintf("step %d %s (%s)", payload.FailedStep.Index, payload.FailedStep.Name, payload.FailedStep.Status)
+		if payload.FailedStep.ExitCode != nil {
+			failedSummary = fmt.Sprintf("step %d %s exited %d", payload.FailedStep.Index, payload.FailedStep.Name, *payload.FailedStep.ExitCode)
+		}
+		if _, err := fmt.Fprintf(w, "Failed:  %s\n", failedSummary); err != nil {
+			return err
+		}
+	}
+	if build.WebURL != "" {
+		if _, err := fmt.Fprintf(w, "URL:     %s\n", build.WebURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBuildLogsHuman(w io.Writer, response api.BuildLogsResponse) error {
+	if len(response.Logs) == 0 {
+		_, err := fmt.Fprintln(w, "No logs found")
+		return err
+	}
+
+	currentHeader := ""
+	for _, entry := range response.Logs {
+		header := logHeader(response.SelectedStep, entry)
+		if header != currentHeader {
+			if currentHeader != "" {
+				if _, err := fmt.Fprintln(w); err != nil {
+					return err
+				}
+			}
+			if _, err := fmt.Fprintf(w, "== %s ==\n", header); err != nil {
+				return err
+			}
+			currentHeader = header
+		}
+
+		line := entry.Line
+		if line == "" {
+			line = entry.Message
+		}
+		if entry.Stream != "" && entry.Stream != "stdout" {
+			line = "[" + entry.Stream + "] " + line
+		}
+		if _, err := io.WriteString(w, line); err != nil {
+			return err
+		}
+		if !strings.HasSuffix(line, "\n") {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+	}
+	if response.Truncated {
+		if _, err := fmt.Fprintln(w, "\n[truncated] Showing the most recent log entries."); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func logHeader(selected *api.BuildLogSelectedStepResponse, entry api.BuildLogResponse) string {
+	if selected != nil {
+		return fmt.Sprintf("step %d: %s (%s)", selected.StepIndex, selected.Name, selected.Status)
+	}
+	return fmt.Sprintf("step %d: %s", entry.StepIndex, entry.StepName)
+}
+
+func firstJobName(steps []api.BuildStepResponse) *string {
+	for _, step := range steps {
+		if step.Job == nil {
+			continue
+		}
+		name := strings.TrimSpace(step.Job.Name)
+		if name != "" {
+			return &name
+		}
+	}
+	return nil
+}
+
+func firstFailedStep(steps []api.BuildStepResponse) *buildFailedStepView {
+	ordered := append([]api.BuildStepResponse(nil), steps...)
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].StepIndex < ordered[j].StepIndex
+	})
+	for _, step := range ordered {
+		if step.Status == "failed" {
+			return &buildFailedStepView{Index: step.StepIndex, Name: step.Name, Status: step.Status, ExitCode: step.ExitCode}
+		}
+	}
+	return nil
+}
+
+func firstNonEmptyPtr(values ...*string) *string {
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(*value)
+		if trimmed != "" {
+			return &trimmed
+		}
+	}
+	return nil
+}
+
+func buildDurationMS(startedAt *string, finishedAt *string) *int64 {
+	if startedAt == nil || finishedAt == nil {
+		return nil
+	}
+	started, err := time.Parse(time.RFC3339, *startedAt)
+	if err != nil {
+		return nil
+	}
+	finished, err := time.Parse(time.RFC3339, *finishedAt)
+	if err != nil || finished.Before(started) {
+		return nil
+	}
+	duration := finished.Sub(started).Milliseconds()
+	return &duration
+}
+
+func buildWebURL(serverURL string, buildID string, failedStep *buildFailedStepView) string {
+	parsed, err := url.Parse(strings.TrimSpace(serverURL))
+	if err != nil {
+		return ""
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	basePath := strings.TrimSuffix(parsed.Path, "/")
+	parsed.Path = basePath + "/builds/" + url.PathEscape(strings.TrimSpace(buildID))
+	if failedStep != nil {
+		query := url.Values{}
+		query.Set("step", strconv.Itoa(failedStep.Index))
+		parsed.RawQuery = query.Encode()
+	}
+	return parsed.String()
+}
+
+func displayProjectLabel(projectName *string, projectID string) string {
+	if projectName != nil && strings.TrimSpace(*projectName) != "" {
+		return *projectName
+	}
+	return projectID
+}
+
+func displayJobLabel(jobName *string, jobID *string) string {
+	if jobName != nil && strings.TrimSpace(*jobName) != "" {
+		return *jobName
+	}
+	if jobID != nil && strings.TrimSpace(*jobID) != "" {
+		return *jobID
+	}
+	return "manual"
+}
+
+func shortSHA(sha string) string {
+	trimmed := strings.TrimSpace(sha)
+	if len(trimmed) <= 7 {
+		return trimmed
+	}
+	return trimmed[:7]
+}
+
+func formatDurationMS(durationMS int64) string {
+	return (time.Duration(durationMS) * time.Millisecond).String()
+}

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/radiation/coyote-ci/backend/internal/api"
+)
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestParseBuildLogsOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		stepRaw    string
+		failed     bool
+		tail       int
+		wantStep   *int
+		wantFailed bool
+		wantTail   int
+		wantErr    string
+	}{
+		{name: "empty step uses defaults", tail: 0, wantFailed: false, wantTail: 0},
+		{name: "step and failed conflict", stepRaw: "2", failed: true, wantErr: "step and failed cannot be used together"},
+		{name: "negative step", stepRaw: "-1", wantErr: "step must be a non-negative integer"},
+		{name: "negative tail", tail: -1, wantErr: "tail must be a positive integer"},
+		{name: "step and tail", stepRaw: " 3 ", tail: 5, wantStep: intPtr(3), wantTail: 5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseBuildLogsOptions(tc.stepRaw, tc.failed, tc.tail)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantStep == nil {
+				if got.Step != nil {
+					t.Fatalf("expected nil step, got %v", *got.Step)
+				}
+			} else if got.Step == nil || *got.Step != *tc.wantStep {
+				t.Fatalf("expected step %v, got %+v", *tc.wantStep, got.Step)
+			}
+			if got.Failed != tc.wantFailed || got.Tail != tc.wantTail {
+				t.Fatalf("unexpected options: %+v", got)
+			}
+		})
+	}
+}
+
+func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
+	projectName := "Project X"
+	jobID := "job-12345678"
+	jobName := "unit"
+	author := "Alice"
+	sha := "abcdef123456"
+	ref := "refs/heads/main"
+	errorMessage := "boom"
+	pipeline := "default"
+	build := api.BuildResponse{
+		ID:           "build-1",
+		ProjectID:    "project-1",
+		ProjectName:  &projectName,
+		JobID:        &jobID,
+		Status:       "failed",
+		CreatedAt:    "2026-07-04T00:00:00Z",
+		StartedAt:    stringPtr("2026-07-04T00:00:01Z"),
+		FinishedAt:   stringPtr("2026-07-04T00:00:03Z"),
+		SourceRef:    &ref,
+		SourceSHA:    &sha,
+		TriggeredBy:  stringPtr("trigger-user"),
+		ErrorMessage: &errorMessage,
+		PipelineName: &pipeline,
+	}
+	steps := []api.BuildStepResponse{{StepIndex: 1, Name: "test", Status: "failed", ExitCode: intPtr(1), Job: &api.ExecutionJobResponse{Name: jobName}}}
+	payload := makeBuildStatusPayload("https://example.com/base", build, steps)
+	if payload.Build.JobName == nil || *payload.Build.JobName != jobName {
+		t.Fatalf("expected derived job name, got %+v", payload)
+	}
+	if payload.Build.Author == nil || *payload.Build.Author != "trigger-user" {
+		t.Fatalf("expected author fallback from trigger, got %+v", payload.Build.Author)
+	}
+	if payload.Build.DurationMS == nil || *payload.Build.DurationMS != 2000 {
+		t.Fatalf("expected duration 2000ms, got %+v", payload.Build.DurationMS)
+	}
+	if !strings.Contains(payload.Build.WebURL, "/base/builds/build-1?step=1") {
+		t.Fatalf("unexpected web url: %s", payload.Build.WebURL)
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeBuildStatusHuman(buf, payload); err != nil {
+		t.Fatalf("writeBuildStatusHuman failed: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Project: Project X", "Job:     unit", "Commit:  abcdef1", "Failed:  step 1 test exited 1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got %s", want, out)
+		}
+	}
+
+	minimal := buildStatusPayload{Build: buildStatusView{ID: "build-2", ProjectID: "project-2", Status: "running", CreatedAt: "2026-07-04T00:00:00Z"}}
+	buf.Reset()
+	if err := writeBuildStatusHuman(buf, minimal); err != nil {
+		t.Fatalf("writeBuildStatusHuman minimal failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Job:     manual") {
+		t.Fatalf("expected manual job fallback, got %s", buf.String())
+	}
+	if err := writeBuildStatusHuman(failWriter{}, payload); err == nil {
+		t.Fatal("expected writeBuildStatusHuman to surface write errors")
+	}
+
+	logsBuf := &bytes.Buffer{}
+	logsResponse := api.BuildLogsResponse{
+		Logs: []api.BuildLogResponse{
+			{StepIndex: 0, StepName: "setup", Stream: "stdout", Line: "alpha"},
+			{StepIndex: 1, StepName: "test", Stream: "stderr", Message: "beta"},
+		},
+		Truncated: true,
+	}
+	if err := writeBuildLogsHuman(logsBuf, logsResponse); err != nil {
+		t.Fatalf("writeBuildLogsHuman failed: %v", err)
+	}
+	logsOut := logsBuf.String()
+	for _, want := range []string{"== step 0: setup ==", "== step 1: test ==", "[stderr] beta", "[truncated] Showing the most recent log entries."} {
+		if !strings.Contains(logsOut, want) {
+			t.Fatalf("expected %q in output, got %s", want, logsOut)
+		}
+	}
+
+	if err := writeBuildLogsHuman(failWriter{}, api.BuildLogsResponse{Logs: []api.BuildLogResponse{{StepIndex: 0, StepName: "setup", Line: "alpha"}}}); err == nil {
+		t.Fatal("expected writeBuildLogsHuman to surface write errors")
+	}
+	logsBuf.Reset()
+	if err := writeBuildLogsHuman(logsBuf, api.BuildLogsResponse{}); err != nil {
+		t.Fatalf("expected no logs response to render, got %v", err)
+	}
+	if strings.TrimSpace(logsBuf.String()) != "No logs found" {
+		t.Fatalf("unexpected no logs output: %q", logsBuf.String())
+	}
+
+	if got := logHeader(&api.BuildLogSelectedStepResponse{StepIndex: 2, Name: "verify", Status: "failed"}, api.BuildLogResponse{}); got != "step 2: verify (failed)" {
+		t.Fatalf("unexpected selected header: %s", got)
+	}
+	if got := logHeader(nil, api.BuildLogResponse{StepIndex: 3, StepName: "build"}); got != "step 3: build" {
+		t.Fatalf("unexpected entry header: %s", got)
+	}
+	if got := displayProjectLabel(nil, "project-3"); got != "project-3" {
+		t.Fatalf("unexpected project label fallback: %s", got)
+	}
+	if got := displayJobLabel(nil, &jobID); got != jobID {
+		t.Fatalf("unexpected job label fallback: %s", got)
+	}
+	if got := displayJobLabel(nil, nil); got != "manual" {
+		t.Fatalf("unexpected manual job label: %s", got)
+	}
+	if got := shortSHA("abc123"); got != "abc123" {
+		t.Fatalf("unexpected short sha short path: %s", got)
+	}
+	if got := formatDurationMS(1500); got != "1.5s" {
+		t.Fatalf("unexpected duration string: %s", got)
+	}
+	if buildDurationMS(nil, stringPtr("2026-07-04T00:00:01Z")) != nil {
+		t.Fatal("expected nil duration for missing start")
+	}
+	if buildDurationMS(stringPtr("bad"), stringPtr("2026-07-04T00:00:01Z")) != nil {
+		t.Fatal("expected nil duration for bad timestamp")
+	}
+	if buildDurationMS(stringPtr("2026-07-04T00:00:02Z"), stringPtr("2026-07-04T00:00:01Z")) != nil {
+		t.Fatal("expected nil duration for reversed timestamps")
+	}
+	if got := buildWebURL("://bad", "build-1", nil); got != "" {
+		t.Fatalf("expected empty web url for invalid server url, got %s", got)
+	}
+	if got := firstJobName([]api.BuildStepResponse{{Job: &api.ExecutionJobResponse{Name: "  "}}}); got != nil {
+		t.Fatalf("expected nil job name when blank, got %v", *got)
+	}
+	if got := firstFailedStep([]api.BuildStepResponse{{StepIndex: 0, Name: "ok", Status: "success"}}); got != nil {
+		t.Fatalf("expected nil failed step, got %+v", got)
+	}
+	if got := firstNonEmptyPtr(nil, stringPtr("  "), &author); got == nil || *got != author {
+		t.Fatalf("unexpected first non-empty ptr result: %+v", got)
+	}
+}
+
+func intPtr(value int) *int { return &value }
+
+func stringPtr(value string) *string { return &value }

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -21,21 +21,23 @@ func TestParseBuildLogsOptions(t *testing.T) {
 		stepRaw    string
 		failed     bool
 		tail       int
+		tailSet    bool
 		wantStep   *int
 		wantFailed bool
 		wantTail   int
 		wantErr    string
 	}{
 		{name: "empty step uses defaults", tail: 0, wantFailed: false, wantTail: 0},
+		{name: "explicit zero tail rejected", tail: 0, tailSet: true, wantErr: "tail must be a positive integer"},
 		{name: "step and failed conflict", stepRaw: "2", failed: true, wantErr: "step and failed cannot be used together"},
 		{name: "negative step", stepRaw: "-1", wantErr: "step must be a non-negative integer"},
 		{name: "negative tail", tail: -1, wantErr: "tail must be a positive integer"},
-		{name: "step and tail", stepRaw: " 3 ", tail: 5, wantStep: intPtr(3), wantTail: 5},
+		{name: "step and tail", stepRaw: " 3 ", tail: 5, tailSet: true, wantStep: intPtr(3), wantTail: 5},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseBuildLogsOptions(tc.stepRaw, tc.failed, tc.tail)
+			got, err := parseBuildLogsOptions(tc.stepRaw, tc.failed, tc.tail, tc.tailSet)
 			if tc.wantErr != "" {
 				if err == nil || err.Error() != tc.wantErr {
 					t.Fatalf("expected error %q, got %v", tc.wantErr, err)

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -168,6 +168,7 @@ func NewRootCommand(deps Dependencies) *cobra.Command {
 	rootCmd.AddCommand(application.newVersionCommand())
 	rootCmd.AddCommand(application.newContextCommand())
 	rootCmd.AddCommand(application.newAuthCommand())
+	rootCmd.AddCommand(application.newBuildCommand())
 	rootCmd.AddCommand(application.newServerCommand())
 
 	return rootCmd

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -213,6 +213,19 @@ func TestBuildStatusAndLogsCommands(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("expected no stdout on validation error, got %q", stdout.String())
 	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code = Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "logs", "build-1", "--tail", "0"}})
+	if code != 2 {
+		t.Fatalf("expected tail validation exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "tail must be a positive integer") {
+		t.Fatalf("unexpected stderr for tail validation: %s", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on tail validation error, got %q", stdout.String())
+	}
 }
 
 func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -113,6 +113,163 @@ func TestContextCommandsAndRemoteCalls(t *testing.T) {
 	}
 }
 
+func TestBuildStatusAndLogsCommands(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1":
+			if got := r.Header.Get("Authorization"); got != "Bearer stored-token" {
+				t.Fatalf("expected bearer token, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":"build-1","build_number":12,"project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","status":"failed","created_at":"2026-07-04T00:00:00Z","queued_at":"2026-07-04T00:00:01Z","started_at":"2026-07-04T00:00:02Z","finished_at":"2026-07-04T00:00:12Z","current_step_index":1,"attempt_number":1,"error_message":null,"source_ref":"refs/heads/main","source_commit_sha":"abcdef1234567890","source_author_name":"Bryan","trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"}}}`))
+		case "/api/builds/build-1/steps":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":1,"name":"test","command":"go test ./...","status":"failed","image":{"source_kind":"external"},"job":{"id":"job-exec-1","build_id":"build-1","step_id":"step-1","name":"test","step_index":1,"attempt_number":1,"status":"failed","image":"golang:1.24","working_dir":"/workspace","command":["go","test","./..."],"command_preview":"go test ./...","environment":{},"spec_version":1,"created_at":"2026-07-04T00:00:00Z","outputs":[]},"worker_id":null,"started_at":"2026-07-04T00:00:02Z","finished_at":"2026-07-04T00:00:12Z","exit_code":1,"stdout":null,"stderr":null,"error_message":null}]}}`))
+		case "/api/builds/build-1/logs?failed=true&tail=1":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","selected_step":{"step_index":1,"name":"test","status":"failed","exit_code":1},"logs":[{"step_index":1,"step_name":"test","timestamp":"2026-07-04T00:00:10Z","stream":"stderr","line":"FAIL\n","message":"FAIL\n"}],"truncated":true}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "status", "build-1", "--json"}}); code != 0 {
+		t.Fatalf("build status exit code %d stderr=%s", code, stderr.String())
+	}
+	var statusPayload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &statusPayload); err != nil {
+		t.Fatalf("decode build status: %v", err)
+	}
+	buildData, ok := statusPayload["build"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected build object, got %+v", statusPayload)
+	}
+	if buildData["status"] != "failed" || buildData["job_name"] != "test" || buildData["duration_ms"] != float64(10000) {
+		t.Fatalf("unexpected build status payload: %+v", statusPayload)
+	}
+	failedStep, ok := statusPayload["failed_step"].(map[string]any)
+	if !ok || failedStep["index"] != float64(1) || failedStep["name"] != "test" {
+		t.Fatalf("unexpected failed step payload: %+v", statusPayload)
+	}
+	if strings.Contains(stdout.String(), "Build:") {
+		t.Fatalf("unexpected human prose in build status JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "logs", "build-1", "--failed", "--tail", "1"}}); code != 0 {
+		t.Fatalf("build logs exit code %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "== step 1: test (failed) ==") || !strings.Contains(stdout.String(), "[stderr] FAIL") {
+		t.Fatalf("unexpected build logs output: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[truncated] Showing the most recent log entries.") {
+		t.Fatalf("expected truncation note, got %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "logs", "build-1", "--failed", "--tail", "1", "--json"}}); code != 0 {
+		t.Fatalf("build logs json exit code %d stderr=%s", code, stderr.String())
+	}
+	var logsPayload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &logsPayload); err != nil {
+		t.Fatalf("decode build logs: %v", err)
+	}
+	if logsPayload["build_id"] != "build-1" || logsPayload["truncated"] != true {
+		t.Fatalf("unexpected build logs payload: %+v", logsPayload)
+	}
+	selectedStep, ok := logsPayload["selected_step"].(map[string]any)
+	if !ok || selectedStep["name"] != "test" {
+		t.Fatalf("unexpected selected_step payload: %+v", logsPayload)
+	}
+	if strings.Contains(stdout.String(), "== step") {
+		t.Fatalf("unexpected human prose in build logs JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "logs", "build-1", "--failed", "--step", "1"}})
+	if code != 2 {
+		t.Fatalf("expected validation exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "step and failed cannot be used together") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on validation error, got %q", stdout.String())
+	}
+}
+
+func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		message := "api token does not have the required scope: build:read"
+		if strings.Contains(r.URL.Path, "/logs") {
+			message = "api token does not have the required scope: build:logs"
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"` + message + `"}}`))
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantContains string
+	}{
+		{name: "status missing scope", args: []string{"build", "status", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:read"},
+		{name: "logs missing scope", args: []string{"build", "logs", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:logs"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: tc.args})
+			if code == 0 {
+				t.Fatal("expected nonzero exit code")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no stdout on scope failure, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantContains) {
+				t.Fatalf("unexpected stderr: %s", stderr.String())
+			}
+			if strings.Contains(stderr.String(), "stored-token") {
+				t.Fatalf("stderr leaked token: %s", stderr.String())
+			}
+		})
+	}
+}
+
 func TestCanceledCommandContextCancelsHTTPRequests(t *testing.T) {
 	requestSeen := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/http/handler/authz_handlers_test.go
+++ b/backend/internal/http/handler/authz_handlers_test.go
@@ -492,6 +492,14 @@ func TestScopedAPITokenRouteEnforcement(t *testing.T) {
 		t.Fatalf("expected build:logs status %d, got %d body=%s", http.StatusOK, logsRes.Code, logsRes.Body.String())
 	}
 
+	logsFailedReq := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/"+build.ID+"/logs?failed=true", nil), build.ID)
+	logsFailedReq = withScopedAPIToken(logsFailedReq, fixture.viewer, domain.APITokenScopeBuildLogs)
+	logsFailedRes := httptest.NewRecorder()
+	h.GetBuildLogs(logsFailedRes, logsFailedReq)
+	if logsFailedRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected failed-step selection to reach handler logic under build:logs scope, got %d body=%s", logsFailedRes.Code, logsFailedRes.Body.String())
+	}
+
 	stepsReq := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/"+build.ID+"/steps", nil), build.ID)
 	stepsReq = withScopedAPIToken(stepsReq, fixture.viewer, domain.APITokenScopeBuildLogs)
 	stepsRes := httptest.NewRecorder()

--- a/backend/internal/http/handler/build_handler_execution.go
+++ b/backend/internal/http/handler/build_handler_execution.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,11 @@ import (
 	"github.com/radiation/coyote-ci/backend/internal/auth"
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	buildsvc "github.com/radiation/coyote-ci/backend/internal/service/build"
+)
+
+const (
+	defaultBuildLogsTail = 500
+	maxBuildLogsTail     = 5000
 )
 
 // GetBuildSteps godoc
@@ -111,25 +117,146 @@ func (h *BuildHandler) GetBuildLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logs, err := h.buildService.GetBuildLogs(r.Context(), id)
+	logRequest, err := parseBuildLogsRequest(r)
+	if err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	steps, err := h.buildService.GetBuildSteps(r.Context(), id)
+	if err != nil {
+		h.writeServiceError(w, err)
+		return
+	}
+	sort.Slice(steps, func(i, j int) bool {
+		return steps[i].StepIndex < steps[j].StepIndex
+	})
+
+	selectedStep, ok, err := resolveRequestedBuildLogStep(steps, logRequest)
+	if err != nil {
+		statusCode := http.StatusBadRequest
+		if errors.Is(err, buildsvc.ErrBuildStepNotFound) {
+			statusCode = http.StatusNotFound
+		}
+		writeErrorJSON(w, statusCode, "invalid_request", err.Error())
+		return
+	}
+
+	var selectedStepIndex *int
+	if ok {
+		selectedStepIndex = &selectedStep.StepIndex
+	}
+
+	chunks, truncated, err := h.buildService.GetBuildLogChunksTail(r.Context(), id, selectedStepIndex, logRequest.Tail)
 	if err != nil {
 		h.writeServiceError(w, err)
 		return
 	}
 
-	respLogs := make([]api.BuildLogResponse, 0, len(logs))
-	for _, logLine := range logs {
+	respLogs := make([]api.BuildLogResponse, 0, len(chunks))
+	for _, chunk := range chunks {
 		respLogs = append(respLogs, api.BuildLogResponse{
-			StepName:  logLine.StepName,
-			Timestamp: logLine.Timestamp.Format(time.RFC3339),
-			Message:   logLine.Message,
+			StepIndex: chunk.StepIndex,
+			StepName:  chunk.StepName,
+			Timestamp: chunk.CreatedAt.Format(time.RFC3339),
+			Stream:    string(chunk.Stream),
+			Line:      chunk.ChunkText,
+			Message:   chunk.ChunkText,
 		})
 	}
 
+	var selectedStepResp *api.BuildLogSelectedStepResponse
+	if ok {
+		selectedStepResp = &api.BuildLogSelectedStepResponse{
+			StepIndex: selectedStep.StepIndex,
+			Name:      selectedStep.Name,
+			Status:    string(selectedStep.Status),
+			ExitCode:  selectedStep.ExitCode,
+		}
+	}
+
 	writeDataJSON(w, http.StatusOK, api.BuildLogsResponse{
-		BuildID: id,
-		Logs:    respLogs,
+		BuildID:      id,
+		SelectedStep: selectedStepResp,
+		Logs:         respLogs,
+		Truncated:    truncated,
 	})
+}
+
+type buildLogsRequest struct {
+	Step   *int
+	Failed bool
+	Tail   int
+}
+
+func parseBuildLogsRequest(r *http.Request) (buildLogsRequest, error) {
+	query := r.URL.Query()
+	request := buildLogsRequest{}
+
+	stepRaw := strings.TrimSpace(query.Get("step"))
+	if stepRaw != "" {
+		stepIndex, err := strconv.Atoi(stepRaw)
+		if err != nil || stepIndex < 0 {
+			return buildLogsRequest{}, errors.New("step must be a non-negative integer")
+		}
+		request.Step = &stepIndex
+	}
+
+	failedRaw := strings.TrimSpace(query.Get("failed"))
+	if failedRaw != "" {
+		failed, err := strconv.ParseBool(failedRaw)
+		if err != nil {
+			return buildLogsRequest{}, errors.New("failed must be true or false")
+		}
+		request.Failed = failed
+	}
+
+	if request.Step != nil && request.Failed {
+		return buildLogsRequest{}, errors.New("step and failed cannot be used together")
+	}
+
+	tailRaw := strings.TrimSpace(query.Get("tail"))
+	if tailRaw == "" {
+		request.Tail = defaultBuildLogsTail
+		return request, nil
+	}
+	if tailRaw != "" {
+		tail, err := strconv.Atoi(tailRaw)
+		if err != nil || tail < 1 {
+			return buildLogsRequest{}, errors.New("tail must be a positive integer")
+		}
+		if tail > maxBuildLogsTail {
+			tail = maxBuildLogsTail
+		}
+		request.Tail = tail
+	}
+
+	return request, nil
+}
+
+func resolveRequestedBuildLogStep(steps []domain.BuildStep, request buildLogsRequest) (domain.BuildStep, bool, error) {
+	if request.Step != nil {
+		for _, step := range steps {
+			if step.StepIndex == *request.Step {
+				return step, true, nil
+			}
+		}
+		return domain.BuildStep{}, false, buildsvc.ErrBuildStepNotFound
+	}
+	if !request.Failed {
+		return domain.BuildStep{}, false, nil
+	}
+
+	failedSteps := make([]domain.BuildStep, 0, 1)
+	for _, step := range steps {
+		if step.Status == domain.BuildStepStatusFailed {
+			failedSteps = append(failedSteps, step)
+		}
+	}
+	if len(failedSteps) != 1 {
+		return domain.BuildStep{}, false, errors.New("failed step selection requires exactly one failed step")
+	}
+	return failedSteps[0], true, nil
 }
 
 // QueueBuild godoc

--- a/backend/internal/http/handler/build_handler_execution.go
+++ b/backend/internal/http/handler/build_handler_execution.go
@@ -99,6 +99,9 @@ func (h *BuildHandler) GetBuildSteps(w http.ResponseWriter, r *http.Request) {
 // @Tags builds
 // @Produce json
 // @Param buildID path string true "Build ID"
+// @Param step query int false "Limit logs to one step index"
+// @Param failed query bool false "Select the failed step when exactly one step failed"
+// @Param tail query int false "Show only the last N log entries"
 // @Success 200 {object} api.BuildLogsEnvelope
 // @Failure 400 {object} api.ErrorResponse
 // @Failure 404 {object} api.ErrorResponse

--- a/backend/internal/http/handler/build_handler_test.go
+++ b/backend/internal/http/handler/build_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1491,8 +1492,17 @@ func TestBuildHandler_GetBuildSteps_EmptyForExistingBuild(t *testing.T) {
 
 func TestBuildHandler_GetBuildLogs(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	repo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusRunning, CreatedAt: now}}
-	h := NewBuildHandler(buildsvc.NewBuildService(repo, nil, nil))
+	repo := &fakeRepo{
+		build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusRunning, CreatedAt: now},
+		steps: map[string][]domain.BuildStep{
+			"build-1": {
+				{ID: "step-1", BuildID: "build-1", StepIndex: 0, Name: "setup", Status: domain.BuildStepStatusRunning},
+			},
+		},
+	}
+	logSink := logs.NewMemorySink()
+	_, _ = logSink.AppendStepLogChunk(context.Background(), logs.StepLogChunk{BuildID: "build-1", StepID: "step-1", StepIndex: 0, StepName: "setup", Stream: logs.StepLogStreamStdout, ChunkText: "setup-line", CreatedAt: now})
+	h := NewBuildHandler(buildsvc.NewBuildService(repo, nil, logSink))
 
 	logsReq := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/logs", nil), "build-1")
 	logsRes := httptest.NewRecorder()
@@ -1503,6 +1513,169 @@ func TestBuildHandler_GetBuildLogs(t *testing.T) {
 	logsData := decodeDataMap(t, logsRes)
 	if logsData["build_id"] != "build-1" {
 		t.Fatalf("expected build_id build-1, got %v", logsData["build_id"])
+	}
+	if logsData["truncated"] != false {
+		t.Fatalf("expected truncated false, got %v", logsData["truncated"])
+	}
+	logsList, ok := logsData["logs"].([]any)
+	if !ok || len(logsList) != 1 {
+		t.Fatalf("expected one log entry, got %+v", logsData["logs"])
+	}
+	entry, ok := logsList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected object log entry, got %T", logsList[0])
+	}
+	if entry["line"] != "setup-line" || entry["message"] != "setup-line" {
+		t.Fatalf("unexpected log entry payload: %+v", entry)
+	}
+}
+
+func TestBuildHandler_GetBuildLogs_FilteredByStepAndTail(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exitCode := 1
+	repo := &fakeRepo{
+		build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusFailed, CreatedAt: now},
+		steps: map[string][]domain.BuildStep{
+			"build-1": {
+				{ID: "step-1", BuildID: "build-1", StepIndex: 0, Name: "setup", Status: domain.BuildStepStatusSuccess},
+				{ID: "step-2", BuildID: "build-1", StepIndex: 1, Name: "test", Status: domain.BuildStepStatusFailed, ExitCode: &exitCode},
+			},
+		},
+	}
+	logSink := logs.NewMemorySink()
+	_, _ = logSink.AppendStepLogChunk(context.Background(), logs.StepLogChunk{BuildID: "build-1", StepID: "step-1", StepIndex: 0, StepName: "setup", Stream: logs.StepLogStreamStdout, ChunkText: "setup-line", CreatedAt: now})
+	_, _ = logSink.AppendStepLogChunk(context.Background(), logs.StepLogChunk{BuildID: "build-1", StepID: "step-2", StepIndex: 1, StepName: "test", Stream: logs.StepLogStreamStdout, ChunkText: "test-line-1", CreatedAt: now.Add(time.Second)})
+	_, _ = logSink.AppendStepLogChunk(context.Background(), logs.StepLogChunk{BuildID: "build-1", StepID: "step-2", StepIndex: 1, StepName: "test", Stream: logs.StepLogStreamStderr, ChunkText: "test-line-2", CreatedAt: now.Add(2 * time.Second)})
+	h := NewBuildHandler(buildsvc.NewBuildService(repo, nil, logSink))
+
+	req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/logs?failed=true&tail=1", nil), "build-1")
+	res := httptest.NewRecorder()
+
+	h.GetBuildLogs(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	data := decodeDataMap(t, res)
+	selectedStep, ok := data["selected_step"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected selected_step object, got %T", data["selected_step"])
+	}
+	if selectedStep["step_index"] != float64(1) || selectedStep["name"] != "test" || selectedStep["status"] != "failed" {
+		t.Fatalf("unexpected selected_step payload: %+v", selectedStep)
+	}
+	if data["truncated"] != true {
+		t.Fatalf("expected truncated true, got %v", data["truncated"])
+	}
+	logsList, ok := data["logs"].([]any)
+	if !ok || len(logsList) != 1 {
+		t.Fatalf("expected single tailed log entry, got %+v", data["logs"])
+	}
+	entry, ok := logsList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected object log entry, got %T", logsList[0])
+	}
+	if entry["step_index"] != float64(1) || entry["stream"] != "stderr" || entry["line"] != "test-line-2" {
+		t.Fatalf("unexpected tailed log entry payload: %+v", entry)
+	}
+}
+
+func TestBuildHandler_GetBuildLogs_DefaultTailAndCap(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := &fakeRepo{
+		build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusRunning, CreatedAt: now},
+		steps: map[string][]domain.BuildStep{
+			"build-1": {
+				{ID: "step-1", BuildID: "build-1", StepIndex: 0, Name: "setup", Status: domain.BuildStepStatusRunning},
+			},
+		},
+	}
+	logSink := logs.NewMemorySink()
+	for idx := 0; idx < 600; idx++ {
+		_, appendErr := logSink.AppendStepLogChunk(context.Background(), logs.StepLogChunk{BuildID: "build-1", StepID: "step-1", StepIndex: 0, StepName: "setup", Stream: logs.StepLogStreamStdout, ChunkText: fmt.Sprintf("line-%03d", idx), CreatedAt: now.Add(time.Duration(idx) * time.Second)})
+		if appendErr != nil {
+			t.Fatalf("append chunk failed at index %d: %v", idx, appendErr)
+		}
+	}
+	h := NewBuildHandler(buildsvc.NewBuildService(repo, nil, logSink))
+
+	req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/logs", nil), "build-1")
+	res := httptest.NewRecorder()
+	h.GetBuildLogs(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	data := decodeDataMap(t, res)
+	if data["truncated"] != true {
+		t.Fatalf("expected truncated true, got %v", data["truncated"])
+	}
+	logsList, ok := data["logs"].([]any)
+	if !ok || len(logsList) != defaultBuildLogsTail {
+		t.Fatalf("expected %d logs, got %+v", defaultBuildLogsTail, data["logs"])
+	}
+	first, _ := logsList[0].(map[string]any)
+	last, _ := logsList[len(logsList)-1].(map[string]any)
+	if first["line"] != "line-100" || last["line"] != "line-599" {
+		t.Fatalf("unexpected default tail window: first=%+v last=%+v", first, last)
+	}
+
+	req = addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/logs?tail=999999", nil), "build-1")
+	res = httptest.NewRecorder()
+	h.GetBuildLogs(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+	data = decodeDataMap(t, res)
+	logsList, ok = data["logs"].([]any)
+	if !ok || len(logsList) != 600 {
+		t.Fatalf("expected full log list capped by available entries, got %+v", data["logs"])
+	}
+	if data["truncated"] != false {
+		t.Fatalf("expected truncated false when available entries fit inside cap, got %v", data["truncated"])
+	}
+}
+
+func TestBuildHandler_GetBuildLogs_InvalidFilters(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := &fakeRepo{
+		build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusFailed, CreatedAt: now},
+		steps: map[string][]domain.BuildStep{
+			"build-1": {
+				{ID: "step-1", BuildID: "build-1", StepIndex: 0, Name: "setup", Status: domain.BuildStepStatusFailed},
+				{ID: "step-2", BuildID: "build-1", StepIndex: 1, Name: "test", Status: domain.BuildStepStatusFailed},
+			},
+		},
+	}
+	h := NewBuildHandler(buildsvc.NewBuildService(repo, nil, logs.NewMemorySink()))
+
+	tests := []struct {
+		name       string
+		url        string
+		wantStatus int
+		wantText   string
+	}{
+		{name: "step and failed", url: "/builds/build-1/logs?step=0&failed=true", wantStatus: http.StatusBadRequest, wantText: "step and failed cannot be used together"},
+		{name: "bad step", url: "/builds/build-1/logs?step=nope", wantStatus: http.StatusBadRequest, wantText: "step must be a non-negative integer"},
+		{name: "missing step", url: "/builds/build-1/logs?step=9", wantStatus: http.StatusNotFound, wantText: "build step not found"},
+		{name: "negative tail", url: "/builds/build-1/logs?tail=-1", wantStatus: http.StatusBadRequest, wantText: "tail must be a positive integer"},
+		{name: "bad tail", url: "/builds/build-1/logs?tail=0", wantStatus: http.StatusBadRequest, wantText: "tail must be a positive integer"},
+		{name: "ambiguous failed", url: "/builds/build-1/logs?failed=true", wantStatus: http.StatusBadRequest, wantText: "failed step selection requires exactly one failed step"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := addBuildIDParam(httptest.NewRequest(http.MethodGet, tc.url, nil), "build-1")
+			res := httptest.NewRecorder()
+
+			h.GetBuildLogs(res, req)
+
+			if res.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, res.Code)
+			}
+			if got := decodeErrorMessage(t, res); got != tc.wantText {
+				t.Fatalf("expected message %q, got %q", tc.wantText, got)
+			}
+		})
 	}
 }
 

--- a/backend/internal/logs/log_sink.go
+++ b/backend/internal/logs/log_sink.go
@@ -35,6 +35,10 @@ type StepLogChunkReader interface {
 	ListStepLogChunks(ctx context.Context, buildID string, stepIndex int, afterSequence int64, limit int) ([]StepLogChunk, error)
 }
 
+type StepLogChunkTailReader interface {
+	ListStepLogChunksTail(ctx context.Context, buildID string, stepIndex *int, limit int) ([]StepLogChunk, bool, error)
+}
+
 type LogSink interface {
 	WriteStepLog(ctx context.Context, buildID string, stepName string, line string) error
 }

--- a/backend/internal/logs/memory_sink.go
+++ b/backend/internal/logs/memory_sink.go
@@ -110,7 +110,7 @@ func (s *MemorySink) ListStepLogChunksTail(_ context.Context, buildID string, st
 		limit = 5000
 	}
 
-	out := make([]StepLogChunk, 0, limit)
+	out := make([]StepLogChunk, 0)
 	truncated := false
 	for idx := len(s.stepChunks) - 1; idx >= 0; idx-- {
 		chunk := s.stepChunks[idx]

--- a/backend/internal/logs/memory_sink.go
+++ b/backend/internal/logs/memory_sink.go
@@ -25,6 +25,7 @@ var _ LogSink = (*MemorySink)(nil)
 var _ LogReader = (*MemorySink)(nil)
 var _ StepLogChunkAppender = (*MemorySink)(nil)
 var _ StepLogChunkReader = (*MemorySink)(nil)
+var _ StepLogChunkTailReader = (*MemorySink)(nil)
 
 func NewMemorySink() *MemorySink {
 	return &MemorySink{entries: make([]memoryLogEntry, 0), stepChunks: make([]StepLogChunk, 0), nextSequence: 1}
@@ -96,6 +97,41 @@ func (s *MemorySink) ListStepLogChunks(_ context.Context, buildID string, stepIn
 	})
 
 	return out, nil
+}
+
+func (s *MemorySink) ListStepLogChunksTail(_ context.Context, buildID string, stepIndex *int, limit int) ([]StepLogChunk, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+
+	out := make([]StepLogChunk, 0, limit)
+	truncated := false
+	for idx := len(s.stepChunks) - 1; idx >= 0; idx-- {
+		chunk := s.stepChunks[idx]
+		if chunk.BuildID != buildID {
+			continue
+		}
+		if stepIndex != nil && chunk.StepIndex != *stepIndex {
+			continue
+		}
+		if len(out) >= limit {
+			truncated = true
+			break
+		}
+		out = append(out, chunk)
+	}
+
+	for left, right := 0, len(out)-1; left < right; left, right = left+1, right-1 {
+		out[left], out[right] = out[right], out[left]
+	}
+
+	return out, truncated, nil
 }
 
 func (s *MemorySink) GetBuildLogs(_ context.Context, buildID string) ([]BuildLogLine, error) {

--- a/backend/internal/logs/memory_sink_test.go
+++ b/backend/internal/logs/memory_sink_test.go
@@ -145,3 +145,32 @@ func TestMemorySink_ListStepLogChunksTail(t *testing.T) {
 		t.Fatalf("unexpected tailed chunks: %+v", chunks)
 	}
 }
+
+func TestMemorySink_ListStepLogChunksTail_DefaultLimitAndNilStep(t *testing.T) {
+	sink := NewMemorySink()
+	for idx := 0; idx < 3; idx++ {
+		_, err := sink.AppendStepLogChunk(context.Background(), StepLogChunk{
+			BuildID:   "build-1",
+			StepID:    "step-1",
+			StepIndex: idx,
+			StepName:  "step",
+			Stream:    StepLogStreamStdout,
+			ChunkText: string(rune('x' + idx)),
+			CreatedAt: time.Now().UTC().Add(time.Duration(idx) * time.Second),
+		})
+		if err != nil {
+			t.Fatalf("append chunk failed: %v", err)
+		}
+	}
+
+	chunks, truncated, err := sink.ListStepLogChunksTail(context.Background(), "build-1", nil, 0)
+	if err != nil {
+		t.Fatalf("tail list failed: %v", err)
+	}
+	if truncated {
+		t.Fatal("expected untruncated result")
+	}
+	if len(chunks) != 3 || chunks[0].ChunkText != "x" || chunks[2].ChunkText != "z" {
+		t.Fatalf("unexpected tail chunks: %+v", chunks)
+	}
+}

--- a/backend/internal/logs/memory_sink_test.go
+++ b/backend/internal/logs/memory_sink_test.go
@@ -115,3 +115,33 @@ func TestMemorySink_ListStepLogChunks_LimitIsCapped(t *testing.T) {
 		t.Fatalf("expected capped result size 2000, got %d", len(chunks))
 	}
 }
+
+func TestMemorySink_ListStepLogChunksTail(t *testing.T) {
+	sink := NewMemorySink()
+	for idx := 0; idx < 4; idx++ {
+		_, err := sink.AppendStepLogChunk(context.Background(), StepLogChunk{
+			BuildID:   "build-1",
+			StepID:    "step-1",
+			StepIndex: 0,
+			StepName:  "setup",
+			Stream:    StepLogStreamStdout,
+			ChunkText: string(rune('a' + idx)),
+			CreatedAt: time.Now().UTC().Add(time.Duration(idx) * time.Second),
+		})
+		if err != nil {
+			t.Fatalf("append chunk failed at index %d: %v", idx, err)
+		}
+	}
+
+	stepIndex := 0
+	chunks, truncated, err := sink.ListStepLogChunksTail(context.Background(), "build-1", &stepIndex, 2)
+	if err != nil {
+		t.Fatalf("tail list failed: %v", err)
+	}
+	if !truncated {
+		t.Fatal("expected truncated result")
+	}
+	if len(chunks) != 2 || chunks[0].ChunkText != "c" || chunks[1].ChunkText != "d" {
+		t.Fatalf("unexpected tailed chunks: %+v", chunks)
+	}
+}

--- a/backend/internal/logs/postgres_sink.go
+++ b/backend/internal/logs/postgres_sink.go
@@ -183,7 +183,7 @@ func (s *PostgresSink) ListStepLogChunksTail(ctx context.Context, buildID string
 		}
 	}()
 
-	chunks = make([]StepLogChunk, 0, limit)
+	chunks = make([]StepLogChunk, 0)
 	for rows.Next() {
 		var chunk StepLogChunk
 		if scanErr := rows.Scan(

--- a/backend/internal/logs/postgres_sink.go
+++ b/backend/internal/logs/postgres_sink.go
@@ -17,6 +17,7 @@ var _ LogSink = (*PostgresSink)(nil)
 var _ LogReader = (*PostgresSink)(nil)
 var _ StepLogChunkAppender = (*PostgresSink)(nil)
 var _ StepLogChunkReader = (*PostgresSink)(nil)
+var _ StepLogChunkTailReader = (*PostgresSink)(nil)
 
 func NewPostgresSink(db *sql.DB) *PostgresSink {
 	return &PostgresSink{db: db}
@@ -142,6 +143,76 @@ func (s *PostgresSink) ListStepLogChunks(ctx context.Context, buildID string, st
 	}
 
 	return chunks, nil
+}
+
+func (s *PostgresSink) ListStepLogChunksTail(ctx context.Context, buildID string, stepIndex *int, limit int) (chunks []StepLogChunk, truncated bool, err error) {
+	if strings.TrimSpace(buildID) == "" {
+		return nil, false, errors.New("build_id is required")
+	}
+	if stepIndex != nil && *stepIndex < 0 {
+		return nil, false, errors.New("step_index must be >= 0")
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 5000 {
+		limit = 5000
+	}
+
+	query := `
+		SELECT sequence_no, build_id, step_id, step_index, step_name, stream, chunk_text, created_at
+		FROM build_step_logs
+		WHERE build_id = $1`
+	args := []any{buildID}
+	argIndex := 2
+	if stepIndex != nil {
+		query += fmt.Sprintf("\n\t\t  AND step_index = $%d", argIndex)
+		args = append(args, *stepIndex)
+		argIndex++
+	}
+	query += fmt.Sprintf("\n\t\tORDER BY sequence_no DESC\n\t\tLIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, queryErr := s.db.QueryContext(ctx, query, args...)
+	if queryErr != nil {
+		return nil, false, queryErr
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	chunks = make([]StepLogChunk, 0, limit)
+	for rows.Next() {
+		var chunk StepLogChunk
+		if scanErr := rows.Scan(
+			&chunk.SequenceNo,
+			&chunk.BuildID,
+			&chunk.StepID,
+			&chunk.StepIndex,
+			&chunk.StepName,
+			&chunk.Stream,
+			&chunk.ChunkText,
+			&chunk.CreatedAt,
+		); scanErr != nil {
+			return nil, false, scanErr
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, false, rowsErr
+	}
+	if len(chunks) > limit {
+		truncated = true
+		chunks = chunks[:limit]
+	}
+	for left, right := 0, len(chunks)-1; left < right; left, right = left+1, right-1 {
+		chunks[left], chunks[right] = chunks[right], chunks[left]
+	}
+
+	return chunks, truncated, nil
 }
 
 func (s *PostgresSink) GetBuildLogs(ctx context.Context, buildID string) (out []BuildLogLine, err error) {

--- a/backend/internal/logs/postgres_sink_test.go
+++ b/backend/internal/logs/postgres_sink_test.go
@@ -80,3 +80,39 @@ func TestPostgresSink_ListStepLogChunks(t *testing.T) {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
+
+func TestPostgresSink_ListStepLogChunksTail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sql mock: %v", err)
+	}
+
+	sink := NewPostgresSink(db)
+	now := time.Now().UTC()
+	stepIndex := 0
+
+	mock.ExpectQuery("SELECT sequence_no, build_id, step_id, step_index, step_name, stream, chunk_text, created_at").
+		WithArgs("build-1", stepIndex, 3).
+		WillReturnRows(sqlmock.NewRows([]string{"sequence_no", "build_id", "step_id", "step_index", "step_name", "stream", "chunk_text", "created_at"}).
+			AddRow(4, "build-1", "step-1", 0, "setup", "stdout", "line-4", now.Add(3*time.Second)).
+			AddRow(3, "build-1", "step-1", 0, "setup", "stdout", "line-3", now.Add(2*time.Second)).
+			AddRow(2, "build-1", "step-1", 0, "setup", "stdout", "line-2", now.Add(1*time.Second)))
+	mock.ExpectClose()
+
+	chunks, truncated, tailErr := sink.ListStepLogChunksTail(context.Background(), "build-1", &stepIndex, 2)
+	if tailErr != nil {
+		t.Fatalf("tail list failed: %v", tailErr)
+	}
+	if !truncated {
+		t.Fatal("expected truncated result")
+	}
+	if len(chunks) != 2 || chunks[0].SequenceNo != 3 || chunks[1].SequenceNo != 4 {
+		t.Fatalf("unexpected sequence ordering: %+v", chunks)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close db: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/backend/internal/logs/postgres_sink_test.go
+++ b/backend/internal/logs/postgres_sink_test.go
@@ -38,12 +38,12 @@ func TestPostgresSink_AppendStepLogChunk(t *testing.T) {
 	if chunk.SequenceNo != 1 {
 		t.Fatalf("expected sequence 1, got %d", chunk.SequenceNo)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close db: %v", err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("failed to close db: %v", closeErr)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if expectErr := mock.ExpectationsWereMet(); expectErr != nil {
+		t.Fatalf("unmet sql expectations: %v", expectErr)
 	}
 }
 
@@ -73,12 +73,12 @@ func TestPostgresSink_ListStepLogChunks(t *testing.T) {
 	if chunks[0].SequenceNo != 1 || chunks[1].SequenceNo != 2 {
 		t.Fatalf("unexpected sequence ordering: %+v", chunks)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close db: %v", err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("failed to close db: %v", closeErr)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if expectErr := mock.ExpectationsWereMet(); expectErr != nil {
+		t.Fatalf("unmet sql expectations: %v", expectErr)
 	}
 }
 
@@ -110,11 +110,11 @@ func TestPostgresSink_ListStepLogChunksTail(t *testing.T) {
 	if len(chunks) != 2 || chunks[0].SequenceNo != 3 || chunks[1].SequenceNo != 4 {
 		t.Fatalf("unexpected sequence ordering: %+v", chunks)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close db: %v", err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("failed to close db: %v", closeErr)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if expectErr := mock.ExpectationsWereMet(); expectErr != nil {
+		t.Fatalf("unmet sql expectations: %v", expectErr)
 	}
 }
 
@@ -144,11 +144,11 @@ func TestPostgresSink_ListStepLogChunksTail_DefaultLimitWithoutStepFilter(t *tes
 	if len(chunks) != 2 || chunks[0].SequenceNo != 1 || chunks[1].SequenceNo != 2 {
 		t.Fatalf("unexpected chunks: %+v", chunks)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close db: %v", err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("failed to close db: %v", closeErr)
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet sql expectations: %v", err)
+	if expectErr := mock.ExpectationsWereMet(); expectErr != nil {
+		t.Fatalf("unmet sql expectations: %v", expectErr)
 	}
 }
 
@@ -174,7 +174,7 @@ func TestPostgresSink_ListStepLogChunksTail_ValidationAndScanErrors(t *testing.T
 	if _, _, err := sink.ListStepLogChunksTail(context.Background(), "build-1", nil, 1); err == nil || err.Error() != "query failed" {
 		t.Fatalf("expected query error, got %v", err)
 	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close db: %v", err)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("failed to close db: %v", closeErr)
 	}
 }

--- a/backend/internal/logs/postgres_sink_test.go
+++ b/backend/internal/logs/postgres_sink_test.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -114,5 +115,66 @@ func TestPostgresSink_ListStepLogChunksTail(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestPostgresSink_ListStepLogChunksTail_DefaultLimitWithoutStepFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sql mock: %v", err)
+	}
+
+	sink := NewPostgresSink(db)
+	now := time.Now().UTC()
+
+	mock.ExpectQuery("SELECT sequence_no, build_id, step_id, step_index, step_name, stream, chunk_text, created_at").
+		WithArgs("build-1", 201).
+		WillReturnRows(sqlmock.NewRows([]string{"sequence_no", "build_id", "step_id", "step_index", "step_name", "stream", "chunk_text", "created_at"}).
+			AddRow(2, "build-1", "step-2", 1, "test", "stdout", "line-2", now.Add(time.Second)).
+			AddRow(1, "build-1", "step-1", 0, "setup", "stdout", "line-1", now))
+	mock.ExpectClose()
+
+	chunks, truncated, tailErr := sink.ListStepLogChunksTail(context.Background(), "build-1", nil, 0)
+	if tailErr != nil {
+		t.Fatalf("tail list failed: %v", tailErr)
+	}
+	if truncated {
+		t.Fatal("expected untruncated result")
+	}
+	if len(chunks) != 2 || chunks[0].SequenceNo != 1 || chunks[1].SequenceNo != 2 {
+		t.Fatalf("unexpected chunks: %+v", chunks)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close db: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestPostgresSink_ListStepLogChunksTail_ValidationAndScanErrors(t *testing.T) {
+	sink := NewPostgresSink(nil)
+	if _, _, err := sink.ListStepLogChunksTail(context.Background(), "", nil, 1); err == nil {
+		t.Fatal("expected build_id validation error")
+	}
+	stepIndex := -1
+	if _, _, err := sink.ListStepLogChunksTail(context.Background(), "build-1", &stepIndex, 1); err == nil {
+		t.Fatal("expected step_index validation error")
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sql mock: %v", err)
+	}
+	sink = NewPostgresSink(db)
+	mock.ExpectQuery("SELECT sequence_no, build_id, step_id, step_index, step_name, stream, chunk_text, created_at").
+		WithArgs("build-1", 2).
+		WillReturnError(errors.New("query failed"))
+	mock.ExpectClose()
+	if _, _, err := sink.ListStepLogChunksTail(context.Background(), "build-1", nil, 1); err == nil || err.Error() != "query failed" {
+		t.Fatalf("expected query error, got %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close db: %v", err)
 	}
 }

--- a/backend/internal/service/build/read_queue.go
+++ b/backend/internal/service/build/read_queue.go
@@ -156,6 +156,19 @@ func (s *BuildService) GetStepLogChunks(ctx context.Context, buildID string, ste
 	return reader.ListStepLogChunks(ctx, buildID, stepIndex, afterSequence, limit)
 }
 
+func (s *BuildService) GetBuildLogChunksTail(ctx context.Context, buildID string, stepIndex *int, limit int) ([]logs.StepLogChunk, bool, error) {
+	if _, err := s.buildRepo.GetByID(ctx, buildID); err != nil {
+		return nil, false, mapRepoErr(err)
+	}
+
+	reader, ok := s.logSink.(logs.StepLogChunkTailReader)
+	if !ok {
+		return []logs.StepLogChunk{}, false, nil
+	}
+
+	return reader.ListStepLogChunksTail(ctx, buildID, stepIndex, limit)
+}
+
 func (s *BuildService) GetBuildArtifacts(ctx context.Context, buildID string) ([]domain.BuildArtifact, error) {
 	if _, err := s.buildRepo.GetByID(ctx, buildID); err != nil {
 		return nil, mapRepoErr(err)

--- a/backend/internal/service/build/read_queue_tail_test.go
+++ b/backend/internal/service/build/read_queue_tail_test.go
@@ -1,0 +1,82 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/logs"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+type tailReaderSink struct {
+	chunks    []logs.StepLogChunk
+	truncated bool
+	err       error
+	buildID   string
+	stepIndex *int
+	limit     int
+}
+
+func (s *tailReaderSink) WriteStepLog(context.Context, string, string, string) error {
+	return nil
+}
+
+func (s *tailReaderSink) ListStepLogChunksTail(_ context.Context, buildID string, stepIndex *int, limit int) ([]logs.StepLogChunk, bool, error) {
+	s.buildID = buildID
+	s.stepIndex = stepIndex
+	s.limit = limit
+	if s.err != nil {
+		return nil, false, s.err
+	}
+	return s.chunks, s.truncated, nil
+}
+
+func TestBuildService_GetBuildLogChunksTail(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeBuildRepository{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusRunning, CreatedAt: now}}
+	stepIndex := 2
+	sink := &tailReaderSink{chunks: []logs.StepLogChunk{{BuildID: "build-1", StepIndex: 2, ChunkText: "tail"}}, truncated: true}
+	svc := NewBuildService(repo, nil, sink)
+
+	chunks, truncated, err := svc.GetBuildLogChunksTail(context.Background(), "build-1", &stepIndex, 77)
+	if err != nil {
+		t.Fatalf("GetBuildLogChunksTail failed: %v", err)
+	}
+	if !truncated || len(chunks) != 1 || chunks[0].ChunkText != "tail" {
+		t.Fatalf("unexpected tail result: chunks=%+v truncated=%v", chunks, truncated)
+	}
+	if sink.buildID != "build-1" || sink.stepIndex == nil || *sink.stepIndex != 2 || sink.limit != 77 {
+		t.Fatalf("unexpected sink call: %+v", sink)
+	}
+}
+
+func TestBuildService_GetBuildLogChunksTail_FallbackAndErrors(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &fakeBuildRepository{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusRunning, CreatedAt: now}}
+	svc := NewBuildService(repo, nil, logs.NewNoopSink())
+
+	chunks, truncated, err := svc.GetBuildLogChunksTail(context.Background(), "build-1", nil, 10)
+	if err != nil {
+		t.Fatalf("expected noop fallback, got %v", err)
+	}
+	if truncated || len(chunks) != 0 {
+		t.Fatalf("expected empty noop fallback, got chunks=%+v truncated=%v", chunks, truncated)
+	}
+
+	notFoundRepo := &fakeBuildRepository{getErr: repository.ErrBuildNotFound}
+	notFoundSvc := NewBuildService(notFoundRepo, nil, logs.NewNoopSink())
+	_, _, notFoundErr := notFoundSvc.GetBuildLogChunksTail(context.Background(), "missing", nil, 10)
+	if !errors.Is(notFoundErr, ErrBuildNotFound) {
+		t.Fatalf("expected ErrBuildNotFound, got %v", notFoundErr)
+	}
+
+	sinkErr := errors.New("tail read failed")
+	errSvc := NewBuildService(repo, nil, &tailReaderSink{err: sinkErr})
+	_, _, gotErr := errSvc.GetBuildLogChunksTail(context.Background(), "build-1", nil, 10)
+	if !errors.Is(gotErr, sinkErr) {
+		t.Fatalf("expected sink error, got %v", gotErr)
+	}
+}


### PR DESCRIPTION
# Add CLI build inspection commands

## Summary

Adds the first read-only build inspection commands to the Coyote CLI.

This PR introduces `coyote build status` and `coyote build logs` so engineers and IDE agents can inspect build state and failure logs without opening the web UI. The commands use the existing authenticated CLI context/token plumbing, enforce scope-aware API-token authorization, and provide stable JSON output for automation.

Rerun/retry/recovery commands remain intentionally deferred.

## What changed

### CLI build command group

Added a new `build` command group with:

- `coyote build status <build-id>`
- `coyote build logs <build-id>`

`build status` displays compact build metadata and failure context.

`build logs` retrieves a bounded snapshot of build logs and supports:

- `--step <step-index>`
- `--failed`
- `--tail <n>`
- `--json`

The command is snapshot-based: re-running it fetches updated logs. Live following is deferred to a future `--follow` or `build watch` slice.

### Human-readable output

`coyote build status` now reports useful build context such as:

- build ID;
- project/job context;
- status;
- ref/SHA;
- author when available;
- timestamps/duration;
- failed-step summary when available;
- build URL.

`coyote build logs` prints readable grouped log output by step, with selected-step behavior for `--step` and `--failed`.

### JSON output for automation and IDE agents

Both commands support stable JSON output.

The JSON output is intended as the automation contract for CI/headless usage and IDE agents. It includes build, step, and log metadata without extra prose in stdout.

`build logs --json` includes selected-step metadata, structured log entries, and truncation information.

### Typed API client additions

Extended the typed CLI API client with focused build-inspection methods.

The client additions preserve existing CLI behavior:

- bearer-token authentication;
- context cancellation;
- path-prefixed server URL handling;
- typed API errors;
- stdout/stderr separation;
- no token leakage.

No broad/generated API client was introduced.

### Backend log API enhancement

Extended the existing aggregate build-log API route so the CLI can retrieve logs by:

- build ID;
- specific step;
- failed step;
- bounded tail.

This avoids requiring `build:read` for failed-step log selection. A token with only `build:logs` can retrieve failed-step logs without calling build-step metadata endpoints that require `build:read`.

### Bounded snapshot log retrieval

The aggregate log route now has a bounded response contract.

Log retrieval is capped by default and by a server-side maximum so all-step log requests cannot return unbounded output.

The response indicates whether results were truncated, and JSON output carries that truncation state for automation.

### Scope-aware authorization

The new commands rely on the scoped-token prerequisite:

- `coyote build status` requires `build:read` for API-token callers.
- `coyote build logs` requires `build:logs` for API-token callers.

The owning user must still be authorized for the build.

Session/browser-authenticated behavior remains unchanged.

Missing token scopes produce authorization failures rather than authentication failures, and CLI tests cover missing-scope stderr/stdout/exit-code behavior.

### Tests

Added focused coverage for:

- `build status` human output;
- `build status --json`;
- `build logs` human output;
- `build logs --json`;
- `build logs --step`;
- `build logs --failed`;
- `build logs --tail`;
- bounded/truncated log retrieval;
- missing-scope CLI behavior;
- typed API-client build/log requests;
- touched backend log handler behavior;
- scope enforcement on touched routes.

Validation included:

```bash
go test ./internal/apiclient ./internal/cli ./internal/http/handler ./internal/api
```

## Local validation

Local command testing should include:

```bash
./backend/tmp/coyote build status <build-id>
./backend/tmp/coyote build status <build-id> --json

./backend/tmp/coyote build logs <build-id> --tail 50
./backend/tmp/coyote build logs <build-id> --failed --tail 50
./backend/tmp/coyote build logs <build-id> --failed --tail 50 --json
```

Recommended scope checks:

- token with `build:read` can run `build status`;
- token without `build:read` cannot run `build status`;
- token with `build:logs` can run `build logs`;
- token without `build:logs` cannot run `build logs`;
- token with only `build:logs` can run `build logs --failed`;
- token with only `build:logs` cannot run `build status`.

## Deferred

Intentionally out of scope:

- `coyote build rerun`;
- `coyote build retry`;
- recovery command orchestration;
- live log following;
- `coyote build watch`;
- artifact download CLI commands;
- Slack notification command text updates;
- token scope changes;
- token-management UI changes;
- local build execution;
- generated API client.

## Suggested PR title

**Add CLI build inspection commands**
