### PR TITLE
Add log watching for CLI

### DIFF
--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -234,6 +235,130 @@ func (c *Client) GetBuildLogs(ctx context.Context, buildID string, options Build
 	return envelope.Data, nil
 }
 
+var ErrStepLogStreamTimeout = errors.New("step log stream timeout")
+
+type StepLogStreamEvent struct {
+	Type  string
+	Chunk *api.StepLogChunkResponse
+}
+
+func (c *Client) StreamBuildStepLogs(ctx context.Context, buildID string, stepIndex int, after int64, handle func(StepLogStreamEvent) error) error {
+	requestPath := buildStepLogStreamPath(buildID, stepIndex, after)
+	requestURL, err := resolveRequestURL(c.baseURL, requestPath)
+	if err != nil {
+		return &Error{Kind: ErrorKindUnexpected, Message: "invalid request path", Err: err}
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return &Error{Kind: ErrorKindUnexpected, Message: "build request", Err: err}
+	}
+	request.Header.Set("Accept", "text/event-stream")
+	if after > 0 {
+		request.Header.Set("Last-Event-ID", strconv.FormatInt(after, 10))
+	}
+	if c.userAgent != "" {
+		request.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return &Error{Kind: ErrorKindTransport, Message: "request failed", Err: err}
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	requestID := strings.TrimSpace(response.Header.Get("X-Request-Id"))
+	if requestID == "" {
+		requestID = strings.TrimSpace(response.Header.Get("X-Request-ID"))
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return decodeErrorResponse(response, requestID)
+	}
+
+	reader := bufio.NewReader(response.Body)
+	currentType := "message"
+	var dataLines []string
+
+	flushEvent := func() error {
+		if len(dataLines) == 0 {
+			currentType = "message"
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		dataLines = nil
+
+		switch currentType {
+		case "chunk":
+			var chunk api.StepLogChunkResponse
+			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+				return &Error{Kind: ErrorKindUnexpected, Message: "invalid sse response", RequestID: requestID, Err: err}
+			}
+			if handle == nil {
+				currentType = "message"
+				return nil
+			}
+			if err := handle(StepLogStreamEvent{Type: currentType, Chunk: &chunk}); err != nil {
+				return err
+			}
+		case "timeout":
+			currentType = "message"
+			return ErrStepLogStreamTimeout
+		case "error":
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(data), &payload); err == nil {
+				message := strings.TrimSpace(payload["message"])
+				if message == "" {
+					message = "step log stream failed"
+				}
+				return &Error{Kind: ErrorKindServer, Message: message, RequestID: requestID}
+			}
+			return &Error{Kind: ErrorKindServer, Message: "step log stream failed", RequestID: requestID}
+		}
+
+		currentType = "message"
+		return nil
+	}
+
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			if errors.Is(readErr, context.Canceled) || errors.Is(readErr, context.DeadlineExceeded) {
+				return readErr
+			}
+			return &Error{Kind: ErrorKindUnexpected, Message: "read sse response", RequestID: requestID, Err: readErr}
+		}
+
+		trimmedLine := strings.TrimRight(line, "\r\n")
+		if trimmedLine == "" {
+			if err := flushEvent(); err != nil {
+				return err
+			}
+		} else if strings.HasPrefix(trimmedLine, ":") {
+			// Ignore SSE comments.
+		} else if strings.HasPrefix(trimmedLine, "event:") {
+			currentType = strings.TrimSpace(strings.TrimPrefix(trimmedLine, "event:"))
+		} else if strings.HasPrefix(trimmedLine, "data:") {
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(trimmedLine, "data:")))
+		}
+
+		if errors.Is(readErr, io.EOF) {
+			if err := flushEvent(); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
 func (c *Client) ListBuildArtifacts(ctx context.Context, buildID string) (api.BuildArtifactsResponse, error) {
 	var envelope api.BuildArtifactsEnvelope
 	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, "/artifacts"), nil, &envelope); err != nil {
@@ -339,6 +464,18 @@ func (c *Client) doJSON(ctx context.Context, method string, path string, request
 		return &Error{Kind: ErrorKindUnexpected, Message: "invalid json response", RequestID: requestID, Err: decodeErr}
 	}
 	return nil
+}
+
+func buildStepLogStreamPath(buildID string, stepIndex int, after int64) string {
+	params := url.Values{}
+	if after > 0 {
+		params.Set("after", strconv.FormatInt(after, 10))
+	}
+	requestPath := buildResourcePath(buildID, "/steps/"+strconv.Itoa(stepIndex)+"/logs/stream")
+	if encoded := params.Encode(); encoded != "" {
+		requestPath += "?" + encoded
+	}
+	return requestPath
 }
 
 func normalizeBaseURL(raw string) (*url.URL, error) {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -155,6 +155,144 @@ func TestClient_StreamBuildStepLogs(t *testing.T) {
 	}
 }
 
+type errReadCloser struct {
+	err  error
+	read bool
+}
+
+func (r *errReadCloser) Read([]byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	return 0, r.err
+}
+
+func (r *errReadCloser) Close() error {
+	return nil
+}
+
+func TestClient_StreamBuildStepLogsBranches(t *testing.T) {
+	t.Run("nil handler ignores chunk and succeeds", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Last-Event-ID"); got != "" {
+				t.Fatalf("expected empty Last-Event-ID, got %q", got)
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: chunk\n")
+			_, _ = io.WriteString(w, "data: {\"sequence_no\":1,\"build_id\":\"build-1\",\"step_id\":\"step-1\",\"step_index\":0,\"step_name\":\"test\",\"stream\":\"stdout\",\"chunk_text\":\"ok\\n\",\"created_at\":\"2026-07-07T00:00:01Z\"}\n\n")
+		}))
+		defer server.Close()
+
+		client, err := New(server.URL, "", "coyote/dev", nil)
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+		if err := client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, nil); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("chunk decode failure returns unexpected error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: chunk\n")
+			_, _ = io.WriteString(w, "data: {not-json}\n\n")
+		}))
+		defer server.Close()
+
+		client, err := New(server.URL, "", "coyote/dev", nil)
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+
+		err = client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, func(StepLogStreamEvent) error { return nil })
+		var apiErr *Error
+		if !errors.As(err, &apiErr) || apiErr.Kind != ErrorKindUnexpected || !strings.Contains(apiErr.Error(), "invalid sse response") {
+			t.Fatalf("expected invalid sse response error, got %v", err)
+		}
+	})
+
+	t.Run("error event with empty message falls back to default", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: error\n")
+			_, _ = io.WriteString(w, "data: {}\n\n")
+		}))
+		defer server.Close()
+
+		client, err := New(server.URL, "", "coyote/dev", nil)
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+
+		err = client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, func(StepLogStreamEvent) error { return nil })
+		var apiErr *Error
+		if !errors.As(err, &apiErr) || apiErr.Kind != ErrorKindServer || apiErr.Message != "step log stream failed" {
+			t.Fatalf("expected default stream failure, got %v", err)
+		}
+	})
+
+	t.Run("error event with invalid payload falls back to default", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: error\n")
+			_, _ = io.WriteString(w, "data: nope\n\n")
+		}))
+		defer server.Close()
+
+		client, err := New(server.URL, "", "coyote/dev", nil)
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+
+		err = client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, func(StepLogStreamEvent) error { return nil })
+		var apiErr *Error
+		if !errors.As(err, &apiErr) || apiErr.Kind != ErrorKindServer || apiErr.Message != "step log stream failed" {
+			t.Fatalf("expected default stream failure, got %v", err)
+		}
+	})
+
+	t.Run("handler error is returned", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: chunk\n")
+			_, _ = io.WriteString(w, "data: {\"sequence_no\":1,\"build_id\":\"build-1\",\"step_id\":\"step-1\",\"step_index\":0,\"step_name\":\"test\",\"stream\":\"stdout\",\"chunk_text\":\"ok\\n\",\"created_at\":\"2026-07-07T00:00:01Z\"}\n\n")
+		}))
+		defer server.Close()
+
+		client, err := New(server.URL, "", "coyote/dev", nil)
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+
+		wantErr := errors.New("stop")
+		err = client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, func(StepLogStreamEvent) error { return wantErr })
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected handler error, got %v", err)
+		}
+	})
+
+	t.Run("read failure returns unexpected error", func(t *testing.T) {
+		client, err := New("https://example.com", "", "coyote/dev", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       &errReadCloser{err: errors.New("broken stream")},
+			}, nil
+		})})
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+
+		err = client.StreamBuildStepLogs(context.Background(), "build-1", 0, 0, func(StepLogStreamEvent) error { return nil })
+		var apiErr *Error
+		if !errors.As(err, &apiErr) || apiErr.Kind != ErrorKindUnexpected || !strings.Contains(apiErr.Error(), "read sse response") {
+			t.Fatalf("expected read sse response error, got %v", err)
+		}
+	})
+}
+
 func TestClient_ProjectAndJobDiscoveryMethods(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -107,6 +107,54 @@ func TestClient_BuildInspectionMethods(t *testing.T) {
 	}
 }
 
+func TestClient_StreamBuildStepLogs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/api/builds/build-1/steps/2/logs/stream?after=4" {
+			t.Fatalf("unexpected request path %q", r.URL.String())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("expected bearer header, got %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Fatalf("expected event-stream accept header, got %q", got)
+		}
+		if got := r.Header.Get("Last-Event-ID"); got != "4" {
+			t.Fatalf("expected Last-Event-ID 4, got %q", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ": connected\n\n")
+		_, _ = io.WriteString(w, "id: 5\n")
+		_, _ = io.WriteString(w, "event: chunk\n")
+		_, _ = io.WriteString(w, "data: {\"sequence_no\":5,\"build_id\":\"build-1\",\"step_id\":\"step-2\",\"step_index\":2,\"step_name\":\"test\",\"stream\":\"stdout\",\"chunk_text\":\"hello\\n\",\"created_at\":\"2026-07-07T00:00:01Z\"}\n\n")
+		_, _ = io.WriteString(w, "event: timeout\n")
+		_, _ = io.WriteString(w, "data: {\"message\":\"maximum stream duration exceeded\"}\n\n")
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	var events []StepLogStreamEvent
+	streamErr := client.StreamBuildStepLogs(context.Background(), "build-1", 2, 4, func(event StepLogStreamEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	if !errors.Is(streamErr, ErrStepLogStreamTimeout) {
+		t.Fatalf("expected timeout sentinel, got %v", streamErr)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected one chunk event, got %+v", events)
+	}
+	if events[0].Type != "chunk" || events[0].Chunk == nil || events[0].Chunk.SequenceNo != 5 || events[0].Chunk.StepName != "test" {
+		t.Fatalf("unexpected chunk event: %+v", events[0])
+	}
+	if events[0].Chunk.ChunkText != "hello\n" {
+		t.Fatalf("unexpected chunk text: %+v", events[0].Chunk)
+	}
+}
+
 func TestClient_ProjectAndJobDiscoveryMethods(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -104,6 +106,34 @@ type buildArtifactDownloadView struct {
 	SizeBytes  int64  `json:"size_bytes"`
 }
 
+var buildWatchPollInterval = 3 * time.Second
+
+type buildWatchEvent struct {
+	Type      string  `json:"type"`
+	BuildID   string  `json:"build_id"`
+	Timestamp string  `json:"timestamp"`
+	Status    string  `json:"status,omitempty"`
+	ExitCode  *int    `json:"exit_code,omitempty"`
+	StepIndex *int    `json:"step_index,omitempty"`
+	StepName  *string `json:"step_name,omitempty"`
+	StepID    *string `json:"step_id,omitempty"`
+	Stream    string  `json:"stream,omitempty"`
+	Text      string  `json:"text,omitempty"`
+}
+
+type buildWatchEmitter struct {
+	mode    output.Mode
+	writer  io.Writer
+	encoder *json.Encoder
+	mu      sync.Mutex
+}
+
+func newBuildWatchEmitter(mode output.Mode, writer io.Writer) *buildWatchEmitter {
+	encoder := json.NewEncoder(writer)
+	encoder.SetEscapeHTML(false)
+	return &buildWatchEmitter{mode: mode, writer: writer, encoder: encoder}
+}
+
 var replaceFileAtomicFunc = atomicfile.ReplaceFileAtomic
 
 var isInteractiveInputFunc = isInteractiveInput
@@ -111,10 +141,43 @@ var isInteractiveInputFunc = isInteractiveInput
 func (a *app) newBuildCommand() *cobra.Command {
 	command := &cobra.Command{Use: "build", Short: "Inspect and manage builds"}
 	command.AddCommand(a.newBuildStatusCommand())
+	command.AddCommand(a.newBuildWatchCommand())
 	command.AddCommand(a.newBuildLogsCommand())
 	command.AddCommand(a.newBuildArtifactsCommand())
 	command.AddCommand(a.newBuildRetryCommand())
 	return command
+}
+
+func (a *app) newBuildWatchCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "watch <build-id>",
+		Short: "Watch a build until it reaches a terminal state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			emitter := newBuildWatchEmitter(resolved.OutputMode, a.stdout)
+			terminalStatus, watchErr := watchBuild(cmd.Context(), client, emitter, args[0])
+			if watchErr != nil {
+				var exitErr *ExitError
+				if errors.As(watchErr, &exitErr) {
+					return watchErr
+				}
+				return mapCommandError(watchErr)
+			}
+			if terminalStatus == "success" {
+				return nil
+			}
+			return &ExitError{Code: 1}
+		},
+	}
 }
 
 func (a *app) newBuildArtifactsCommand() *cobra.Command {
@@ -341,6 +404,235 @@ func parseBuildLogsOptions(stepRaw string, failed bool, tail int, tailSet bool) 
 	options.Failed = failed
 	options.Tail = tail
 	return options, nil
+}
+
+func watchBuild(ctx context.Context, client *apiclient.Client, emitter *buildWatchEmitter, buildID string) (string, error) {
+	logsCtx, cancelLogs := context.WithCancel(ctx)
+	defer cancelLogs()
+
+	var streamWG sync.WaitGroup
+	defer streamWG.Wait()
+	streamErrors := make(chan error, 1)
+
+	activeStreams := make(map[int]struct{})
+	var activeStreamsMu sync.Mutex
+	var logsUnavailableOnce sync.Once
+
+	logsEnabled := func() bool {
+		return logsCtx.Err() == nil
+	}
+
+	reportStreamError := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case streamErrors <- err:
+		default:
+		}
+	}
+
+	markLogsUnavailable := func() {
+		logsUnavailableOnce.Do(func() {
+			cancelLogs()
+			reportStreamError(emitter.emit(buildWatchEvent{
+				Type:      "logs_unavailable",
+				BuildID:   buildID,
+				Timestamp: watchTimestamp(nil),
+			}))
+		})
+	}
+
+	startStepStream := func(step api.BuildStepResponse) {
+		if !logsEnabled() || step.Status != "running" {
+			return
+		}
+		activeStreamsMu.Lock()
+		if _, ok := activeStreams[step.StepIndex]; ok {
+			activeStreamsMu.Unlock()
+			return
+		}
+		activeStreams[step.StepIndex] = struct{}{}
+		activeStreamsMu.Unlock()
+
+		streamWG.Add(1)
+		go func(step api.BuildStepResponse) {
+			defer streamWG.Done()
+
+			var after int64
+			for {
+				streamErr := client.StreamBuildStepLogs(logsCtx, buildID, step.StepIndex, after, func(event apiclient.StepLogStreamEvent) error {
+					if event.Chunk == nil {
+						return nil
+					}
+					after = maxInt64(after, event.Chunk.SequenceNo)
+					return emitter.emit(buildWatchLogChunkEvent(buildID, *event.Chunk))
+				})
+				if streamErr == nil {
+					if logsCtx.Err() != nil {
+						return
+					}
+				} else {
+					if logsCtx.Err() != nil || errors.Is(streamErr, context.Canceled) || errors.Is(streamErr, context.DeadlineExceeded) {
+						return
+					}
+					if errors.Is(streamErr, apiclient.ErrStepLogStreamTimeout) {
+						continue
+					}
+
+					var apiErr *apiclient.Error
+					if errors.As(streamErr, &apiErr) && apiErr.Kind == apiclient.ErrorKindAuthorization && apiErr.Code == "missing_token_scope" {
+						markLogsUnavailable()
+						return
+					}
+					reportStreamError(streamErr)
+					return
+				}
+
+				select {
+				case <-logsCtx.Done():
+					return
+				case <-time.After(time.Second):
+				}
+			}
+		}(step)
+	}
+
+	initialized := false
+	previousStatus := ""
+	previousSteps := map[int]api.BuildStepResponse{}
+
+	for {
+		select {
+		case streamErr := <-streamErrors:
+			return "", streamErr
+		default:
+		}
+
+		build, err := client.GetBuild(ctx, buildID)
+		if err != nil {
+			return "", err
+		}
+		steps, err := client.GetBuildSteps(ctx, buildID)
+		if err != nil {
+			return "", err
+		}
+
+		sortedSteps := sortBuildSteps(steps)
+		stepLookup := make(map[int]api.BuildStepResponse, len(sortedSteps))
+		for _, step := range sortedSteps {
+			stepLookup[step.StepIndex] = step
+		}
+
+		if !initialized || build.Status != previousStatus {
+			if emitErr := emitter.emit(buildWatchEvent{
+				Type:      "build_status",
+				BuildID:   buildID,
+				Timestamp: watchTimestamp(nil),
+				Status:    strings.TrimSpace(build.Status),
+			}); emitErr != nil {
+				return "", emitErr
+			}
+		}
+
+		for _, step := range sortedSteps {
+			prev, hadPrev := previousSteps[step.StepIndex]
+			if step.Status == "running" {
+				if !initialized || !hadPrev || prev.Status != step.Status {
+					if emitErr := emitter.emit(buildWatchStepEvent("step_started", buildID, step, nil)); emitErr != nil {
+						return "", emitErr
+					}
+				}
+				startStepStream(step)
+				continue
+			}
+
+			if initialized && hadPrev && prev.Status != step.Status && isTerminalStepStatus(step.Status) {
+				exitCode := step.ExitCode
+				if emitErr := emitter.emit(buildWatchStepEvent("step_finished", buildID, step, exitCode)); emitErr != nil {
+					return "", emitErr
+				}
+			}
+		}
+
+		initialized = true
+		previousStatus = build.Status
+		previousSteps = stepLookup
+
+		if isTerminalBuildStatus(build.Status) {
+			cancelLogs()
+			status := strings.TrimSpace(build.Status)
+			exitCode := buildWatchExitCode(status)
+			if emitErr := emitter.emit(buildWatchEvent{
+				Type:      "terminal",
+				BuildID:   buildID,
+				Timestamp: watchTimestamp(build.FinishedAt),
+				Status:    status,
+				ExitCode:  &exitCode,
+			}); emitErr != nil {
+				return "", emitErr
+			}
+			return status, nil
+		}
+
+		select {
+		case streamErr := <-streamErrors:
+			return "", streamErr
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(buildWatchPollInterval):
+		}
+	}
+}
+
+func (e *buildWatchEmitter) emit(event buildWatchEvent) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.mode == output.ModeJSON {
+		return e.encoder.Encode(event)
+	}
+	return e.writeHuman(event)
+}
+
+func (e *buildWatchEmitter) writeHuman(event buildWatchEvent) error {
+	switch event.Type {
+	case "build_status":
+		_, err := fmt.Fprintf(e.writer, "Build %s: %s\n", event.BuildID, event.Status)
+		return err
+	case "step_started":
+		_, err := fmt.Fprintf(e.writer, "==> step %d: %s started\n", valueOrZero(event.StepIndex), valueOrUnknownPtr(event.StepName))
+		return err
+	case "step_finished":
+		line := fmt.Sprintf("<== step %d: %s %s", valueOrZero(event.StepIndex), valueOrUnknownPtr(event.StepName), event.Status)
+		if event.ExitCode != nil {
+			line += fmt.Sprintf(" (exit code %d)", *event.ExitCode)
+		}
+		_, err := fmt.Fprintln(e.writer, line)
+		return err
+	case "log_chunk":
+		prefix := fmt.Sprintf("[step %d %s] ", valueOrZero(event.StepIndex), valueOrUnknownPtr(event.StepName))
+		if event.Stream != "" && event.Stream != "stdout" {
+			prefix = fmt.Sprintf("[step %d %s][%s] ", valueOrZero(event.StepIndex), valueOrUnknownPtr(event.StepName), event.Stream)
+		}
+		text := event.Text
+		if _, err := io.WriteString(e.writer, prefix+text); err != nil {
+			return err
+		}
+		if strings.HasSuffix(text, "\n") {
+			return nil
+		}
+		_, err := fmt.Fprintln(e.writer)
+		return err
+	case "logs_unavailable":
+		_, err := fmt.Fprintln(e.writer, "Live logs unavailable for this token; continuing with status-only watch.")
+		return err
+	case "terminal":
+		_, err := fmt.Fprintf(e.writer, "Build %s completed with status %s (exit %d)\n", event.BuildID, event.Status, valueOrZero(event.ExitCode))
+		return err
+	default:
+		return nil
+	}
 }
 
 func makeBuildArtifactsPayload(buildID string, artifacts []api.BuildArtifactResponse) buildArtifactsPayload {
@@ -905,6 +1197,101 @@ func logHeader(selected *api.BuildLogSelectedStepResponse, entry api.BuildLogRes
 		return fmt.Sprintf("step %d: %s (%s)", selected.StepIndex, selected.Name, selected.Status)
 	}
 	return fmt.Sprintf("step %d: %s", entry.StepIndex, entry.StepName)
+}
+
+func buildWatchLogChunkEvent(buildID string, chunk api.StepLogChunkResponse) buildWatchEvent {
+	stepIndex := chunk.StepIndex
+	stepName := trimStringPtr(&chunk.StepName)
+	stepID := trimStringPtr(&chunk.StepID)
+	return buildWatchEvent{
+		Type:      "log_chunk",
+		BuildID:   buildID,
+		Timestamp: watchTimestamp(&chunk.CreatedAt),
+		StepIndex: &stepIndex,
+		StepName:  stepName,
+		StepID:    stepID,
+		Stream:    strings.TrimSpace(chunk.Stream),
+		Text:      chunk.ChunkText,
+	}
+}
+
+func buildWatchStepEvent(eventType string, buildID string, step api.BuildStepResponse, exitCode *int) buildWatchEvent {
+	stepIndex := step.StepIndex
+	stepName := trimStringPtr(&step.Name)
+	stepID := trimStringPtr(&step.ID)
+	timestampSource := step.StartedAt
+	if eventType == "step_finished" {
+		timestampSource = step.FinishedAt
+	}
+	return buildWatchEvent{
+		Type:      eventType,
+		BuildID:   buildID,
+		Timestamp: watchTimestamp(timestampSource),
+		Status:    strings.TrimSpace(step.Status),
+		ExitCode:  exitCode,
+		StepIndex: &stepIndex,
+		StepName:  stepName,
+		StepID:    stepID,
+	}
+}
+
+func watchTimestamp(value *string) string {
+	if value != nil {
+		trimmed := strings.TrimSpace(*value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func buildWatchExitCode(status string) int {
+	if strings.TrimSpace(status) == "success" {
+		return 0
+	}
+	return 1
+}
+
+func isTerminalBuildStatus(status string) bool {
+	trimmed := strings.TrimSpace(status)
+	return trimmed == "success" || trimmed == "failed" || trimmed == "canceled"
+}
+
+func isTerminalStepStatus(status string) bool {
+	trimmed := strings.TrimSpace(status)
+	return trimmed == "success" || trimmed == "failed" || trimmed == "canceled"
+}
+
+func sortBuildSteps(steps []api.BuildStepResponse) []api.BuildStepResponse {
+	sorted := append([]api.BuildStepResponse(nil), steps...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].StepIndex == sorted[j].StepIndex {
+			return sorted[i].ID < sorted[j].ID
+		}
+		return sorted[i].StepIndex < sorted[j].StepIndex
+	})
+	return sorted
+}
+
+func maxInt64(left int64, right int64) int64 {
+	if right > left {
+		return right
+	}
+	return left
+}
+
+func valueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func valueOrUnknownPtr(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return "unknown"
+	}
+	return strings.TrimSpace(*value)
 }
 
 func firstJobName(steps []api.BuildStepResponse) *string {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -408,10 +408,10 @@ func parseBuildLogsOptions(stepRaw string, failed bool, tail int, tailSet bool) 
 
 func watchBuild(ctx context.Context, client *apiclient.Client, emitter *buildWatchEmitter, buildID string) (string, error) {
 	logsCtx, cancelLogs := context.WithCancel(ctx)
-	defer cancelLogs()
 
 	var streamWG sync.WaitGroup
 	defer streamWG.Wait()
+	defer cancelLogs()
 	streamErrors := make(chan error, 1)
 
 	activeStreams := make(map[int]struct{})

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -377,6 +377,59 @@ func TestBuildWatchEmitterOutputs(t *testing.T) {
 	}
 }
 
+func TestBuildWatchHelpers(t *testing.T) {
+	t.Run("log chunk event trims step metadata", func(t *testing.T) {
+		event := buildWatchLogChunkEvent("build-1", api.StepLogChunkResponse{
+			StepIndex: 3,
+			StepName:  "  test-step  ",
+			StepID:    "  step-3  ",
+			Stream:    " stderr ",
+			ChunkText: "boom\n",
+			CreatedAt: "2026-07-07T00:00:00Z",
+		})
+		if event.StepIndex == nil || *event.StepIndex != 3 || event.StepName == nil || *event.StepName != "test-step" || event.StepID == nil || *event.StepID != "step-3" || event.Stream != "stderr" {
+			t.Fatalf("unexpected log chunk event: %+v", event)
+		}
+	})
+
+	t.Run("step event uses finished timestamp for finished events", func(t *testing.T) {
+		step := api.BuildStepResponse{ID: " step-1 ", StepIndex: 1, Name: " test ", Status: "failed", StartedAt: stringPtr("2026-07-07T00:00:01Z"), FinishedAt: stringPtr("2026-07-07T00:00:02Z")}
+		started := buildWatchStepEvent("step_started", "build-1", step, nil)
+		finished := buildWatchStepEvent("step_finished", "build-1", step, intPtr(1))
+		if started.Timestamp != "2026-07-07T00:00:01Z" || finished.Timestamp != "2026-07-07T00:00:02Z" {
+			t.Fatalf("unexpected step timestamps: started=%+v finished=%+v", started, finished)
+		}
+	})
+
+	t.Run("watch helper fallbacks", func(t *testing.T) {
+		if got := watchTimestamp(nil); strings.TrimSpace(got) == "" {
+			t.Fatal("expected fallback timestamp")
+		}
+		steps := sortBuildSteps([]api.BuildStepResponse{{ID: "b", StepIndex: 2}, {ID: "a", StepIndex: 2}, {ID: "c", StepIndex: 1}})
+		if steps[0].ID != "c" || steps[1].ID != "a" || steps[2].ID != "b" {
+			t.Fatalf("unexpected step ordering: %+v", steps)
+		}
+		if got := maxInt64(1, 5); got != 5 {
+			t.Fatalf("expected maxInt64 to pick 5, got %d", got)
+		}
+		if got := maxInt64(7, 2); got != 7 {
+			t.Fatalf("expected maxInt64 to keep 7, got %d", got)
+		}
+		if got := valueOrZero(nil); got != 0 {
+			t.Fatalf("expected zero fallback, got %d", got)
+		}
+		if got := valueOrZero(intPtr(4)); got != 4 {
+			t.Fatalf("expected value fallback 4, got %d", got)
+		}
+		if got := valueOrUnknownPtr(nil); got != "unknown" {
+			t.Fatalf("expected unknown fallback, got %q", got)
+		}
+		if got := valueOrUnknownPtr(stringPtr("  named-step  ")); got != "named-step" {
+			t.Fatalf("expected trimmed value, got %q", got)
+		}
+	})
+}
+
 func TestBuildArtifactHelpers(t *testing.T) {
 	stepID := "step-1"
 	contentType := "application/xml"

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -323,6 +324,57 @@ func TestConfirmBuildRetry(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestBuildWatchEmitterOutputs(t *testing.T) {
+	human := &bytes.Buffer{}
+	humanEmitter := newBuildWatchEmitter(output.ModeHuman, human)
+	stepIndex := 2
+	stepName := "test"
+	exitCode := 1
+	for _, event := range []buildWatchEvent{
+		{Type: "build_status", BuildID: "build-1", Timestamp: "2026-07-07T00:00:00Z", Status: "running"},
+		{Type: "step_started", BuildID: "build-1", Timestamp: "2026-07-07T00:00:01Z", StepIndex: &stepIndex, StepName: &stepName, Status: "running"},
+		{Type: "log_chunk", BuildID: "build-1", Timestamp: "2026-07-07T00:00:02Z", StepIndex: &stepIndex, StepName: &stepName, Stream: "stderr", Text: "boom\n"},
+		{Type: "logs_unavailable", BuildID: "build-1", Timestamp: "2026-07-07T00:00:03Z"},
+		{Type: "step_finished", BuildID: "build-1", Timestamp: "2026-07-07T00:00:04Z", StepIndex: &stepIndex, StepName: &stepName, Status: "failed", ExitCode: &exitCode},
+		{Type: "terminal", BuildID: "build-1", Timestamp: "2026-07-07T00:00:05Z", Status: "failed", ExitCode: &exitCode},
+	} {
+		if err := humanEmitter.emit(event); err != nil {
+			t.Fatalf("emit human event: %v", err)
+		}
+	}
+	out := human.String()
+	for _, want := range []string{
+		"Build build-1: running",
+		"==> step 2: test started",
+		"[step 2 test][stderr] boom",
+		"Live logs unavailable for this token; continuing with status-only watch.",
+		"<== step 2: test failed (exit code 1)",
+		"Build build-1 completed with status failed (exit 1)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got %s", want, out)
+		}
+	}
+
+	jsonBuf := &bytes.Buffer{}
+	jsonEmitter := newBuildWatchEmitter(output.ModeJSON, jsonBuf)
+	if err := jsonEmitter.emit(buildWatchEvent{Type: "terminal", BuildID: "build-1", Timestamp: "2026-07-07T00:00:05Z", Status: "success", ExitCode: intPtr(0)}); err != nil {
+		t.Fatalf("emit json event: %v", err)
+	}
+	var decoded buildWatchEvent
+	if err := json.Unmarshal(jsonBuf.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode json event: %v", err)
+	}
+	if decoded.Type != "terminal" || decoded.BuildID != "build-1" || decoded.Status != "success" || decoded.ExitCode == nil || *decoded.ExitCode != 0 {
+		t.Fatalf("unexpected decoded event: %+v", decoded)
+	}
+
+	failingEmitter := newBuildWatchEmitter(output.ModeHuman, failWriter{})
+	if err := failingEmitter.emit(buildWatchEvent{Type: "build_status", BuildID: "build-1", Timestamp: "2026-07-07T00:00:00Z", Status: "running"}); err == nil || err.Error() != "write failed" {
+		t.Fatalf("expected write failure, got %v", err)
+	}
 }
 
 func TestBuildArtifactHelpers(t *testing.T) {

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -102,7 +102,9 @@ func Run(deps Dependencies) int {
 		if stderr == nil {
 			stderr = os.Stderr
 		}
-		_, _ = fmt.Fprintln(stderr, err.Error())
+		if message := strings.TrimSpace(err.Error()); message != "" {
+			_, _ = fmt.Fprintln(stderr, message)
+		}
 		var exitErr *ExitError
 		if errors.As(err, &exitErr) {
 			return exitErr.Code

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -230,6 +231,236 @@ func TestBuildStatusAndLogsCommands(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("expected no stdout on tail validation error, got %q", stdout.String())
+	}
+}
+
+func TestBuildWatchCommandHuman(t *testing.T) {
+	originalPollInterval := buildWatchPollInterval
+	buildWatchPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		buildWatchPollInterval = originalPollInterval
+	})
+
+	var buildCalls int32
+	var stepsCalls int32
+	var streamHit int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1":
+			call := atomic.AddInt32(&buildCalls, 1)
+			if call == 1 || atomic.LoadInt32(&streamHit) == 0 {
+				_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","job_name":"watch-job","status":"running","created_at":"2026-07-07T00:00:00Z","started_at":"2026-07-07T00:00:01Z","finished_at":null,"current_step_index":0,"attempt_number":1,"error_message":null,"trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"},"current_steps":[{"id":"step-1","index":0,"name":"test","status":"running","started_at":"2026-07-07T00:00:01Z"}]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","job_name":"watch-job","status":"success","created_at":"2026-07-07T00:00:00Z","started_at":"2026-07-07T00:00:01Z","finished_at":"2026-07-07T00:00:03Z","current_step_index":0,"attempt_number":1,"error_message":null,"trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"},"current_steps":[]}}`))
+		case "/api/builds/build-1/steps":
+			call := atomic.AddInt32(&stepsCalls, 1)
+			if call == 1 || atomic.LoadInt32(&streamHit) == 0 {
+				_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":0,"name":"test","command":"go test ./...","status":"running","image":{"source_kind":"external"},"job":null,"worker_id":null,"started_at":"2026-07-07T00:00:01Z","finished_at":null,"exit_code":null,"stdout":null,"stderr":null,"error_message":null}]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":0,"name":"test","command":"go test ./...","status":"success","image":{"source_kind":"external"},"job":null,"worker_id":null,"started_at":"2026-07-07T00:00:01Z","finished_at":"2026-07-07T00:00:03Z","exit_code":0,"stdout":null,"stderr":null,"error_message":null}]}}`))
+		case "/api/builds/build-1/steps/0/logs/stream":
+			atomic.StoreInt32(&streamHit, 1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: chunk\n")
+			_, _ = io.WriteString(w, "data: {\"sequence_no\":1,\"build_id\":\"build-1\",\"step_id\":\"step-1\",\"step_index\":0,\"step_name\":\"test\",\"stream\":\"stdout\",\"chunk_text\":\"ok\\n\",\"created_at\":\"2026-07-07T00:00:02Z\"}\n\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "watch", "build-1"}}); code != 0 {
+		t.Fatalf("build watch exit code %d stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"Build build-1: running",
+		"==> step 0: test started",
+		"[step 0 test] ok",
+		"<== step 0: test success (exit code 0)",
+		"Build build-1 completed with status success (exit 0)",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected %q in output, got %s", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	if atomic.LoadInt32(&buildCalls) < 2 || atomic.LoadInt32(&stepsCalls) < 2 {
+		t.Fatalf("expected repeated polling, got buildCalls=%d stepsCalls=%d", atomic.LoadInt32(&buildCalls), atomic.LoadInt32(&stepsCalls))
+	}
+}
+
+func TestBuildWatchCommandJSONLogsUnavailable(t *testing.T) {
+	originalPollInterval := buildWatchPollInterval
+	buildWatchPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		buildWatchPollInterval = originalPollInterval
+	})
+
+	var buildCalls int32
+	var stepsCalls int32
+	var streamAttempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1":
+			call := atomic.AddInt32(&buildCalls, 1)
+			if call == 1 || atomic.LoadInt32(&streamAttempts) == 0 {
+				_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","job_name":"watch-job","status":"running","created_at":"2026-07-07T00:00:00Z","started_at":"2026-07-07T00:00:01Z","finished_at":null,"current_step_index":0,"attempt_number":1,"error_message":null,"trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"},"current_steps":[{"id":"step-1","index":0,"name":"test","status":"running","started_at":"2026-07-07T00:00:01Z"}]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","job_name":"watch-job","status":"failed","created_at":"2026-07-07T00:00:00Z","started_at":"2026-07-07T00:00:01Z","finished_at":"2026-07-07T00:00:03Z","current_step_index":0,"attempt_number":1,"error_message":"boom","trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"},"current_steps":[]}}`))
+		case "/api/builds/build-1/steps":
+			call := atomic.AddInt32(&stepsCalls, 1)
+			if call == 1 || atomic.LoadInt32(&streamAttempts) == 0 {
+				_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":0,"name":"test","command":"go test ./...","status":"running","image":{"source_kind":"external"},"job":null,"worker_id":null,"started_at":"2026-07-07T00:00:01Z","finished_at":null,"exit_code":null,"stdout":null,"stderr":null,"error_message":null}]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":0,"name":"test","command":"go test ./...","status":"failed","image":{"source_kind":"external"},"job":null,"worker_id":null,"started_at":"2026-07-07T00:00:01Z","finished_at":"2026-07-07T00:00:03Z","exit_code":1,"stdout":null,"stderr":null,"error_message":"boom"}]}}`))
+		case "/api/builds/build-1/steps/0/logs/stream":
+			atomic.AddInt32(&streamAttempts, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:logs"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "watch", "build-1", "--json"}})
+	if code != 1 {
+		t.Fatalf("expected failed build watch exit code 1, got %d stderr=%s", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 5 {
+		t.Fatalf("expected multiple ndjson events, got %q", stdout.String())
+	}
+	seenTypes := map[string]buildWatchEvent{}
+	typeCounts := map[string]int{}
+	for _, line := range lines {
+		var event buildWatchEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode ndjson line %q: %v", line, err)
+		}
+		if event.Type == "" || event.BuildID != "build-1" || strings.TrimSpace(event.Timestamp) == "" {
+			t.Fatalf("event missing required fields: %+v", event)
+		}
+		typeCounts[event.Type]++
+		seenTypes[event.Type] = event
+	}
+	for _, wantType := range []string{"build_status", "step_started", "logs_unavailable", "step_finished", "terminal"} {
+		if _, ok := seenTypes[wantType]; !ok {
+			t.Fatalf("expected event type %q, got %+v", wantType, seenTypes)
+		}
+	}
+	if typeCounts["logs_unavailable"] != 1 {
+		t.Fatalf("expected logs_unavailable once, got counts=%+v", typeCounts)
+	}
+	terminal := seenTypes["terminal"]
+	if terminal.Status != "failed" || terminal.ExitCode == nil || *terminal.ExitCode != 1 {
+		t.Fatalf("unexpected terminal event: %+v", terminal)
+	}
+	if seenTypes["logs_unavailable"].StepIndex != nil {
+		t.Fatalf("logs_unavailable should not be step scoped: %+v", seenTypes["logs_unavailable"])
+	}
+	stepStarted := seenTypes["step_started"]
+	if stepStarted.StepIndex == nil || *stepStarted.StepIndex != 0 || stepStarted.StepName == nil || *stepStarted.StepName != "test" || stepStarted.StepID == nil || *stepStarted.StepID != "step-1" {
+		t.Fatalf("unexpected step_started event: %+v", stepStarted)
+	}
+}
+
+func TestBuildWatchCommandStreamFailureSurfaces(t *testing.T) {
+	originalPollInterval := buildWatchPollInterval
+	buildWatchPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		buildWatchPollInterval = originalPollInterval
+	})
+
+	var streamAttempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1":
+			_, _ = w.Write([]byte(`{"data":{"id":"build-1","project_id":"project-1","project_name":"Coyote CI","job_id":"job-1","job_name":"watch-job","status":"running","created_at":"2026-07-07T00:00:00Z","started_at":"2026-07-07T00:00:01Z","finished_at":null,"current_step_index":0,"attempt_number":1,"error_message":null,"trigger_type":"manual","trigger_kind":"manual","image":{"source_kind":"external"},"current_steps":[{"id":"step-1","index":0,"name":"test","status":"running","started_at":"2026-07-07T00:00:01Z"}]}}`))
+		case "/api/builds/build-1/steps":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","steps":[{"id":"step-1","build_id":"build-1","step_index":0,"name":"test","command":"go test ./...","status":"running","image":{"source_kind":"external"},"job":null,"worker_id":null,"started_at":"2026-07-07T00:00:01Z","finished_at":null,"exit_code":null,"stdout":null,"stderr":null,"error_message":null}]}}`))
+		case "/api/builds/build-1/steps/0/logs/stream":
+			atomic.AddInt32(&streamAttempts, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"error":{"code":"bad_gateway","message":"upstream stream failed"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "watch", "build-1"}})
+	if code != 9 {
+		t.Fatalf("expected server error exit code 9, got %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if atomic.LoadInt32(&streamAttempts) == 0 {
+		t.Fatal("expected log stream request before failure")
+	}
+	if !strings.Contains(stderr.String(), "upstream stream failed") {
+		t.Fatalf("expected surfaced stream error, got %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Live logs unavailable") {
+		t.Fatalf("did not expect logs_unavailable output for non-scope failure: %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `coyote build watch <build-id>` for watching builds from the CLI without introducing a new backend watch endpoint. The command polls existing build/status metadata and attaches to the existing per-step SSE log stream for live output.

## What Changed

- Added hybrid build watching to the CLI:
  - human mode prints build/step transition markers and prefixed live log lines;
  - `--json` emits NDJSON events.
- Added watch event types:
  - `build_status`
  - `step_started`
  - `step_finished`
  - `log_chunk`
  - `logs_unavailable`
  - `terminal`
- Added client support for streaming step logs from `/api/builds/{buildID}/steps/{stepIndex}/logs/stream`.
- Preserved scope boundaries:
  - `build:read` is enough for status watch;
  - `build:logs` is only required for live logs.
- If live logs are unavailable due to missing `build:logs`, watch emits `logs_unavailable` and continues status-only.
- Failed/canceled builds exit nonzero; successful builds exit `0`.
- Context cancellation/Ctrl-C preserves the existing `130` behavior.
- Avoids blank stderr output for intentional nonzero terminal exits.

## Validation

- Verified regular human watch output works.
- Verified JSON/NDJSON watch output works.
- Added focused tests for SSE parsing, watch output, missing log-scope fallback, terminal behavior, and output error handling.