### PR TITLE
Add CLI build retry command

### DIFF
--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -111,6 +111,14 @@ func (c *Client) GetBuild(ctx context.Context, buildID string) (api.BuildRespons
 	return envelope.Data, nil
 }
 
+func (c *Client) RerunBuild(ctx context.Context, buildID string) (api.BuildResponse, error) {
+	var envelope api.BuildEnvelope
+	if err := c.doJSON(ctx, http.MethodPost, buildResourcePath(buildID, "/rerun"), nil, &envelope); err != nil {
+		return api.BuildResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
 func (c *Client) GetBuildSteps(ctx context.Context, buildID string) ([]api.BuildStepResponse, error) {
 	var envelope api.BuildStepsEnvelope
 	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, "/steps"), nil, &envelope); err != nil {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -120,6 +120,29 @@ func TestClient_RerunBuild(t *testing.T) {
 	}
 }
 
+func TestClient_RerunBuildReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:run"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, rerunErr := client.RerunBuild(context.Background(), "build-1")
+	var apiErr *Error
+	if !errors.As(rerunErr, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", rerunErr)
+	}
+	if apiErr.Kind != ErrorKindAuthorization || apiErr.Code != "missing_token_scope" {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
 func TestClient_GetBuildLogsWithoutExplicitTailUsesServerDefaultBehavior(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() != "/api/builds/build-1/logs" {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -94,6 +94,32 @@ func TestClient_BuildInspectionMethods(t *testing.T) {
 	}
 }
 
+func TestClient_RerunBuild(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.String() != "/api/builds/build-1/rerun" {
+			t.Fatalf("unexpected request path %q", r.URL.String())
+		}
+		_, _ = w.Write([]byte(`{"data":{"id":"build-2","project_id":"project-1","project_name":"Coyote","job_id":"job-1","status":"queued","created_at":"2026-07-04T00:02:00Z","queued_at":"2026-07-04T00:02:00Z","started_at":null,"finished_at":null,"current_step_index":0,"attempt_number":2,"rerun_of_build_id":"build-1","error_message":null,"trigger_type":"rerun","trigger_kind":"manual","image":{"source_kind":"external"}}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	build, rerunErr := client.RerunBuild(context.Background(), "build-1")
+	if rerunErr != nil {
+		t.Fatalf("rerun build: %v", rerunErr)
+	}
+	if build.ID != "build-2" || build.RerunOfBuildID == nil || *build.RerunOfBuildID != "build-1" || build.Status != "queued" {
+		t.Fatalf("unexpected rerun response: %+v", build)
+	}
+}
+
 func TestClient_GetBuildLogsWithoutExplicitTailUsesServerDefaultBehavior(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() != "/api/builds/build-1/logs" {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -63,8 +63,10 @@ type buildRetryView struct {
 	WebURL        string `json:"web_url,omitempty"`
 }
 
+var isInteractiveInputFunc = isInteractiveInput
+
 func (a *app) newBuildCommand() *cobra.Command {
-	command := &cobra.Command{Use: "build", Short: "Inspect builds"}
+	command := &cobra.Command{Use: "build", Short: "Inspect and manage builds"}
 	command.AddCommand(a.newBuildStatusCommand())
 	command.AddCommand(a.newBuildLogsCommand())
 	command.AddCommand(a.newBuildRetryCommand())
@@ -386,7 +388,7 @@ func (a *app) confirmBuildRetry(buildID string, mode output.Mode, assumeYes bool
 	if mode == output.ModeJSON {
 		return &ExitError{Code: 2, Err: errors.New("build retry with --json requires --yes")}
 	}
-	if !isInteractiveInput(a.stdin) {
+	if !isInteractiveInputFunc(a.stdin) {
 		return &ExitError{Code: 2, Err: errors.New("build retry requires --yes when stdin is not interactive")}
 	}
 	if _, err := fmt.Fprintf(a.stderr, "Retry build %s? This may start a new build. [y/N] ", strings.TrimSpace(buildID)); err != nil {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -1,15 +1,19 @@
 package cli
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
 	"github.com/radiation/coyote-ci/backend/internal/apiclient"
@@ -48,10 +52,22 @@ type buildFailedStepView struct {
 	ExitCode *int   `json:"exit_code,omitempty"`
 }
 
+type buildRetryPayload struct {
+	Retried buildRetryView `json:"retried"`
+}
+
+type buildRetryView struct {
+	SourceBuildID string `json:"source_build_id"`
+	BuildID       string `json:"build_id"`
+	Status        string `json:"status"`
+	WebURL        string `json:"web_url,omitempty"`
+}
+
 func (a *app) newBuildCommand() *cobra.Command {
 	command := &cobra.Command{Use: "build", Short: "Inspect builds"}
 	command.AddCommand(a.newBuildStatusCommand())
 	command.AddCommand(a.newBuildLogsCommand())
+	command.AddCommand(a.newBuildRetryCommand())
 	return command
 }
 
@@ -125,6 +141,44 @@ func (a *app) newBuildLogsCommand() *cobra.Command {
 	command.Flags().StringVar(&stepRaw, "step", "", "Limit logs to one step index")
 	command.Flags().BoolVar(&failed, "failed", false, "Select the failed step when exactly one step failed")
 	command.Flags().IntVar(&tail, "tail", 0, "Show only the last N log entries")
+	return command
+}
+
+func (a *app) newBuildRetryCommand() *cobra.Command {
+	var assumeYes bool
+
+	command := &cobra.Command{
+		Use:     "retry <build-id>",
+		Aliases: []string{"rerun"},
+		Short:   "Retry a whole build by creating a new attempt",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			confirmErr := a.confirmBuildRetry(args[0], resolved.OutputMode, assumeYes)
+			if confirmErr != nil {
+				return confirmErr
+			}
+
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			build, rerunErr := client.RerunBuild(cmd.Context(), args[0])
+			if rerunErr != nil {
+				return mapCommandError(rerunErr)
+			}
+
+			payload := makeBuildRetryPayload(resolved.ServerURL, args[0], build)
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildRetryHuman(w, payload)
+			}, payload)
+		},
+	}
+	command.Flags().BoolVar(&assumeYes, "yes", false, "Skip confirmation prompt")
 	return command
 }
 
@@ -290,6 +344,72 @@ func writeBuildLogsHuman(w io.Writer, response api.BuildLogsResponse) error {
 		}
 	}
 	return nil
+}
+
+func makeBuildRetryPayload(serverURL string, sourceBuildID string, build api.BuildResponse) buildRetryPayload {
+	return buildRetryPayload{
+		Retried: buildRetryView{
+			SourceBuildID: strings.TrimSpace(sourceBuildID),
+			BuildID:       build.ID,
+			Status:        build.Status,
+			WebURL:        buildWebURL(serverURL, build.ID, nil),
+		},
+	}
+}
+
+func writeBuildRetryHuman(w io.Writer, payload buildRetryPayload) error {
+	retried := payload.Retried
+	if retried.SourceBuildID != "" && retried.SourceBuildID != retried.BuildID {
+		if _, err := fmt.Fprintf(w, "Retried build %s -> %s\n", retried.SourceBuildID, retried.BuildID); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "Retried build %s\n", retried.BuildID); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "Status: %s\n", retried.Status); err != nil {
+		return err
+	}
+	if retried.WebURL != "" {
+		if _, err := fmt.Fprintf(w, "URL: %s\n", retried.WebURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *app) confirmBuildRetry(buildID string, mode output.Mode, assumeYes bool) error {
+	if assumeYes {
+		return nil
+	}
+	if mode == output.ModeJSON {
+		return &ExitError{Code: 2, Err: errors.New("build retry with --json requires --yes")}
+	}
+	if !isInteractiveInput(a.stdin) {
+		return &ExitError{Code: 2, Err: errors.New("build retry requires --yes when stdin is not interactive")}
+	}
+	if _, err := fmt.Fprintf(a.stderr, "Retry build %s? This may start a new build. [y/N] ", strings.TrimSpace(buildID)); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(a.stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(answer))
+	if trimmed != "y" && trimmed != "yes" {
+		return &ExitError{Code: 2, Err: errors.New("build retry canceled")}
+	}
+	return nil
+}
+
+func isInteractiveInput(reader io.Reader) bool {
+	file, ok := reader.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
 }
 
 func logHeader(selected *api.BuildLogSelectedStepResponse, entry api.BuildLogResponse) string {

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -194,6 +194,31 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 	if got := firstNonEmptyPtr(nil, stringPtr("  "), &author); got == nil || *got != author {
 		t.Fatalf("unexpected first non-empty ptr result: %+v", got)
 	}
+
+	retryPayload := makeBuildRetryPayload("https://example.com/base", "build-1", api.BuildResponse{ID: "build-2", Status: "queued"})
+	if retryPayload.Retried.SourceBuildID != "build-1" || retryPayload.Retried.BuildID != "build-2" || !strings.Contains(retryPayload.Retried.WebURL, "/base/builds/build-2") {
+		t.Fatalf("unexpected retry payload: %+v", retryPayload)
+	}
+	buf.Reset()
+	if err := writeBuildRetryHuman(buf, retryPayload); err != nil {
+		t.Fatalf("writeBuildRetryHuman failed: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Retried build build-1 -> build-2") || !strings.Contains(got, "Status: queued") {
+		t.Fatalf("unexpected retry output: %s", got)
+	}
+	buf.Reset()
+	if err := writeBuildRetryHuman(buf, buildRetryPayload{Retried: buildRetryView{SourceBuildID: "build-1", BuildID: "build-1", Status: "queued"}}); err != nil {
+		t.Fatalf("writeBuildRetryHuman same-id failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Retried build build-1\n") {
+		t.Fatalf("expected same-id retry output, got %q", buf.String())
+	}
+	if err := writeBuildRetryHuman(failWriter{}, retryPayload); err == nil {
+		t.Fatal("expected writeBuildRetryHuman to surface write errors")
+	}
+	if isInteractiveInput(strings.NewReader("y\n")) {
+		t.Fatal("expected strings reader to be treated as non-interactive")
+	}
 }
 
 func intPtr(value int) *int { return &value }

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -3,16 +3,24 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/cli/output"
 )
 
 type failWriter struct{}
 
 func (failWriter) Write([]byte) (int, error) {
 	return 0, errors.New("write failed")
+}
+
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }
 
 func TestParseBuildLogsOptions(t *testing.T) {
@@ -219,6 +227,87 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 	if isInteractiveInput(strings.NewReader("y\n")) {
 		t.Fatal("expected strings reader to be treated as non-interactive")
 	}
+}
+
+func TestConfirmBuildRetry(t *testing.T) {
+	originalInteractiveCheck := isInteractiveInputFunc
+	t.Cleanup(func() {
+		isInteractiveInputFunc = originalInteractiveCheck
+	})
+
+	t.Run("assume yes skips prompt", func(t *testing.T) {
+		app := &app{stdin: strings.NewReader("ignored"), stderr: &bytes.Buffer{}}
+		if err := app.confirmBuildRetry("build-1", output.ModeHuman, true); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("json requires yes", func(t *testing.T) {
+		app := &app{stdin: strings.NewReader("ignored"), stderr: &bytes.Buffer{}}
+		err := app.confirmBuildRetry("build-1", output.ModeJSON, false)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "requires --yes") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("noninteractive requires yes", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return false }
+		app := &app{stdin: strings.NewReader("ignored"), stderr: &bytes.Buffer{}}
+		err := app.confirmBuildRetry("build-1", output.ModeHuman, false)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "stdin is not interactive") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("accepts confirmation", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return true }
+		stderr := &bytes.Buffer{}
+		app := &app{stdin: strings.NewReader("yes\n"), stderr: stderr}
+		if err := app.confirmBuildRetry("build-1", output.ModeHuman, false); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if !strings.Contains(stderr.String(), "Retry build build-1?") {
+			t.Fatalf("expected prompt in stderr, got %q", stderr.String())
+		}
+	})
+
+	t.Run("declines confirmation", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return true }
+		app := &app{stdin: strings.NewReader("n\n"), stderr: &bytes.Buffer{}}
+		err := app.confirmBuildRetry("build-1", output.ModeHuman, false)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "canceled") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("stderr write failure is returned", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return true }
+		app := &app{stdin: strings.NewReader("yes\n"), stderr: failWriter{}}
+		if err := app.confirmBuildRetry("build-1", output.ModeHuman, false); err == nil || err.Error() != "write failed" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("stdin read failure is returned", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return true }
+		app := &app{stdin: failReader{}, stderr: &bytes.Buffer{}}
+		if err := app.confirmBuildRetry("build-1", output.ModeHuman, false); err == nil || err.Error() != "read failed" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("eof without yes cancels", func(t *testing.T) {
+		isInteractiveInputFunc = func(io.Reader) bool { return true }
+		app := &app{stdin: strings.NewReader(""), stderr: &bytes.Buffer{}}
+		err := app.confirmBuildRetry("build-1", output.ModeHuman, false)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "canceled") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func intPtr(value int) *int { return &value }

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -228,11 +228,123 @@ func TestBuildStatusAndLogsCommands(t *testing.T) {
 	}
 }
 
+func TestBuildRetryCommand(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/rerun":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST, got %s", r.Method)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":"build-2","build_number":13,"project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","status":"queued","created_at":"2026-07-04T00:01:00Z","queued_at":"2026-07-04T00:01:00Z","started_at":null,"finished_at":null,"current_step_index":0,"attempt_number":2,"rerun_of_build_id":"build-1","error_message":null,"trigger_type":"rerun","trigger_kind":"manual","image":{"source_kind":"external"}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, Stdin: strings.NewReader("ignored"), ConfigStore: configStore, Credentials: creds, Args: []string{"build", "retry", "build-1", "--yes"}}); code != 0 {
+		t.Fatalf("build retry exit code %d stderr=%s", code, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "Retried build build-1 -> build-2") || !strings.Contains(got, "Status: queued") || !strings.Contains(got, "/builds/build-2") {
+		t.Fatalf("unexpected retry output: %s", got)
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, Stdin: strings.NewReader("ignored"), ConfigStore: configStore, Credentials: creds, Args: []string{"build", "rerun", "build-1", "--yes", "--json"}}); code != 0 {
+		t.Fatalf("build rerun json exit code %d stderr=%s", code, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode build retry json: %v", err)
+	}
+	retried, ok := payload["retried"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected retried object, got %+v", payload)
+	}
+	if retried["source_build_id"] != "build-1" || retried["build_id"] != "build-2" || retried["status"] != "queued" {
+		t.Fatalf("unexpected retry payload: %+v", payload)
+	}
+	if strings.Contains(stdout.String(), "Retried build") {
+		t.Fatalf("unexpected human prose in build retry JSON: %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestBuildRetryCommandRequiresExplicitYesWhenNonInteractive(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, Stdin: strings.NewReader(""), ConfigStore: configStore, Credentials: creds, Args: []string{"build", "retry", "build-1"}})
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if called {
+		t.Fatal("expected retry command to stop before making an HTTP request")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "build retry requires --yes when stdin is not interactive") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code = Run(Dependencies{Stdout: stdout, Stderr: stderr, Stdin: strings.NewReader(""), ConfigStore: configStore, Credentials: creds, Args: []string{"build", "retry", "build-1", "--json"}})
+	if code != 2 {
+		t.Fatalf("expected json retry exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "build retry with --json requires --yes") {
+		t.Fatalf("unexpected json stderr: %s", stderr.String())
+	}
+}
+
 func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		message := "api token does not have the required scope: build:read"
 		if strings.Contains(r.URL.Path, "/logs") {
 			message = "api token does not have the required scope: build:logs"
+		} else if strings.Contains(r.URL.Path, "/rerun") {
+			message = "api token does not have the required scope: build:run"
 		}
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"` + message + `"}}`))
@@ -260,6 +372,7 @@ func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {
 	}{
 		{name: "status missing scope", args: []string{"build", "status", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:read"},
 		{name: "logs missing scope", args: []string{"build", "logs", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:logs"},
+		{name: "retry missing scope", args: []string{"build", "retry", "build-1", "--yes", "--json"}, wantContains: "api token does not have the required scope: build:run"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Add CLI build retry command

## Summary

Adds the first mutating build command to the Coyote CLI.

This PR introduces whole-build retry/rerun support so engineers and IDE agents can complete the initial failure-recovery loop from the command line:

```text
status -> failed logs -> retry
```

The command uses the existing authenticated CLI context/token plumbing, calls the existing backend rerun API, enforces the `build:run` API-token scope server-side, and supports automation-safe JSON output.

Step-level retry remains intentionally deferred.

## What changed

### CLI retry command

Added a whole-build retry command under the existing build command group:

```bash
coyote build retry <build-id>
```

Also added `rerun` as an alias:

```bash
coyote build rerun <build-id>
```

Both commands call the same backend whole-build rerun operation.

### Backend API integration

The CLI uses the existing backend route:

```text
POST /api/builds/{buildID}/rerun
```

The backend creates a new build attempt with a new build ID and links it to the original build using the existing rerun lineage behavior.

No backend worker execution semantics were changed.

### Human output

Successful human output reports the source build, the new build, status, and URL.

Example:

```text
Retried build bld_123 -> bld_456
Status: queued
URL: http://localhost:8080/builds/bld_456
```

The output gives users enough information to continue with:

```bash
coyote build status <new-build-id>
```

### JSON output

Added stable JSON output for automation and IDE-agent workflows.

Example shape:

```json
{
  "retried": {
    "source_build_id": "bld_123",
    "build_id": "bld_456",
    "status": "queued",
    "web_url": "http://localhost:8080/builds/bld_456"
  }
}
```

JSON output contains only JSON on stdout. Errors and prompts go to stderr.

### Confirmation and automation behavior

Because retrying a build mutates server state and may consume compute, the command requires confirmation by default.

Added:

```bash
coyote build retry <build-id> --yes
```

`--yes` skips confirmation for CI, scripts, and IDE agents.

Noninteractive execution fails clearly unless `--yes` is supplied.

`--json` also requires `--yes`, preventing interactive prompts from mixing with machine-readable output.

### Scope-aware authorization

The retry command relies on the existing scoped-token authorization model.

API-token callers must have:

```text
build:run
```

The owning user must still be authorized to rerun the build.

A token with `build:run` cannot bypass normal project/build authorization.

Tokens with only diagnostic scopes such as `build:read` and `build:logs` can inspect builds and logs, but cannot retry/rerun builds.

### Typed API client

Extended the typed CLI API client with a focused build retry/rerun method.

The client preserves existing behavior:

- bearer-token authentication;
- path-prefixed server URL support;
- context cancellation;
- typed API error mapping;
- missing-scope handling;
- no token leakage in output or errors.

### Tests

Added focused coverage for:

- retry human output;
- retry JSON output;
- `rerun` alias behavior;
- `--yes` skipping confirmation;
- confirmation accepted/declined;
- noninteractive execution requiring `--yes`;
- `--json` requiring `--yes`;
- auth failure;
- missing `build:run` scope;
- invalid build IDs;
- not-found/domain errors;
- stdout/stderr separation;
- typed API client retry request/response behavior.

Validation included:

```bash
go test ./internal/apiclient ./internal/cli
```

Local testing also covered invalid tokens, missing scopes, invalid IDs, and successful retry/rerun with a correctly scoped token.

## Deferred

Intentionally out of scope:

- step retry;
- failed-step retry;
- partial pipeline retry;
- live log following;
- `coyote build watch`;
- artifact download CLI commands;
- project/job discovery commands;
- Slack notification command text updates;
- token scope vocabulary changes;
- token-management UI changes;
- local build execution;
- generated API client.

## Suggested PR title

**Add CLI build retry command**
