### PR TITLE
Expand artifact download for CLI

### DIFF
--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -100,10 +100,15 @@ type buildArtifactDownloadPayload struct {
 }
 
 type buildArtifactDownloadView struct {
-	ArtifactID string `json:"artifact_id"`
-	Name       string `json:"name"`
-	Path       string `json:"path"`
-	SizeBytes  int64  `json:"size_bytes"`
+	ArtifactID      string  `json:"artifact_id"`
+	Name            string  `json:"name"`
+	ArtifactPath    string  `json:"artifact_path"`
+	StepID          *string `json:"step_id,omitempty"`
+	ContentType     *string `json:"content_type,omitempty"`
+	SizeBytes       int64   `json:"size_bytes"`
+	Path            string  `json:"path,omitempty"`
+	LocalPath       string  `json:"local_path"`
+	DownloadedBytes int64   `json:"downloaded_bytes"`
 }
 
 var buildWatchPollInterval = 3 * time.Second
@@ -268,7 +273,7 @@ func (a *app) newBuildArtifactsDownloadCommand() *cobra.Command {
 			}, payload)
 		},
 	}
-	command.Flags().StringVar(&selector, "artifact", "", "Artifact ID, path, or name")
+	command.Flags().StringVar(&selector, "artifact", "", "Artifact selector: ID first, exact path second, then name or basename; ambiguous matches require ID or full path")
 	command.Flags().StringVar(&outputPath, "output", "", "Output file or directory path")
 	command.Flags().BoolVar(&force, "force", false, "Overwrite an existing file")
 	return command
@@ -1151,19 +1156,20 @@ func downloadBuildArtifactToPath(ctx context.Context, client *apiclient.Client, 
 }
 
 func buildArtifactDownloadViewFromArtifact(artifact api.BuildArtifactResponse, destinationPath string, written int64) buildArtifactDownloadView {
-	sizeBytes := written
-	if sizeBytes == 0 && artifact.SizeBytes > 0 {
-		sizeBytes = artifact.SizeBytes
-	}
 	name, err := artifactDownloadName(artifact)
 	if err != nil {
 		name = strings.TrimSpace(artifact.ID)
 	}
 	return buildArtifactDownloadView{
-		ArtifactID: artifact.ID,
-		Name:       name,
-		Path:       destinationPath,
-		SizeBytes:  sizeBytes,
+		ArtifactID:      artifact.ID,
+		Name:            name,
+		ArtifactPath:    strings.TrimSpace(artifact.Path),
+		StepID:          trimStringPtr(artifact.StepID),
+		ContentType:     trimStringPtr(artifact.ContentType),
+		SizeBytes:       artifact.SizeBytes,
+		Path:            destinationPath,
+		LocalPath:       destinationPath,
+		DownloadedBytes: written,
 	}
 }
 

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -504,7 +504,7 @@ func TestBuildArtifactHelpers(t *testing.T) {
 		t.Fatalf("expected drive path rejection, got %v", drivePathErr)
 	}
 
-	downloadPayload := buildArtifactDownloadPayload{BuildID: "build-1", Downloaded: []buildArtifactDownloadView{{ArtifactID: "artifact-1", Name: "report.xml", Path: "./report.xml", SizeBytes: 42}}}
+	downloadPayload := buildArtifactDownloadPayload{BuildID: "build-1", Downloaded: []buildArtifactDownloadView{{ArtifactID: "artifact-1", Name: "report.xml", ArtifactPath: "reports/report.xml", StepID: &stepID, ContentType: &contentType, SizeBytes: 42, Path: "./report.xml", LocalPath: "./report.xml", DownloadedBytes: 13}}}
 	buf.Reset()
 	if writeDownloadErr := writeBuildArtifactDownloadHuman(buf, downloadPayload); writeDownloadErr != nil {
 		t.Fatalf("writeBuildArtifactDownloadHuman failed: %v", writeDownloadErr)
@@ -608,7 +608,7 @@ func TestBuildArtifactHelpers(t *testing.T) {
 		t.Fatalf("expected temp files to be cleaned up after replace failure, got %v", tempMatches)
 	}
 
-	if got := buildArtifactDownloadViewFromArtifact(api.BuildArtifactResponse{ID: "artifact-fallback", Path: "../unsafe"}, "./artifact-fallback", 0); got.Name != "artifact-fallback" || got.SizeBytes != 0 {
+	if got := buildArtifactDownloadViewFromArtifact(api.BuildArtifactResponse{ID: "artifact-fallback", Path: "../unsafe"}, "./artifact-fallback", 0); got.Name != "artifact-fallback" || got.SizeBytes != 0 || got.DownloadedBytes != 0 || got.LocalPath != "./artifact-fallback" || got.Path != "./artifact-fallback" {
 		t.Fatalf("expected fallback download view, got %+v", got)
 	}
 
@@ -701,6 +701,20 @@ func TestBuildArtifactHelperEdgeCases(t *testing.T) {
 
 	if got, err := artifactDownloadName(api.BuildArtifactResponse{Name: "report.xml"}); err != nil || got != "report.xml" {
 		t.Fatalf("expected artifactDownloadName name fallback, got %q err=%v", got, err)
+	}
+
+	stepID := " step-7 "
+	contentType := " application/xml "
+	view := buildArtifactDownloadViewFromArtifact(api.BuildArtifactResponse{
+		ID:          "artifact-7",
+		Name:        "report.xml",
+		Path:        "reports/report.xml",
+		StepID:      &stepID,
+		ContentType: &contentType,
+		SizeBytes:   42,
+	}, "./downloads/report.xml", 13)
+	if view.ArtifactID != "artifact-7" || view.Name != "report.xml" || view.ArtifactPath != "reports/report.xml" || view.StepID == nil || *view.StepID != "step-7" || view.ContentType == nil || *view.ContentType != "application/xml" || view.SizeBytes != 42 || view.Path != "./downloads/report.xml" || view.LocalPath != "./downloads/report.xml" || view.DownloadedBytes != 13 {
+		t.Fatalf("unexpected download view: %+v", view)
 	}
 	if got := displayPath("./report.xml"); got != "./report.xml" {
 		t.Fatalf("expected dotted display path to remain unchanged, got %s", got)

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -566,6 +566,27 @@ func TestBuildArtifactsCommands(t *testing.T) {
 	if !ok || downloadedFirst["artifact_id"] != "artifact-1" {
 		t.Fatalf("unexpected downloaded entry: %+v", downloadedFirst)
 	}
+	if downloadedFirst["artifact_path"] != "reports/report.xml" {
+		t.Fatalf("expected artifact_path reports/report.xml, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["step_id"] != "step-1" {
+		t.Fatalf("expected step_id step-1, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["content_type"] != "application/xml" {
+		t.Fatalf("expected content_type application/xml, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["size_bytes"] != float64(42) {
+		t.Fatalf("expected size_bytes 42, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["local_path"] != filepath.Join(outputDir, "report.xml") {
+		t.Fatalf("expected local_path to match output file, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["path"] != filepath.Join(outputDir, "report.xml") {
+		t.Fatalf("expected legacy path alias to match local_path, got %+v", downloadedFirst)
+	}
+	if downloadedFirst["downloaded_bytes"] != float64(len("artifact-body")) {
+		t.Fatalf("expected downloaded_bytes %d, got %+v", len("artifact-body"), downloadedFirst)
+	}
 	if strings.Contains(stdout.String(), "Downloaded report.xml") {
 		t.Fatalf("unexpected human prose in artifact download JSON: %s", stdout.String())
 	}
@@ -588,6 +609,47 @@ func TestBuildArtifactsCommands(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "already exists") {
 		t.Fatalf("unexpected overwrite stderr: %s", stderr.String())
+	}
+}
+
+func TestBuildArtifactsDownloadCommandRejectsAmbiguousNameAtCommandLevel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifacts":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","name":"report.xml","path":"reports/a/report.xml","size_bytes":42,"storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"},{"id":"artifact-2","build_id":"build-1","name":"report.xml","path":"reports/b/report.xml","size_bytes":84,"storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-2/download","created_at":"2026-07-05T00:00:01Z"}]}}`))
+		case "/api/builds/build-1/artifacts/artifact-1/download", "/api/builds/build-1/artifacts/artifact-2/download":
+			t.Fatalf("download endpoint should not be called for ambiguous selector")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifacts", "download", "build-1", "--artifact", "report.xml", "--json"}})
+	if code != 2 {
+		t.Fatalf("expected ambiguity exit code 2, got %d stderr=%s", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on ambiguity error, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "matched multiple artifact names") {
+		t.Fatalf("unexpected ambiguity stderr: %s", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Polishes `coyote build artifacts download` JSON output so humans and IDE agents can clearly distinguish artifact metadata from local download results.

## What Changed

- Expanded artifact download JSON entries with agent-friendly fields:
  - `artifact_path`
  - `step_id`
  - `content_type`
  - `local_path`
  - `downloaded_bytes`
- Preserved the existing `path` field as a legacy alias for the local destination path.
- Kept existing artifact selector behavior:
  - artifact ID first;
  - exact artifact path second;
  - artifact name or basename third;
  - ambiguous name/path matches require ID or full path.
- Clarified `--artifact` help text.
- Added focused tests for the new JSON shape, metadata preservation, downloaded byte count, and command-level ambiguity behavior.

## Validation

- Verified artifact listing works.
- Verified single-artifact download works by artifact ID.
- Confirmed the command downloads the selected artifact only.
- Existing selector, destination, overwrite, and path-safety behavior remains unchanged.