### PR TITLE
Add CLI build artifact commands

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ set -eu
 failed=0
 
 # ── Backend ──────────────────────────────────────────────────────────────────
-if command -v go >/dev/null 2>&1; then
+if command -v go >/dev/null 2>&1 && command -v make >/dev/null 2>&1; then
 	echo "== Backend =="
 
 	echo "  go fmt"
@@ -29,7 +29,7 @@ if command -v go >/dev/null 2>&1; then
 		failed=1
 	fi
 else
-	echo "== Backend (skipped: go not found) =="
+	echo "== Backend (skipped: go or make not found) =="
 fi
 
 # ── Frontend ─────────────────────────────────────────────────────────────────

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,18 +24,9 @@ if command -v go >/dev/null 2>&1; then
 		echo "  gofmt formatted files and staged"
 	fi
 
-	echo "  go vet"
-	if ! (cd backend && go vet ./...) ; then
+	echo "  backend lint"
+	if ! make backend-lint ; then
 		failed=1
-	fi
-
-	if command -v golangci-lint >/dev/null 2>&1; then
-		echo "  golangci-lint"
-		if ! (cd backend && golangci-lint run ./...) ; then
-			failed=1
-		fi
-	else
-		echo "  golangci-lint (skipped: not installed)"
 	fi
 else
 	echo "== Backend (skipped: go not found) =="

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,11 @@ failed=0
 
 # ── Backend ──────────────────────────────────────────────────────────────────
 if command -v go >/dev/null 2>&1 && command -v make >/dev/null 2>&1; then
+	echo "== Backend lint =="
+	if ! make backend-lint ; then
+		failed=1
+	fi
+
 	echo "== Backend tests =="
 	if ! make backend-test ; then
 		failed=1
@@ -20,7 +25,7 @@ if command -v go >/dev/null 2>&1 && command -v make >/dev/null 2>&1; then
 		failed=1
 	fi
 else
-	echo "== Backend tests and swagger validation (skipped: go or make not found) =="
+	echo "== Backend lint, tests, and swagger validation (skipped: go or make not found) =="
 fi
 
 # ── Frontend ─────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: swagger swagger-check backend-format-check backend-vet backend-architecture backend-unit-test backend-test frontend-lint frontend-test frontend-build pre-push-check check-go-version install-hooks db-migrate-create db-migrate-up db-migrate-down-one db-migrate-status cli-build cli-snapshot cli-validate-release-matrix
+.PHONY: swagger swagger-check backend-format-check backend-vet backend-lint backend-architecture backend-unit-test backend-test frontend-lint frontend-test frontend-build pre-push-check check-go-version install-hooks db-migrate-create db-migrate-up db-migrate-down-one db-migrate-status cli-build cli-snapshot cli-validate-release-matrix
 
 CLI_VERSION ?= dev
 CLI_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -29,6 +29,14 @@ backend-format-check:
 
 backend-vet:
 	cd backend && go vet ./...
+
+backend-lint: backend-vet
+	@set -e; \
+	if command -v golangci-lint >/dev/null 2>&1; then \
+		cd backend && golangci-lint run ./...; \
+	else \
+		cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 run ./...; \
+	fi
 
 backend-architecture:
 	cd backend && go test ./architecture
@@ -61,7 +69,7 @@ frontend-test:
 frontend-build:
 	cd frontend && npm run build
 
-pre-push-check: backend-test frontend-lint frontend-test frontend-build swagger-check
+pre-push-check: backend-lint backend-test frontend-lint frontend-test frontend-build swagger-check
 
 check-go-version:
 	@echo "Checking Go version consistency (source of truth: backend/go.mod)..."

--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -156,6 +156,63 @@ func (c *Client) GetBuildLogs(ctx context.Context, buildID string, options Build
 	return envelope.Data, nil
 }
 
+func (c *Client) ListBuildArtifacts(ctx context.Context, buildID string) (api.BuildArtifactsResponse, error) {
+	var envelope api.BuildArtifactsEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, "/artifacts"), nil, &envelope); err != nil {
+		return api.BuildArtifactsResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
+func (c *Client) DownloadBuildArtifact(ctx context.Context, buildID string, artifactID string, writer io.Writer) error {
+	requestURL, err := resolveRequestURL(c.baseURL, buildArtifactDownloadPath(buildID, artifactID))
+	if err != nil {
+		return &Error{Kind: ErrorKindUnexpected, Message: "invalid request path", Err: err}
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return &Error{Kind: ErrorKindUnexpected, Message: "build request", Err: err}
+	}
+	request.Header.Set("Accept", "application/octet-stream")
+	if c.userAgent != "" {
+		request.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return &Error{Kind: ErrorKindTransport, Message: "request failed", Err: err}
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	requestID := strings.TrimSpace(response.Header.Get("X-Request-Id"))
+	if requestID == "" {
+		requestID = strings.TrimSpace(response.Header.Get("X-Request-ID"))
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return decodeErrorResponse(response, requestID)
+	}
+	if writer == nil {
+		_, _ = io.Copy(io.Discard, response.Body)
+		return nil
+	}
+	if _, err := io.Copy(writer, response.Body); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return &Error{Kind: ErrorKindUnexpected, Message: "stream artifact response", RequestID: requestID, Err: err}
+	}
+	return nil
+}
+
 func (c *Client) doJSON(ctx context.Context, method string, path string, requestBody io.Reader, out any) error {
 	requestURL, err := resolveRequestURL(c.baseURL, path)
 	if err != nil {
@@ -257,6 +314,10 @@ func resolveRequestURL(baseURL *url.URL, requestPath string) (*url.URL, error) {
 
 func buildResourcePath(buildID string, suffix string) string {
 	return "api/builds/" + url.PathEscape(strings.TrimSpace(buildID)) + suffix
+}
+
+func buildArtifactDownloadPath(buildID string, artifactID string) string {
+	return buildResourcePath(buildID, "/artifacts/"+url.PathEscape(strings.TrimSpace(artifactID))+"/download")
 }
 
 func decodeErrorResponse(response *http.Response, requestID string) error {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -91,6 +92,72 @@ func TestClient_BuildInspectionMethods(t *testing.T) {
 	}
 	if logs.BuildID != "build-1" || logs.SelectedStep == nil || logs.SelectedStep.Name != "test" || len(logs.Logs) != 1 {
 		t.Fatalf("unexpected logs response: %+v", logs)
+	}
+}
+
+func TestClient_BuildArtifactMethods(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifacts":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("expected bearer header, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","name":"report.xml","path":"reports/report.xml","size_bytes":42,"content_type":"application/xml","storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+		case "/api/builds/build-1/artifacts/artifact-1/download":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("expected bearer header, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte("artifact-body"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	artifacts, listErr := client.ListBuildArtifacts(context.Background(), "build-1")
+	if listErr != nil {
+		t.Fatalf("list build artifacts: %v", listErr)
+	}
+	if artifacts.BuildID != "build-1" || len(artifacts.Artifacts) != 1 || artifacts.Artifacts[0].Path != "reports/report.xml" {
+		t.Fatalf("unexpected artifacts response: %+v", artifacts)
+	}
+
+	var body bytes.Buffer
+	if downloadErr := client.DownloadBuildArtifact(context.Background(), "build-1", "artifact-1", &body); downloadErr != nil {
+		t.Fatalf("download build artifact: %v", downloadErr)
+	}
+	if body.String() != "artifact-body" {
+		t.Fatalf("unexpected artifact body: %q", body.String())
+	}
+}
+
+func TestClient_DownloadBuildArtifactReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: artifact:read"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	var sink bytes.Buffer
+	err = client.DownloadBuildArtifact(context.Background(), "build-1", "artifact-1", &sink)
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindAuthorization || apiErr.Code != "missing_token_scope" {
+		t.Fatalf("unexpected api error: %+v", apiErr)
 	}
 }
 

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -20,6 +20,12 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 	return f(request)
 }
 
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
 func TestClient_GetMeSendsBearerAndUserAgent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/me" {
@@ -158,6 +164,84 @@ func TestClient_DownloadBuildArtifactReturnsTypedError(t *testing.T) {
 	}
 	if apiErr.Kind != ErrorKindAuthorization || apiErr.Code != "missing_token_scope" {
 		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
+func TestClient_ListBuildArtifactsReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: artifact:read"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.ListBuildArtifacts(context.Background(), "build-1")
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindAuthorization || apiErr.Code != "missing_token_scope" {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
+func TestClient_DownloadBuildArtifactNilWriterAndWriterFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-ID", "req-alt")
+		_, _ = w.Write([]byte("artifact-body"))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "", "", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if nilWriterErr := client.DownloadBuildArtifact(context.Background(), "build-1", "artifact-1", nil); nilWriterErr != nil {
+		t.Fatalf("expected nil writer download to succeed, got %v", nilWriterErr)
+	}
+
+	err = client.DownloadBuildArtifact(context.Background(), "build-1", "artifact-1", failingWriter{})
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindUnexpected || apiErr.RequestID != "req-alt" || !strings.Contains(apiErr.Error(), "stream artifact response") {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
+func TestClient_DownloadBuildArtifactTransportAndCancellation(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client, err := New("https://example.com", "token", "agent", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	})})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if canceledErr := client.DownloadBuildArtifact(canceledCtx, "build-1", "artifact-1", &bytes.Buffer{}); !errors.Is(canceledErr, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", canceledErr)
+	}
+
+	client, err = New("https://example.com", "token", "agent", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial failed")
+	})})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	err = client.DownloadBuildArtifact(context.Background(), "build-1", "artifact-1", &bytes.Buffer{})
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindTransport || !strings.Contains(apiErr.Error(), "request failed") {
+		t.Fatalf("unexpected transport error: %+v", apiErr)
 	}
 }
 
@@ -395,6 +479,16 @@ func TestResolveRequestURLRejectsAbsoluteRequestURLs(t *testing.T) {
 	_, err := resolveRequestURL(baseURL, "https://other.example.com/api/me")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestResolveRequestURLEmptyPathAndDownloadPathEncoding(t *testing.T) {
+	baseURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/coyote"}
+	if _, err := resolveRequestURL(baseURL, "   "); err == nil {
+		t.Fatal("expected empty path error")
+	}
+	if got := buildArtifactDownloadPath(" build 1 ", "artifact/1"); got != "api/builds/build%201/artifacts/artifact%2F1/download" {
+		t.Fatalf("unexpected download path: %s", got)
 	}
 }
 

--- a/backend/internal/cli/atomicfile/replace_test.go
+++ b/backend/internal/cli/atomicfile/replace_test.go
@@ -1,0 +1,34 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceFileAtomicReplacesExistingDestination(t *testing.T) {
+	tempDir := t.TempDir()
+	source := filepath.Join(tempDir, "source.txt")
+	destination := filepath.Join(tempDir, "destination.txt")
+
+	if err := os.WriteFile(source, []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+
+	if err := ReplaceFileAtomic(source, destination); err != nil {
+		t.Fatalf("ReplaceFileAtomic failed: %v", err)
+	}
+	body, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(body) != "new" {
+		t.Fatalf("unexpected destination body: %q", string(body))
+	}
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Fatalf("expected source to be removed, got err=%v", err)
+	}
+}

--- a/backend/internal/cli/atomicfile/replace_unix.go
+++ b/backend/internal/cli/atomicfile/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+func ReplaceFileAtomic(source string, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/backend/internal/cli/atomicfile/replace_windows.go
+++ b/backend/internal/cli/atomicfile/replace_windows.go
@@ -1,10 +1,10 @@
 //go:build windows
 
-package config
+package atomicfile
 
 import "golang.org/x/sys/windows"
 
-func replaceFileAtomic(source string, destination string) error {
+func ReplaceFileAtomic(source string, destination string) error {
 	from, fromErr := windows.UTF16PtrFromString(source)
 	if fromErr != nil {
 		return fromErr

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -2,14 +2,18 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,6 +21,7 @@ import (
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
 	"github.com/radiation/coyote-ci/backend/internal/apiclient"
+	"github.com/radiation/coyote-ci/backend/internal/cli/atomicfile"
 	"github.com/radiation/coyote-ci/backend/internal/cli/output"
 )
 
@@ -63,13 +68,137 @@ type buildRetryView struct {
 	WebURL        string `json:"web_url,omitempty"`
 }
 
+type buildArtifactsPayload struct {
+	BuildID   string                  `json:"build_id"`
+	Artifacts []buildArtifactListView `json:"artifacts"`
+}
+
+type buildArtifactListView struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name,omitempty"`
+	Path        string  `json:"path"`
+	StepID      *string `json:"step_id,omitempty"`
+	SizeBytes   int64   `json:"size_bytes"`
+	ContentType *string `json:"content_type,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+}
+
+type buildArtifactDownloadPayload struct {
+	BuildID    string                      `json:"build_id"`
+	Downloaded []buildArtifactDownloadView `json:"downloaded"`
+}
+
+type buildArtifactDownloadView struct {
+	ArtifactID string `json:"artifact_id"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	SizeBytes  int64  `json:"size_bytes"`
+}
+
+var replaceFileAtomicFunc = atomicfile.ReplaceFileAtomic
+
 var isInteractiveInputFunc = isInteractiveInput
 
 func (a *app) newBuildCommand() *cobra.Command {
 	command := &cobra.Command{Use: "build", Short: "Inspect and manage builds"}
 	command.AddCommand(a.newBuildStatusCommand())
 	command.AddCommand(a.newBuildLogsCommand())
+	command.AddCommand(a.newBuildArtifactsCommand())
 	command.AddCommand(a.newBuildRetryCommand())
+	return command
+}
+
+func (a *app) newBuildArtifactsCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "artifacts <build-id>",
+		Short: "List build artifacts",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			artifactsResponse, artifactsErr := client.ListBuildArtifacts(cmd.Context(), args[0])
+			if artifactsErr != nil {
+				return mapCommandError(artifactsErr)
+			}
+
+			payload := makeBuildArtifactsPayload(args[0], artifactsResponse.Artifacts)
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildArtifactsHuman(w, payload)
+			}, payload)
+		},
+	}
+	command.AddCommand(a.newBuildArtifactsDownloadCommand())
+	return command
+}
+
+func (a *app) newBuildArtifactsDownloadCommand() *cobra.Command {
+	var selector string
+	var outputPath string
+	var force bool
+
+	command := &cobra.Command{
+		Use:   "download <build-id>",
+		Short: "Download one build artifact",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selector = strings.TrimSpace(selector)
+			if selector == "" {
+				return &ExitError{Code: 2, Err: errors.New("artifact selector is required")}
+			}
+
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			artifactsResponse, artifactsErr := client.ListBuildArtifacts(cmd.Context(), args[0])
+			if artifactsErr != nil {
+				return mapCommandError(artifactsErr)
+			}
+
+			artifact, selectErr := selectBuildArtifact(artifactsResponse.Artifacts, selector)
+			if selectErr != nil {
+				return &ExitError{Code: 2, Err: selectErr}
+			}
+
+			destinationPath, pathErr := resolveArtifactOutputPath(outputPath, artifact)
+			if pathErr != nil {
+				return &ExitError{Code: 2, Err: pathErr}
+			}
+
+			written, downloadErr := downloadBuildArtifactToPath(cmd.Context(), client, args[0], artifact, destinationPath, force)
+			if downloadErr != nil {
+				var apiErr *apiclient.Error
+				if errors.As(downloadErr, &apiErr) {
+					return mapCommandError(downloadErr)
+				}
+				return &ExitError{Code: 1, Err: downloadErr}
+			}
+
+			displayPath := displayPath(destinationPath)
+			payload := buildArtifactDownloadPayload{
+				BuildID:    args[0],
+				Downloaded: []buildArtifactDownloadView{buildArtifactDownloadViewFromArtifact(artifact, displayPath, written)},
+			}
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildArtifactDownloadHuman(w, payload)
+			}, payload)
+		},
+	}
+	command.Flags().StringVar(&selector, "artifact", "", "Artifact ID, path, or name")
+	command.Flags().StringVar(&outputPath, "output", "", "Output file or directory path")
+	command.Flags().BoolVar(&force, "force", false, "Overwrite an existing file")
 	return command
 }
 
@@ -203,6 +332,29 @@ func parseBuildLogsOptions(stepRaw string, failed bool, tail int, tailSet bool) 
 	options.Failed = failed
 	options.Tail = tail
 	return options, nil
+}
+
+func makeBuildArtifactsPayload(buildID string, artifacts []api.BuildArtifactResponse) buildArtifactsPayload {
+	items := make([]buildArtifactListView, 0, len(artifacts))
+	for _, artifact := range sortBuildArtifacts(artifacts) {
+		stepID := trimStringPtr(artifact.StepID)
+		item := buildArtifactListView{
+			ID:          artifact.ID,
+			Name:        strings.TrimSpace(artifact.Name),
+			Path:        artifact.Path,
+			StepID:      stepID,
+			SizeBytes:   artifact.SizeBytes,
+			ContentType: trimStringPtr(artifact.ContentType),
+			CreatedAt:   artifact.CreatedAt,
+		}
+		items = append(items, item)
+	}
+
+	resolvedBuildID := strings.TrimSpace(buildID)
+	if len(artifacts) > 0 && strings.TrimSpace(artifacts[0].BuildID) != "" {
+		resolvedBuildID = artifacts[0].BuildID
+	}
+	return buildArtifactsPayload{BuildID: resolvedBuildID, Artifacts: items}
 }
 
 func makeBuildStatusPayload(serverURL string, build api.BuildResponse, steps []api.BuildStepResponse) buildStatusPayload {
@@ -348,6 +500,44 @@ func writeBuildLogsHuman(w io.Writer, response api.BuildLogsResponse) error {
 	return nil
 }
 
+func writeBuildArtifactsHuman(w io.Writer, payload buildArtifactsPayload) error {
+	if _, err := fmt.Fprintf(w, "Artifacts for build %s\n", payload.BuildID); err != nil {
+		return err
+	}
+	if len(payload.Artifacts) == 0 {
+		_, err := fmt.Fprintln(w, "\nNo artifacts found")
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tSTEP ID\tPATH\tSIZE\tTYPE"); err != nil {
+		return err
+	}
+	for _, artifact := range payload.Artifacts {
+		step := "-"
+		if artifact.StepID != nil {
+			step = *artifact.StepID
+		}
+		contentType := "-"
+		if artifact.ContentType != nil && strings.TrimSpace(*artifact.ContentType) != "" {
+			contentType = *artifact.ContentType
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", artifact.ID, step, artifact.Path, formatArtifactSize(artifact.SizeBytes), contentType); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "\nDownload:\n  coyote build artifacts download %s --artifact %s\n", payload.BuildID, payload.Artifacts[0].ID); err != nil {
+		return err
+	}
+	return nil
+}
+
 func makeBuildRetryPayload(serverURL string, sourceBuildID string, build api.BuildResponse) buildRetryPayload {
 	return buildRetryPayload{
 		Retried: buildRetryView{
@@ -375,6 +565,15 @@ func writeBuildRetryHuman(w io.Writer, payload buildRetryPayload) error {
 	}
 	if retried.WebURL != "" {
 		if _, err := fmt.Fprintf(w, "URL: %s\n", retried.WebURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBuildArtifactDownloadHuman(w io.Writer, payload buildArtifactDownloadPayload) error {
+	for _, item := range payload.Downloaded {
+		if _, err := fmt.Fprintf(w, "Downloaded %s -> %s\n", item.Name, item.Path); err != nil {
 			return err
 		}
 	}
@@ -412,6 +611,272 @@ func isInteractiveInput(reader io.Reader) bool {
 		return false
 	}
 	return term.IsTerminal(int(file.Fd()))
+}
+
+func sortBuildArtifacts(artifacts []api.BuildArtifactResponse) []api.BuildArtifactResponse {
+	sorted := append([]api.BuildArtifactResponse(nil), artifacts...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].CreatedAt != sorted[j].CreatedAt {
+			return sorted[i].CreatedAt > sorted[j].CreatedAt
+		}
+		if sorted[i].Path != sorted[j].Path {
+			return sorted[i].Path < sorted[j].Path
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	return sorted
+}
+
+func trimStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func selectBuildArtifact(artifacts []api.BuildArtifactResponse, selector string) (api.BuildArtifactResponse, error) {
+	trimmed := strings.TrimSpace(selector)
+	for _, artifact := range artifacts {
+		if artifact.ID == trimmed {
+			return artifact, nil
+		}
+	}
+
+	pathMatches := make([]api.BuildArtifactResponse, 0)
+	nameMatches := make([]api.BuildArtifactResponse, 0)
+	for _, artifact := range artifacts {
+		if strings.TrimSpace(artifact.Path) == trimmed {
+			pathMatches = append(pathMatches, artifact)
+		}
+		if artifactNameMatches(artifact, trimmed) {
+			nameMatches = append(nameMatches, artifact)
+		}
+	}
+
+	if len(pathMatches) == 1 {
+		return pathMatches[0], nil
+	}
+	if len(pathMatches) > 1 {
+		return api.BuildArtifactResponse{}, fmt.Errorf("artifact selector %q matched multiple artifact paths; use an artifact ID", trimmed)
+	}
+	if len(nameMatches) == 1 {
+		return nameMatches[0], nil
+	}
+	if len(nameMatches) > 1 {
+		return api.BuildArtifactResponse{}, fmt.Errorf("artifact selector %q matched multiple artifact names; use an artifact ID or full path", trimmed)
+	}
+	return api.BuildArtifactResponse{}, fmt.Errorf("artifact %q not found for build", trimmed)
+}
+
+func artifactNameMatches(artifact api.BuildArtifactResponse, selector string) bool {
+	if strings.TrimSpace(artifact.Name) == selector {
+		return true
+	}
+	return path.Base(strings.TrimSpace(artifact.Path)) == selector
+}
+
+func resolveArtifactOutputPath(outputPath string, artifact api.BuildArtifactResponse) (string, error) {
+	trimmedOutput := strings.TrimSpace(outputPath)
+	if trimmedOutput == "" {
+		defaultName, err := artifactDownloadName(artifact)
+		if err != nil {
+			return "", err
+		}
+		return defaultName, nil
+	}
+
+	if info, err := os.Stat(trimmedOutput); err == nil {
+		if info.IsDir() {
+			defaultName, nameErr := artifactDownloadName(artifact)
+			if nameErr != nil {
+				return "", nameErr
+			}
+			return filepath.Join(trimmedOutput, defaultName), nil
+		}
+		return trimmedOutput, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	if strings.HasSuffix(trimmedOutput, string(os.PathSeparator)) || strings.HasSuffix(trimmedOutput, "/") {
+		defaultName, nameErr := artifactDownloadName(artifact)
+		if nameErr != nil {
+			return "", nameErr
+		}
+		return filepath.Join(trimmedOutput, defaultName), nil
+	}
+	return trimmedOutput, nil
+}
+
+func artifactDownloadName(artifact api.BuildArtifactResponse) (string, error) {
+	relativePath, err := artifactDownloadRelativePath(artifact)
+	if err != nil {
+		return "", err
+	}
+	base := path.Base(relativePath)
+	if base == "" || base == "." || base == "/" {
+		return "", fmt.Errorf("artifact path %q does not resolve to a safe filename", artifact.Path)
+	}
+	return base, nil
+}
+
+func artifactDownloadRelativePath(artifact api.BuildArtifactResponse) (string, error) {
+	for _, candidate := range []string{strings.TrimSpace(artifact.Path), strings.TrimSpace(artifact.Name), strings.TrimSpace(artifact.ID)} {
+		if candidate == "" {
+			continue
+		}
+		relativePath, err := validateArtifactRelativePath(candidate)
+		if err != nil {
+			return "", err
+		}
+		return relativePath, nil
+	}
+	return "", errors.New("artifact does not have a safe local filename")
+}
+
+func validateArtifactRelativePath(candidate string) (string, error) {
+	normalized := strings.TrimSpace(strings.ReplaceAll(candidate, "\\", "/"))
+	if normalized == "" {
+		return "", errors.New("artifact does not have a safe local filename")
+	}
+	if path.IsAbs(normalized) || strings.HasPrefix(normalized, "/") || hasWindowsDrivePrefix(normalized) {
+		return "", fmt.Errorf("artifact path %q is not safe for local output", candidate)
+	}
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("artifact path %q is not safe for local output", candidate)
+		}
+	}
+	cleaned := path.Clean(normalized)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("artifact path %q is not safe for local output", candidate)
+	}
+	return cleaned, nil
+}
+
+func hasWindowsDrivePrefix(value string) bool {
+	if len(value) < 2 || value[1] != ':' {
+		return false
+	}
+	first := value[0]
+	return (first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')
+}
+
+type countingWriter struct {
+	writer io.Writer
+	count  int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	w.count += int64(n)
+	return n, err
+}
+
+func downloadBuildArtifactToPath(ctx context.Context, client *apiclient.Client, buildID string, artifact api.BuildArtifactResponse, destinationPath string, force bool) (int64, error) {
+	trimmedDestination := strings.TrimSpace(destinationPath)
+	if trimmedDestination == "" {
+		return 0, errors.New("output path is required")
+	}
+
+	parentDir := filepath.Dir(trimmedDestination)
+	if parentDir == "" {
+		parentDir = "."
+	}
+	if parentDir != "." {
+		if err := os.MkdirAll(parentDir, 0o755); err != nil {
+			return 0, err
+		}
+	}
+	destinationPerm := os.FileMode(0o600)
+	if info, err := os.Stat(trimmedDestination); err == nil {
+		destinationPerm = info.Mode().Perm()
+		if !force {
+			return 0, fmt.Errorf("output file already exists: %s (use --force to overwrite)", trimmedDestination)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return 0, err
+	}
+	if !force {
+		if _, err := os.Stat(trimmedDestination); err == nil {
+			return 0, fmt.Errorf("output file already exists: %s (use --force to overwrite)", trimmedDestination)
+		}
+	}
+
+	tempFile, err := os.CreateTemp(parentDir, ".coyote-artifact-*")
+	if err != nil {
+		return 0, err
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+	if err := tempFile.Chmod(destinationPerm); err != nil {
+		return 0, err
+	}
+
+	counting := &countingWriter{writer: tempFile}
+	if err := client.DownloadBuildArtifact(ctx, buildID, artifact.ID, counting); err != nil {
+		_ = tempFile.Close()
+		return 0, err
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return 0, err
+	}
+	if err := tempFile.Close(); err != nil {
+		return 0, err
+	}
+	if err := replaceFileAtomicFunc(tempPath, trimmedDestination); err != nil {
+		return 0, err
+	}
+	return counting.count, nil
+}
+
+func buildArtifactDownloadViewFromArtifact(artifact api.BuildArtifactResponse, destinationPath string, written int64) buildArtifactDownloadView {
+	sizeBytes := written
+	if sizeBytes == 0 && artifact.SizeBytes > 0 {
+		sizeBytes = artifact.SizeBytes
+	}
+	name, err := artifactDownloadName(artifact)
+	if err != nil {
+		name = strings.TrimSpace(artifact.ID)
+	}
+	return buildArtifactDownloadView{
+		ArtifactID: artifact.ID,
+		Name:       name,
+		Path:       destinationPath,
+		SizeBytes:  sizeBytes,
+	}
+}
+
+func displayPath(pathValue string) string {
+	trimmed := strings.TrimSpace(pathValue)
+	if trimmed == "" || filepath.IsAbs(trimmed) || strings.HasPrefix(trimmed, ".") {
+		return trimmed
+	}
+	return "." + string(os.PathSeparator) + trimmed
+}
+
+func formatArtifactSize(sizeBytes int64) string {
+	if sizeBytes < 1024 {
+		return fmt.Sprintf("%d B", sizeBytes)
+	}
+	units := []string{"KB", "MB", "GB", "TB"}
+	size := float64(sizeBytes)
+	unitIndex := -1
+	for size >= 1024 && unitIndex < len(units)-1 {
+		size /= 1024
+		unitIndex++
+	}
+	if size >= 10 || size == float64(int64(size)) {
+		return fmt.Sprintf("%.0f %s", size, units[unitIndex])
+	}
+	return fmt.Sprintf("%.1f %s", size, units[unitIndex])
 }
 
 func logHeader(selected *api.BuildLogSelectedStepResponse, entry api.BuildLogResponse) string {

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/apiclient"
 	"github.com/radiation/coyote-ci/backend/internal/cli/output"
 )
 
@@ -308,6 +313,196 @@ func TestConfirmBuildRetry(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestBuildArtifactHelpers(t *testing.T) {
+	stepID := "step-1"
+	contentType := "application/xml"
+	artifacts := []api.BuildArtifactResponse{
+		{ID: "artifact-2", BuildID: "build-1", Name: "coverage.html", Path: "reports/coverage.html", SizeBytes: 2048, CreatedAt: "2026-07-05T00:00:01Z"},
+		{ID: "artifact-1", BuildID: "build-1", StepID: &stepID, Name: "report.xml", Path: "reports/report.xml", SizeBytes: 42, ContentType: &contentType, CreatedAt: "2026-07-05T00:00:02Z"},
+	}
+
+	payload := makeBuildArtifactsPayload("build-1", artifacts)
+	if payload.BuildID != "build-1" || len(payload.Artifacts) != 2 {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Artifacts[0].ID != "artifact-1" || payload.Artifacts[0].StepID == nil || *payload.Artifacts[0].StepID != "step-1" {
+		t.Fatalf("expected newest artifact with step metadata first, got %+v", payload.Artifacts[0])
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeBuildArtifactsHuman(buf, payload); err != nil {
+		t.Fatalf("writeBuildArtifactsHuman failed: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Artifacts for build build-1", "artifact-1", "reports/report.xml", "2 KB", "coyote build artifacts download build-1 --artifact artifact-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got %s", want, out)
+		}
+	}
+
+	selected, err := selectBuildArtifact(artifacts, "reports/report.xml")
+	if err != nil || selected.ID != "artifact-1" {
+		t.Fatalf("expected select by path to return artifact-1, got %+v err=%v", selected, err)
+	}
+	selected, err = selectBuildArtifact(artifacts, "coverage.html")
+	if err != nil || selected.ID != "artifact-2" {
+		t.Fatalf("expected select by name to return artifact-2, got %+v err=%v", selected, err)
+	}
+	if _, selectMissingErr := selectBuildArtifact(artifacts, "missing"); selectMissingErr == nil || !strings.Contains(selectMissingErr.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", selectMissingErr)
+	}
+
+	duplicateArtifacts := []api.BuildArtifactResponse{
+		{ID: "artifact-a", Path: "reports/a/report.xml", Name: "report.xml"},
+		{ID: "artifact-b", Path: "reports/b/report.xml", Name: "report.xml"},
+	}
+	if _, selectAmbiguousErr := selectBuildArtifact(duplicateArtifacts, "report.xml"); selectAmbiguousErr == nil || !strings.Contains(selectAmbiguousErr.Error(), "matched multiple artifact names") {
+		t.Fatalf("expected ambiguity error, got %v", selectAmbiguousErr)
+	}
+
+	reportArtifact := artifacts[1]
+	tempDir := t.TempDir()
+	if got, resolveDefaultErr := resolveArtifactOutputPath("", reportArtifact); resolveDefaultErr != nil || got != "report.xml" {
+		t.Fatalf("expected default file name, got %q err=%v", got, resolveDefaultErr)
+	}
+	if got, resolveDirErr := resolveArtifactOutputPath(tempDir, reportArtifact); resolveDirErr != nil || got != filepath.Join(tempDir, "report.xml") {
+		t.Fatalf("expected directory output path, got %q err=%v", got, resolveDirErr)
+	}
+	if got := displayPath("report.xml"); got != "./report.xml" {
+		t.Fatalf("unexpected display path: %s", got)
+	}
+	if got := formatArtifactSize(42); got != "42 B" {
+		t.Fatalf("unexpected byte format: %s", got)
+	}
+	if got := formatArtifactSize(2048); got != "2 KB" {
+		t.Fatalf("unexpected kilobyte format: %s", got)
+	}
+	if _, traversalErr := resolveArtifactOutputPath("", api.BuildArtifactResponse{ID: "artifact-unsafe", Path: "../secrets.txt"}); traversalErr == nil || !strings.Contains(traversalErr.Error(), "not safe") {
+		t.Fatalf("expected traversal path rejection, got %v", traversalErr)
+	}
+	if _, absolutePathErr := resolveArtifactOutputPath(tempDir, api.BuildArtifactResponse{ID: "artifact-unsafe", Path: "/etc/passwd"}); absolutePathErr == nil || !strings.Contains(absolutePathErr.Error(), "not safe") {
+		t.Fatalf("expected absolute path rejection, got %v", absolutePathErr)
+	}
+	if _, drivePathErr := resolveArtifactOutputPath("", api.BuildArtifactResponse{ID: "artifact-unsafe", Path: `C:\temp\evil.txt`}); drivePathErr == nil || !strings.Contains(drivePathErr.Error(), "not safe") {
+		t.Fatalf("expected drive path rejection, got %v", drivePathErr)
+	}
+
+	downloadPayload := buildArtifactDownloadPayload{BuildID: "build-1", Downloaded: []buildArtifactDownloadView{{ArtifactID: "artifact-1", Name: "report.xml", Path: "./report.xml", SizeBytes: 42}}}
+	buf.Reset()
+	if writeDownloadErr := writeBuildArtifactDownloadHuman(buf, downloadPayload); writeDownloadErr != nil {
+		t.Fatalf("writeBuildArtifactDownloadHuman failed: %v", writeDownloadErr)
+	}
+	if !strings.Contains(buf.String(), "Downloaded report.xml -> ./report.xml") {
+		t.Fatalf("unexpected download human output: %s", buf.String())
+	}
+	if writeFailErr := writeBuildArtifactDownloadHuman(failWriter{}, downloadPayload); writeFailErr == nil {
+		t.Fatal("expected download human writer to surface write errors")
+	}
+
+	destination := filepath.Join(tempDir, "nested", "report.xml")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/api/builds/build-1/artifacts/artifact-1/download" {
+			t.Fatalf("unexpected download path %q", r.URL.String())
+		}
+		_, _ = w.Write([]byte("artifact-body"))
+	}))
+	defer server.Close()
+	client, err := apiclient.New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	originalReplace := replaceFileAtomicFunc
+	t.Cleanup(func() {
+		replaceFileAtomicFunc = originalReplace
+	})
+	written, err := downloadBuildArtifactToPath(t.Context(), client, "build-1", reportArtifact, destination, false)
+	if err != nil {
+		t.Fatalf("downloadBuildArtifactToPath failed: %v", err)
+	}
+	if written != int64(len("artifact-body")) {
+		t.Fatalf("unexpected written bytes: %d", written)
+	}
+	body, readErr := os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatalf("read downloaded file: %v", readErr)
+	}
+	if string(body) != "artifact-body" {
+		t.Fatalf("unexpected downloaded file body: %q", string(body))
+	}
+	if _, overwriteErr := downloadBuildArtifactToPath(t.Context(), client, "build-1", reportArtifact, destination, false); overwriteErr == nil || !strings.Contains(overwriteErr.Error(), "already exists") {
+		t.Fatalf("expected overwrite protection, got %v", overwriteErr)
+	}
+	if _, forceOverwriteErr := downloadBuildArtifactToPath(t.Context(), client, "build-1", reportArtifact, destination, true); forceOverwriteErr != nil {
+		t.Fatalf("expected force overwrite to succeed, got %v", forceOverwriteErr)
+	}
+	tempMatches, err := filepath.Glob(filepath.Join(filepath.Dir(destination), ".coyote-artifact-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(tempMatches) != 0 {
+		t.Fatalf("expected temp files to be cleaned up, got %v", tempMatches)
+	}
+
+	originalContent := []byte("old-content")
+	if seedWriteErr := os.WriteFile(destination, originalContent, 0o640); seedWriteErr != nil {
+		t.Fatalf("seed destination: %v", seedWriteErr)
+	}
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: artifact:read"}}`))
+	}))
+	defer failingServer.Close()
+	failingClient, err := apiclient.New(failingServer.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new failing client: %v", err)
+	}
+	if _, failingDownloadErr := downloadBuildArtifactToPath(t.Context(), failingClient, "build-1", reportArtifact, destination, true); failingDownloadErr == nil {
+		t.Fatal("expected download failure")
+	}
+	body, readErr = os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatalf("read preserved destination: %v", readErr)
+	}
+	if string(body) != string(originalContent) {
+		t.Fatalf("expected destination to remain intact after download failure, got %q", string(body))
+	}
+
+	replaceFileAtomicFunc = func(source string, destination string) error {
+		if filepath.Dir(source) != filepath.Dir(destination) {
+			t.Fatalf("expected temp file in destination directory, got %s for %s", source, destination)
+		}
+		return errors.New("replace failed")
+	}
+	if _, replaceErr := downloadBuildArtifactToPath(t.Context(), client, "build-1", reportArtifact, destination, true); replaceErr == nil || !strings.Contains(replaceErr.Error(), "replace failed") {
+		t.Fatalf("expected replacement failure, got %v", replaceErr)
+	}
+	body, readErr = os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatalf("read destination after replace failure: %v", readErr)
+	}
+	if string(body) != string(originalContent) {
+		t.Fatalf("expected destination to remain intact after replace failure, got %q", string(body))
+	}
+	tempMatches, err = filepath.Glob(filepath.Join(filepath.Dir(destination), ".coyote-artifact-*"))
+	if err != nil {
+		t.Fatalf("glob temp files after replace failure: %v", err)
+	}
+	if len(tempMatches) != 0 {
+		t.Fatalf("expected temp files to be cleaned up after replace failure, got %v", tempMatches)
+	}
+
+	if err := writeBuildArtifactsHuman(failWriter{}, payload); err == nil {
+		t.Fatal("expected writeBuildArtifactsHuman to surface write errors")
+	}
+	emptyBuf := &bytes.Buffer{}
+	if err := writeBuildArtifactsHuman(emptyBuf, buildArtifactsPayload{BuildID: "build-empty"}); err != nil {
+		t.Fatalf("writeBuildArtifactsHuman empty failed: %v", err)
+	}
+	if !strings.Contains(emptyBuf.String(), "No artifacts found") {
+		t.Fatalf("unexpected empty artifacts output: %s", emptyBuf.String())
+	}
 }
 
 func intPtr(value int) *int { return &value }

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
 	"github.com/radiation/coyote-ci/backend/internal/apiclient"
+	"github.com/radiation/coyote-ci/backend/internal/cli/config"
+	"github.com/radiation/coyote-ci/backend/internal/cli/credentials"
 	"github.com/radiation/coyote-ci/backend/internal/cli/output"
 )
 
@@ -493,6 +495,10 @@ func TestBuildArtifactHelpers(t *testing.T) {
 		t.Fatalf("expected temp files to be cleaned up after replace failure, got %v", tempMatches)
 	}
 
+	if got := buildArtifactDownloadViewFromArtifact(api.BuildArtifactResponse{ID: "artifact-fallback", Path: "../unsafe"}, "./artifact-fallback", 0); got.Name != "artifact-fallback" || got.SizeBytes != 0 {
+		t.Fatalf("expected fallback download view, got %+v", got)
+	}
+
 	if err := writeBuildArtifactsHuman(failWriter{}, payload); err == nil {
 		t.Fatal("expected writeBuildArtifactsHuman to surface write errors")
 	}
@@ -503,6 +509,229 @@ func TestBuildArtifactHelpers(t *testing.T) {
 	if !strings.Contains(emptyBuf.String(), "No artifacts found") {
 		t.Fatalf("unexpected empty artifacts output: %s", emptyBuf.String())
 	}
+}
+
+func TestBuildArtifactHelperEdgeCases(t *testing.T) {
+	blankStepID := "  "
+	blankContentType := "  "
+	payload := makeBuildArtifactsPayload(" trimmed-build ", []api.BuildArtifactResponse{{
+		ID:          "artifact-1",
+		BuildID:     "",
+		Name:        " report.xml ",
+		Path:        "reports/report.xml",
+		StepID:      &blankStepID,
+		ContentType: &blankContentType,
+		SizeBytes:   512,
+		CreatedAt:   "2026-07-05T00:00:00Z",
+	}})
+	if payload.BuildID != "trimmed-build" {
+		t.Fatalf("expected trimmed build id fallback, got %+v", payload)
+	}
+	if payload.Artifacts[0].StepID != nil || payload.Artifacts[0].ContentType != nil || payload.Artifacts[0].Name != "report.xml" {
+		t.Fatalf("expected trimmed metadata in payload, got %+v", payload.Artifacts[0])
+	}
+
+	buf := &bytes.Buffer{}
+	if err := writeBuildArtifactsHuman(buf, payload); err != nil {
+		t.Fatalf("writeBuildArtifactsHuman failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "artifact-1") || !strings.Contains(buf.String(), "reports/report.xml") || !strings.Contains(buf.String(), "512 B") {
+		t.Fatalf("expected nil step/content type placeholders in output, got %s", buf.String())
+	}
+
+	duplicatePaths := []api.BuildArtifactResponse{
+		{ID: "artifact-a", Path: "reports/report.xml"},
+		{ID: "artifact-b", Path: "reports/report.xml"},
+	}
+	if _, duplicatePathErr := selectBuildArtifact(duplicatePaths, "reports/report.xml"); duplicatePathErr == nil || !strings.Contains(duplicatePathErr.Error(), "multiple artifact paths") {
+		t.Fatalf("expected duplicate path error, got %v", duplicatePathErr)
+	}
+
+	if !artifactNameMatches(api.BuildArtifactResponse{Name: "other", Path: "reports/report.xml"}, "report.xml") {
+		t.Fatal("expected artifactNameMatches to match path basename")
+	}
+	if artifactNameMatches(api.BuildArtifactResponse{Name: "other", Path: "reports/report.xml"}, "missing") {
+		t.Fatal("expected artifactNameMatches to reject non-matches")
+	}
+
+	if got, err := artifactDownloadRelativePath(api.BuildArtifactResponse{Name: "reports/from-name.xml"}); err != nil || got != "reports/from-name.xml" {
+		t.Fatalf("expected name fallback path, got %q err=%v", got, err)
+	}
+	if got, err := artifactDownloadRelativePath(api.BuildArtifactResponse{ID: "artifact-id-only"}); err != nil || got != "artifact-id-only" {
+		t.Fatalf("expected id fallback path, got %q err=%v", got, err)
+	}
+	if _, err := artifactDownloadRelativePath(api.BuildArtifactResponse{}); err == nil || !strings.Contains(err.Error(), "safe local filename") {
+		t.Fatalf("expected empty artifact path error, got %v", err)
+	}
+
+	if got, err := validateArtifactRelativePath("reports/nested/output.txt"); err != nil || got != "reports/nested/output.txt" {
+		t.Fatalf("expected safe nested path, got %q err=%v", got, err)
+	}
+	if _, err := validateArtifactRelativePath("."); err == nil || !strings.Contains(err.Error(), "not safe") {
+		t.Fatalf("expected dot path rejection, got %v", err)
+	}
+	if _, err := validateArtifactRelativePath("   "); err == nil || !strings.Contains(err.Error(), "safe local filename") {
+		t.Fatalf("expected blank path rejection, got %v", err)
+	}
+
+	fileOutput := filepath.Join(t.TempDir(), "artifact.out")
+	if err := os.WriteFile(fileOutput, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("seed file output: %v", err)
+	}
+	if got, err := resolveArtifactOutputPath(fileOutput, api.BuildArtifactResponse{Path: "reports/report.xml"}); err != nil || got != fileOutput {
+		t.Fatalf("expected existing file output path, got %q err=%v", got, err)
+	}
+	missingDirOutput := filepath.Join(t.TempDir(), "missing-dir") + string(os.PathSeparator)
+	if got, err := resolveArtifactOutputPath(missingDirOutput, api.BuildArtifactResponse{Path: "reports/report.xml"}); err != nil || got != filepath.Join(missingDirOutput, "report.xml") {
+		t.Fatalf("expected trailing separator directory output path, got %q err=%v", got, err)
+	}
+
+	if got, err := artifactDownloadName(api.BuildArtifactResponse{Name: "report.xml"}); err != nil || got != "report.xml" {
+		t.Fatalf("expected artifactDownloadName name fallback, got %q err=%v", got, err)
+	}
+	if got := displayPath("./report.xml"); got != "./report.xml" {
+		t.Fatalf("expected dotted display path to remain unchanged, got %s", got)
+	}
+	if got := displayPath(filepath.Join(string(os.PathSeparator), "tmp", "report.xml")); got != filepath.Join(string(os.PathSeparator), "tmp", "report.xml") {
+		t.Fatalf("expected absolute display path to remain unchanged, got %s", got)
+	}
+	if hasWindowsDrivePrefix("artifact.txt") {
+		t.Fatal("expected non-drive path to be false")
+	}
+
+	unsorted := []api.BuildArtifactResponse{
+		{ID: "b", Path: "zeta", CreatedAt: "2026-07-05T00:00:00Z"},
+		{ID: "a", Path: "alpha", CreatedAt: "2026-07-05T00:00:00Z"},
+		{ID: "c", Path: "latest", CreatedAt: "2026-07-05T00:00:01Z"},
+		{ID: "d", Path: "alpha", CreatedAt: "2026-07-05T00:00:00Z"},
+	}
+	sorted := sortBuildArtifacts(unsorted)
+	if sorted[0].ID != "c" || sorted[1].ID != "a" || sorted[2].ID != "d" || sorted[3].ID != "b" {
+		t.Fatalf("unexpected artifact sort order: %+v", sorted)
+	}
+}
+
+func TestBuildArtifactsCommandValidationAndErrorPaths(t *testing.T) {
+	t.Run("download requires artifact selector before network", func(t *testing.T) {
+		called := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+		if err := configStore.Save(config.File{
+			CurrentContext: "local",
+			Contexts: map[string]config.Context{
+				"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+			},
+		}); err != nil {
+			t.Fatalf("save config: %v", err)
+		}
+		creds := credentials.NewMemoryStore()
+		if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+			t.Fatalf("set token: %v", setErr)
+		}
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1"}})
+		if code != 2 {
+			t.Fatalf("expected exit code 2, got %d stderr=%s", code, stderr.String())
+		}
+		if called {
+			t.Fatal("expected selector validation to stop before HTTP requests")
+		}
+		if !strings.Contains(stderr.String(), "artifact selector is required") {
+			t.Fatalf("unexpected stderr: %s", stderr.String())
+		}
+	})
+
+	t.Run("download rejects unsafe artifact metadata", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.String() {
+			case "/api/builds/build-1/artifacts":
+				_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","name":"report.xml","path":"../secrets.txt","size_bytes":42,"storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+		if err := configStore.Save(config.File{
+			CurrentContext: "local",
+			Contexts: map[string]config.Context{
+				"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+			},
+		}); err != nil {
+			t.Fatalf("save config: %v", err)
+		}
+		creds := credentials.NewMemoryStore()
+		if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+			t.Fatalf("set token: %v", setErr)
+		}
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1"}})
+		if code != 2 {
+			t.Fatalf("expected exit code 2, got %d stderr=%s", code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "not safe for local output") {
+			t.Fatalf("unexpected stderr: %s", stderr.String())
+		}
+		if strings.Contains(stderr.String(), "stored-token") {
+			t.Fatalf("stderr leaked token: %s", stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("expected no stdout, got %q", stdout.String())
+		}
+	})
+
+	t.Run("download returns exit 1 for local write errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.String() {
+			case "/api/builds/build-1/artifacts":
+				_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","name":"report.xml","path":"reports/report.xml","size_bytes":42,"storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+		if err := configStore.Save(config.File{
+			CurrentContext: "local",
+			Contexts: map[string]config.Context{
+				"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+			},
+		}); err != nil {
+			t.Fatalf("save config: %v", err)
+		}
+		creds := credentials.NewMemoryStore()
+		if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+			t.Fatalf("set token: %v", setErr)
+		}
+
+		existingOutput := filepath.Join(t.TempDir(), "report.xml")
+		if err := os.WriteFile(existingOutput, []byte("existing"), 0o600); err != nil {
+			t.Fatalf("seed existing output: %v", err)
+		}
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1", "--output", existingOutput}})
+		if code != 1 {
+			t.Fatalf("expected exit code 1, got %d stderr=%s", code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "already exists") {
+			t.Fatalf("unexpected stderr: %s", stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("expected no stdout on local write error, got %q", stdout.String())
+		}
+	})
 }
 
 func intPtr(value int) *int { return &value }

--- a/backend/internal/cli/config/atomic_replace_unix.go
+++ b/backend/internal/cli/config/atomic_replace_unix.go
@@ -1,9 +1,0 @@
-//go:build !windows
-
-package config
-
-import "os"
-
-func replaceFileAtomic(source string, destination string) error {
-	return os.Rename(source, destination)
-}

--- a/backend/internal/cli/config/store.go
+++ b/backend/internal/cli/config/store.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/radiation/coyote-ci/backend/internal/cli/atomicfile"
 )
 
 const (
@@ -35,7 +37,7 @@ type Store struct {
 }
 
 func NewStore(configPath string) *Store {
-	return &Store{configPath: strings.TrimSpace(configPath), userConfigDir: os.UserConfigDir, replaceFile: replaceFileAtomic}
+	return &Store{configPath: strings.TrimSpace(configPath), userConfigDir: os.UserConfigDir, replaceFile: atomicfile.ReplaceFileAtomic}
 }
 
 func (s *Store) Path() (string, error) {

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -228,6 +229,202 @@ func TestBuildStatusAndLogsCommands(t *testing.T) {
 	}
 }
 
+func TestBuildArtifactsCommands(t *testing.T) {
+	stepsCalled := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifacts":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","step_id":"step-1","name":"report.xml","path":"reports/report.xml","size_bytes":42,"content_type":"application/xml","storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+		case "/api/builds/build-1/steps":
+			stepsCalled++
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:read"}}`))
+		case "/api/builds/build-1/artifacts/artifact-1/download":
+			_, _ = w.Write([]byte("artifact-body"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "build-1"}}); code != 0 {
+		t.Fatalf("build artifacts exit code %d stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"Artifacts for build build-1", "artifact-1", "reports/report.xml", "coyote build artifacts download build-1 --artifact artifact-1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected %q in human output, got %s", want, stdout.String())
+		}
+	}
+	if stepsCalled != 0 {
+		t.Fatalf("expected artifact list to avoid build-step endpoint, got %d calls", stepsCalled)
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "build-1", "--json"}}); code != 0 {
+		t.Fatalf("build artifacts json exit code %d stderr=%s", code, stderr.String())
+	}
+	var listPayload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &listPayload); err != nil {
+		t.Fatalf("decode build artifacts json: %v", err)
+	}
+	artifacts, ok := listPayload["artifacts"].([]any)
+	if !ok || len(artifacts) != 1 {
+		t.Fatalf("unexpected artifacts payload: %+v", listPayload)
+	}
+	first, ok := artifacts[0].(map[string]any)
+	if !ok || first["id"] != "artifact-1" || first["step_id"] != "step-1" {
+		t.Fatalf("unexpected first artifact payload: %+v", first)
+	}
+	if strings.Contains(stdout.String(), "Artifacts for build") {
+		t.Fatalf("unexpected human prose in build artifacts JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	outputFile := filepath.Join(t.TempDir(), "downloads", "report.xml")
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1", "--output", outputFile}}); code != 0 {
+		t.Fatalf("build artifacts download exit code %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Downloaded report.xml ->") {
+		t.Fatalf("unexpected download human output: %s", stdout.String())
+	}
+	body, readErr := os.ReadFile(outputFile)
+	if readErr != nil {
+		t.Fatalf("read downloaded artifact: %v", readErr)
+	}
+	if string(body) != "artifact-body" {
+		t.Fatalf("unexpected artifact file body: %q", string(body))
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	outputDir := t.TempDir()
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "reports/report.xml", "--output", outputDir, "--json"}}); code != 0 {
+		t.Fatalf("build artifacts download json exit code %d stderr=%s", code, stderr.String())
+	}
+	var downloadPayload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &downloadPayload); err != nil {
+		t.Fatalf("decode build artifact download json: %v", err)
+	}
+	downloaded, ok := downloadPayload["downloaded"].([]any)
+	if !ok || len(downloaded) != 1 {
+		t.Fatalf("unexpected download payload: %+v", downloadPayload)
+	}
+	downloadedFirst, ok := downloaded[0].(map[string]any)
+	if !ok || downloadedFirst["artifact_id"] != "artifact-1" {
+		t.Fatalf("unexpected downloaded entry: %+v", downloadedFirst)
+	}
+	if strings.Contains(stdout.String(), "Downloaded report.xml") {
+		t.Fatalf("unexpected human prose in artifact download JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "missing"}})
+	if code != 2 {
+		t.Fatalf("expected selector validation exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "artifact \"missing\" not found") {
+		t.Fatalf("unexpected selector stderr: %s", stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code = Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1", "--output", outputFile}})
+	if code == 0 {
+		t.Fatal("expected overwrite protection to fail")
+	}
+	if !strings.Contains(stderr.String(), "already exists") {
+		t.Fatalf("unexpected overwrite stderr: %s", stderr.String())
+	}
+}
+
+func TestBuildArtifactsCommands_ArtifactReadOnlyScope(t *testing.T) {
+	stepsCalled := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifacts":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","step_id":"step-1","name":"report.xml","path":"reports/report.xml","size_bytes":42,"content_type":"application/xml","storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+		case "/api/builds/build-1/artifacts/artifact-1/download":
+			_, _ = w.Write([]byte("artifact-body"))
+		case "/api/builds/build-1":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:read"}}`))
+		case "/api/builds/build-1/steps":
+			stepsCalled++
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:read"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "build-1", "--json"}}); code != 0 {
+		t.Fatalf("artifact-read-only list exit code %d stderr=%s", code, stderr.String())
+	}
+	if stepsCalled != 0 {
+		t.Fatalf("expected no build-step requests for artifact list, got %d", stepsCalled)
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	outputFile := filepath.Join(t.TempDir(), "artifact.txt")
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1", "--output", outputFile, "--json"}}); code != 0 {
+		t.Fatalf("artifact-read-only download exit code %d stderr=%s", code, stderr.String())
+	}
+	body, readErr := os.ReadFile(outputFile)
+	if readErr != nil {
+		t.Fatalf("read downloaded artifact: %v", readErr)
+	}
+	if string(body) != "artifact-body" {
+		t.Fatalf("unexpected artifact body: %q", string(body))
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "status", "build-1", "--json"}})
+	if code == 0 {
+		t.Fatal("expected build status to fail without build:read")
+	}
+	if !strings.Contains(stderr.String(), "api token does not have the required scope: build:read") {
+		t.Fatalf("unexpected status stderr: %s", stderr.String())
+	}
+}
+
 func TestBuildRetryCommand(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {
@@ -343,6 +540,8 @@ func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {
 		message := "api token does not have the required scope: build:read"
 		if strings.Contains(r.URL.Path, "/logs") {
 			message = "api token does not have the required scope: build:logs"
+		} else if strings.Contains(r.URL.Path, "/artifacts") {
+			message = "api token does not have the required scope: artifact:read"
 		} else if strings.Contains(r.URL.Path, "/rerun") {
 			message = "api token does not have the required scope: build:run"
 		}
@@ -372,6 +571,8 @@ func TestBuildCommands_MissingTokenScopeErrors(t *testing.T) {
 	}{
 		{name: "status missing scope", args: []string{"build", "status", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:read"},
 		{name: "logs missing scope", args: []string{"build", "logs", "build-1", "--json"}, wantContains: "api token does not have the required scope: build:logs"},
+		{name: "artifacts missing scope", args: []string{"build", "artifacts", "build-1", "--json"}, wantContains: "api token does not have the required scope: artifact:read"},
+		{name: "artifact download missing scope", args: []string{"build", "artifacts", "download", "build-1", "--artifact", "artifact-1", "--json"}, wantContains: "api token does not have the required scope: artifact:read"},
 		{name: "retry missing scope", args: []string{"build", "retry", "build-1", "--yes", "--json"}, wantContains: "api token does not have the required scope: build:run"},
 	}
 

--- a/docs/architecture-guardrails.md
+++ b/docs/architecture-guardrails.md
@@ -56,13 +56,14 @@ These rules run through [the frontend ESLint boundaries](../frontend/eslint.conf
 
 ## Local enforcement
 
+- `make backend-lint`
 - `make backend-architecture`
 - `make backend-test`
 - `make frontend-lint`
 - `make pre-push-check`
 - `.githooks/pre-push`
 
-The pre-push hook now reuses the same root commands for backend architecture checks, backend tests, frontend lint, frontend tests, frontend build, and Swagger drift detection.
+The pre-push hook now reuses the same root commands for backend lint, backend architecture checks, backend tests, frontend lint, frontend tests, frontend build, and Swagger drift detection.
 
 ## CI enforcement
 


### PR DESCRIPTION
# Add CLI build artifact commands

## Summary

Adds read-only build artifact access to the Coyote CLI.

This PR introduces artifact listing and single-artifact download commands so engineers and IDE agents can inspect and retrieve build outputs without opening the web UI. The commands use the existing authenticated CLI context/token plumbing, rely on the existing artifact APIs, enforce the `artifact:read` scope boundary, and preserve safe local file-write behavior.

## What changed

### CLI artifact commands

Added artifact commands under the existing build command group:

```bash
coyote build artifacts <build-id>
coyote build artifacts <build-id> --json
coyote build artifacts download <build-id> --artifact <artifact-id-or-name>
```

The command shape keeps artifact access grouped with the build workflow alongside:

```bash
coyote build status <build-id>
coyote build logs <build-id>
coyote build retry <build-id>
```

### Artifact listing

`coyote build artifacts <build-id>` now lists safe artifact metadata, including:

- artifact ID;
- step ID when present;
- artifact path;
- size;
- content type when available.

Human output includes a copyable download hint.

JSON output provides stable machine-readable artifact metadata for automation and IDE agents.

Example:

```json
{
  "build_id": "193be2e6-6237-4686-b521-9311012db47b",
  "artifacts": [
    {
      "id": "df39fb4c-e60a-481c-bf86-2ee8f85461e2",
      "name": "coyote-ci/frontend",
      "path": "artifacts/images/frontend-image.tar",
      "step_id": "c0da5ecd-d97c-4966-92ee-34bcf2c4353e",
      "size_bytes": 26064384,
      "created_at": "2026-07-05T12:11:05Z"
    }
  ]
}
```

### Artifact download

`coyote build artifacts download` downloads a single artifact.

Supported behavior:

- resolve artifact selectors by ID, path, or unambiguous name;
- preserve the artifact filename by default;
- support `--output` as a file path or directory;
- refuse to overwrite existing files unless `--force` is provided;
- stream artifact content to disk;
- support JSON result output.

### Scope boundary correctness

Artifact commands use artifact APIs only.

The CLI no longer enriches artifact output by calling build-step metadata endpoints. This preserves the intended least-privilege model:

```text
artifact:read can list/download artifacts
build:read is not required for artifact access
```

This means a token with only `artifact:read` can list and download artifacts for authorized builds, while a token with only `build:read` cannot list or download artifacts.

### Safe file writes

Artifact downloads now use safer local file-write behavior.

The download flow:

- writes to a temporary file in the destination directory;
- avoids overwriting existing files by default;
- supports `--force` for replacement;
- avoids remove-then-rename data-loss behavior;
- cleans up temporary files on failure;
- preserves the existing file when a download fails before replacement.

### Path safety

Download paths are validated to avoid unsafe artifact metadata escaping the requested output location.

The CLI rejects unsafe paths such as:

- absolute artifact paths when preserving artifact names under a directory;
- `..` path traversal;
- paths that would escape the output directory.

### Typed API client

Extended the typed CLI API client with focused artifact methods for:

- listing build artifacts;
- streaming artifact downloads.

The client preserves existing behavior:

- bearer-token authentication;
- context cancellation;
- path-prefixed server URL support;
- typed API errors;
- missing-scope handling;
- no token leakage.

No broad/generated API client was introduced.

### Tests

Added focused coverage for:

- artifact list human output;
- artifact list JSON output;
- empty artifact lists;
- download by artifact ID;
- download by path/name selector;
- ambiguous artifact selector errors;
- missing `artifact:read` scope;
- `artifact:read`-only behavior;
- `build:read`-only denial for artifacts;
- output path behavior;
- existing-file protection;
- `--force` replacement;
- path traversal rejection;
- streaming download behavior;
- typed API-client artifact requests.

Validation included:

```bash
go test ./backend/internal/apiclient ./backend/internal/cli
```

Local manual testing confirmed:

- artifact listing works for a build with artifacts;
- JSON listing emits valid JSON;
- artifact download works with the documented nested command shape;
- artifact metadata includes step IDs without requiring build-step enrichment;
- overwrite and output-path behavior work as expected.

## Deferred

Intentionally out of scope:

- `--all` artifact download;
- artifact upload from CLI;
- artifact deletion;
- artifact retention policy changes;
- worker artifact generation changes;
- build rerun/retry changes;
- step retry;
- live log following;
- project/job discovery commands;
- Slack notification changes;
- token scope vocabulary changes;
- local build execution;
- generated API client.

Also deferred: a future worker validation slice for real-world dependency/toolchain behavior such as Docker pulls, Maven dependency resolution, and similar package/image fetch scenarios.

## Suggested PR title

**Add CLI build artifact commands**
