### PR TITLE
Worker-side handoff for artifact triggered builds

### DIFF
--- a/backend/internal/runner/docker/runner.go
+++ b/backend/internal/runner/docker/runner.go
@@ -104,6 +104,13 @@ func (r *Runner) ResolveStepImage(stepImage string) string {
 	return r.resolveExecutionImage(stepImage)
 }
 
+func (r *Runner) StepVisibleWorkspaceRoot(buildID string) (string, bool) {
+	if strings.TrimSpace(buildID) == "" {
+		return "", false
+	}
+	return workspaceMountPath, true
+}
+
 func (r *Runner) ensureBuildWorkspaceReady(ctx context.Context, request runner.PrepareBuildRequest) (string, error) {
 	if r.workspace == nil {
 		return "", errors.New("workspace materializer is required")
@@ -608,9 +615,10 @@ func mergeStepEnvironment(request runner.RunStepRequest) []string {
 		merged[k] = v
 	}
 	merged["CI"] = "true"
-	merged["COYOTE_BUILD_ID"] = request.BuildID
-	merged["COYOTE_STEP_ID"] = request.StepID
-	merged["COYOTE_WORKSPACE"] = workspaceMountPath
+	merged[runner.EnvBuildID] = request.BuildID
+	merged[runner.EnvStepID] = request.StepID
+	merged[runner.EnvWorkspace] = workspaceMountPath
+	augmentTriggerArtifactEnvironment(merged, workspaceMountPath)
 
 	keys := make([]string, 0, len(merged))
 	for k := range merged {
@@ -623,6 +631,15 @@ func mergeStepEnvironment(request runner.RunStepRequest) []string {
 		out = append(out, k+"="+merged[k])
 	}
 	return out
+}
+
+func augmentTriggerArtifactEnvironment(env map[string]string, workspacePath string) {
+	relativePath := strings.TrimSpace(env[runner.EnvTriggerArtifactLocalRelative])
+	if relativePath == "" {
+		return
+	}
+	env[runner.EnvTriggerArtifactLocalDir] = path.Join(workspacePath, workspace.TriggerArtifactsRelativeRoot)
+	env[runner.EnvTriggerArtifactLocalPath] = path.Join(workspacePath, relativePath)
 }
 
 func timeoutFailureReason(timeout time.Duration) string {

--- a/backend/internal/runner/docker/runner_test.go
+++ b/backend/internal/runner/docker/runner_test.go
@@ -405,6 +405,24 @@ func TestMergeStepEnvironment_DerivesTriggerArtifactVisiblePaths(t *testing.T) {
 	}
 }
 
+func TestRunner_StepVisibleWorkspaceRoot(t *testing.T) {
+	r := New(Options{})
+	if got, ok := r.StepVisibleWorkspaceRoot("build-1"); !ok || got != "/workspace" {
+		t.Fatalf("expected docker-visible workspace root, got %q ok=%v", got, ok)
+	}
+	if got, ok := r.StepVisibleWorkspaceRoot(" "); ok || got != "" {
+		t.Fatalf("expected blank build id to fail, got %q ok=%v", got, ok)
+	}
+}
+
+func TestAugmentTriggerArtifactEnvironment_NoRelativePathNoop(t *testing.T) {
+	env := map[string]string{}
+	augmentTriggerArtifactEnvironment(env, "/workspace")
+	if len(env) != 0 {
+		t.Fatalf("expected noop env augmentation, got %#v", env)
+	}
+}
+
 func TestResolveContainerWorkingDirForStep_SymlinkEscapeFallsBackToWorkspaceRoot(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	outsideRoot := t.TempDir()

--- a/backend/internal/runner/docker/runner_test.go
+++ b/backend/internal/runner/docker/runner_test.go
@@ -376,6 +376,35 @@ func TestStepContainerRunArgs_BuildsCorrectArgs(t *testing.T) {
 	}
 }
 
+func TestMergeStepEnvironment_DerivesTriggerArtifactVisiblePaths(t *testing.T) {
+	envEntries := mergeStepEnvironment(runner.RunStepRequest{
+		BuildID: "build-1",
+		StepID:  "step-1",
+		Env: map[string]string{
+			runner.EnvTriggerArtifactLocalRelative: ".coyote/trigger-artifacts/dist/app.tar.gz",
+		},
+	})
+
+	envMap := map[string]string{}
+	for _, entry := range envEntries {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		envMap[parts[0]] = parts[1]
+	}
+
+	if envMap[runner.EnvWorkspace] != "/workspace" {
+		t.Fatalf("expected docker workspace env /workspace, got %q", envMap[runner.EnvWorkspace])
+	}
+	if envMap[runner.EnvTriggerArtifactLocalDir] != "/workspace/.coyote/trigger-artifacts" {
+		t.Fatalf("expected trigger artifact local dir under docker workspace, got %q", envMap[runner.EnvTriggerArtifactLocalDir])
+	}
+	if envMap[runner.EnvTriggerArtifactLocalPath] != "/workspace/.coyote/trigger-artifacts/dist/app.tar.gz" {
+		t.Fatalf("expected trigger artifact local path under docker workspace, got %q", envMap[runner.EnvTriggerArtifactLocalPath])
+	}
+}
+
 func TestResolveContainerWorkingDirForStep_SymlinkEscapeFallsBackToWorkspaceRoot(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	outsideRoot := t.TempDir()

--- a/backend/internal/runner/inprocess/runner.go
+++ b/backend/internal/runner/inprocess/runner.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/radiation/coyote-ci/backend/internal/runner"
 	"github.com/radiation/coyote-ci/backend/internal/source"
+	"github.com/radiation/coyote-ci/backend/internal/workspace"
 )
 
 var _ runner.Runner = (*Runner)(nil)
@@ -94,6 +95,10 @@ func (r *Runner) CleanupBuild(ctx context.Context, buildID string) error {
 	return nil
 }
 
+func (r *Runner) StepVisibleWorkspaceRoot(buildID string) (string, bool) {
+	return r.lookupWorkspacePath(buildID)
+}
+
 func (r *Runner) RunStep(ctx context.Context, request runner.RunStepRequest) (runner.RunStepResult, error) {
 	return r.RunStepStream(ctx, request, nil)
 }
@@ -119,10 +124,13 @@ func (r *Runner) RunStepStream(ctx context.Context, request runner.RunStepReques
 		}
 		cmd.Dir = resolvedDir
 		log.Printf("inprocess run step: build_id=%s workspace_path=%s working_dir=%s resolved_dir=%s", strings.TrimSpace(request.BuildID), workspacePath, strings.TrimSpace(request.WorkingDir), resolvedDir)
+		cmd.Env = mergeEnvironment(request, workspacePath)
 	} else if request.WorkingDir != "" {
 		cmd.Dir = request.WorkingDir
+		cmd.Env = mergeEnvironment(request, "")
+	} else {
+		cmd.Env = mergeEnvironment(request, "")
 	}
-	cmd.Env = mergeEnvironment(request.Env)
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -260,26 +268,37 @@ var safeEnvKeys = []string{
 	"SHELL",
 }
 
-func mergeEnvironment(extra map[string]string) []string {
-	base := make([]string, 0, len(safeEnvKeys)+len(extra))
+func mergeEnvironment(request runner.RunStepRequest, workspacePath string) []string {
+	base := make([]string, 0, len(safeEnvKeys)+len(request.Env)+4)
 	for _, key := range safeEnvKeys {
 		if val, ok := os.LookupEnv(key); ok {
 			base = append(base, key+"="+val)
 		}
 	}
 
-	if len(extra) == 0 {
-		return base
+	merged := make(map[string]string, len(request.Env)+4)
+	for key, value := range request.Env {
+		merged[key] = value
+	}
+	merged["CI"] = "true"
+	merged[runner.EnvBuildID] = request.BuildID
+	merged[runner.EnvStepID] = request.StepID
+	if strings.TrimSpace(workspacePath) != "" {
+		merged[runner.EnvWorkspace] = workspacePath
+		if relativePath := strings.TrimSpace(merged[runner.EnvTriggerArtifactLocalRelative]); relativePath != "" {
+			merged[runner.EnvTriggerArtifactLocalDir] = filepath.Join(workspacePath, filepath.FromSlash(workspace.TriggerArtifactsRelativeRoot))
+			merged[runner.EnvTriggerArtifactLocalPath] = filepath.Join(workspacePath, filepath.FromSlash(relativePath))
+		}
 	}
 
-	keys := make([]string, 0, len(extra))
-	for key := range extra {
+	keys := make([]string, 0, len(merged))
+	for key := range merged {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		base = append(base, key+"="+extra[key])
+		base = append(base, key+"="+merged[key])
 	}
 
 	return base

--- a/backend/internal/runner/inprocess/runner_test.go
+++ b/backend/internal/runner/inprocess/runner_test.go
@@ -166,3 +166,80 @@ func TestRunner_CleanupBuild_RemovesPreparedWorkspace(t *testing.T) {
 		t.Fatalf("expected workspace to be removed, got err=%v", err)
 	}
 }
+
+func TestMergeEnvironment_AddsWorkspaceAndTriggerArtifactPaths(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	env := mergeEnvironment(runner.RunStepRequest{
+		BuildID: "build-1",
+		StepID:  "step-1",
+		Env: map[string]string{
+			runner.EnvTriggerArtifactLocalRelative: ".coyote/trigger-artifacts/dist/app.tgz",
+		},
+	}, workspaceRoot)
+	joined := strings.Join(env, "\n")
+	if !strings.Contains(joined, runner.EnvWorkspace+"="+workspaceRoot) {
+		t.Fatalf("expected workspace env, got %q", joined)
+	}
+	if !strings.Contains(joined, runner.EnvTriggerArtifactLocalDir+"="+filepath.Join(workspaceRoot, ".coyote", "trigger-artifacts")) {
+		t.Fatalf("expected local dir env, got %q", joined)
+	}
+	if !strings.Contains(joined, runner.EnvTriggerArtifactLocalPath+"="+filepath.Join(workspaceRoot, ".coyote", "trigger-artifacts", "dist", "app.tgz")) {
+		t.Fatalf("expected local path env, got %q", joined)
+	}
+	if !strings.Contains(joined, runner.EnvBuildID+"=build-1") || !strings.Contains(joined, runner.EnvStepID+"=step-1") {
+		t.Fatalf("expected build and step env, got %q", joined)
+	}
+	if !strings.Contains(joined, "CI=true") {
+		t.Fatalf("expected CI env, got %q", joined)
+	}
+}
+
+func TestMergeEnvironment_WithoutWorkspaceSkipsLocalArtifactAbsolutePaths(t *testing.T) {
+	env := mergeEnvironment(runner.RunStepRequest{
+		BuildID: "build-1",
+		StepID:  "step-1",
+		Env: map[string]string{
+			runner.EnvTriggerArtifactLocalRelative: ".coyote/trigger-artifacts/dist/app.tgz",
+		},
+	}, "")
+	joined := strings.Join(env, "\n")
+	if strings.Contains(joined, runner.EnvWorkspace+"=") || strings.Contains(joined, runner.EnvTriggerArtifactLocalPath+"=") || strings.Contains(joined, runner.EnvTriggerArtifactLocalDir+"=") {
+		t.Fatalf("expected no workspace-derived env without workspace path, got %q", joined)
+	}
+}
+
+func TestRunner_StepVisibleWorkspaceRoot_FallbackLookup(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildWorkspace := filepath.Join(workspaceRoot, "build-1")
+	if err := os.MkdirAll(buildWorkspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	r := NewWithWorkspaceRoot(workspaceRoot)
+	resolvedExpected, err := filepath.EvalSymlinks(buildWorkspace)
+	if err != nil {
+		t.Fatalf("resolve expected workspace path: %v", err)
+	}
+	if got, ok := r.StepVisibleWorkspaceRoot("build-1"); !ok || got != resolvedExpected {
+		t.Fatalf("expected fallback workspace lookup %q, got %q ok=%v", resolvedExpected, got, ok)
+	}
+	if got, ok := r.StepVisibleWorkspaceRoot(" "); ok || got != "" {
+		t.Fatalf("expected blank build id to fail lookup, got %q ok=%v", got, ok)
+	}
+}
+
+func TestResolveWorkingDir(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if _, err := resolveWorkingDir("", "."); err == nil {
+		t.Fatal("expected empty workspace path error")
+	}
+	if got, err := resolveWorkingDir(workspaceRoot, "."); err != nil || got != workspaceRoot {
+		t.Fatalf("expected workspace root for dot, got %q err=%v", got, err)
+	}
+	abs := filepath.Join(workspaceRoot, "backend")
+	if got, err := resolveWorkingDir(workspaceRoot, abs); err != nil || got != abs {
+		t.Fatalf("expected absolute path to pass through, got %q err=%v", got, err)
+	}
+	if _, err := resolveWorkingDir(workspaceRoot, "../escape"); err == nil {
+		t.Fatal("expected traversal working dir error")
+	}
+}

--- a/backend/internal/runner/runner.go
+++ b/backend/internal/runner/runner.go
@@ -74,6 +74,15 @@ type RunStepResult struct {
 	FinishedAt time.Time
 }
 
+const (
+	EnvBuildID                      = "COYOTE_BUILD_ID"
+	EnvStepID                       = "COYOTE_STEP_ID"
+	EnvWorkspace                    = "COYOTE_WORKSPACE"
+	EnvTriggerArtifactLocalRelative = "COYOTE_TRIGGER_ARTIFACT_LOCAL_RELATIVE_PATH"
+	EnvTriggerArtifactLocalDir      = "COYOTE_TRIGGER_ARTIFACT_LOCAL_DIR"
+	EnvTriggerArtifactLocalPath     = "COYOTE_TRIGGER_ARTIFACT_LOCAL_PATH"
+)
+
 type Runner interface {
 	RunStep(ctx context.Context, request RunStepRequest) (RunStepResult, error)
 }
@@ -88,4 +97,10 @@ type BuildScopedRunner interface {
 	StreamingRunner
 	PrepareBuild(ctx context.Context, request PrepareBuildRequest) error
 	CleanupBuild(ctx context.Context, buildID string) error
+}
+
+// WorkspacePathProvider reports the workspace root path visible to executed
+// steps for a prepared build.
+type WorkspacePathProvider interface {
+	StepVisibleWorkspaceRoot(buildID string) (string, bool)
 }

--- a/backend/internal/service/build/execution_orchestration.go
+++ b/backend/internal/service/build/execution_orchestration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/radiation/coyote-ci/backend/internal/pipeline"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 	"github.com/radiation/coyote-ci/backend/internal/runner"
+	"github.com/radiation/coyote-ci/backend/internal/workspace"
 )
 
 func (s *BuildService) createDurableJobsForBuild(ctx context.Context, build domain.Build, steps []domain.BuildStep) error {
@@ -91,6 +93,7 @@ func (s *BuildService) RunStep(ctx context.Context, request runner.RunStepReques
 	if err != nil {
 		return runner.RunStepResult{}, StepCompletionReport{}, mapExecutionErr(err)
 	}
+	executionContext = s.enrichExecutionContextForRunner(executionContext)
 
 	logManager := NewExecutionLogManager(s, executionContext)
 	completionManager := NewStepCompletionManager(s)
@@ -149,6 +152,42 @@ func (s *BuildService) RunStep(ctx context.Context, request runner.RunStepReques
 	}
 
 	return runOutcome.Result, report, nil
+}
+
+func (s *BuildService) enrichExecutionContextForRunner(executionContext StepExecutionContext) StepExecutionContext {
+	visibleWorkspace := workspace.DefaultContainerRoot
+	if provider, ok := s.runner.(runner.WorkspacePathProvider); ok {
+		if root, found := provider.StepVisibleWorkspaceRoot(executionContext.Build.ID); found && strings.TrimSpace(root) != "" {
+			visibleWorkspace = root
+		}
+	}
+
+	executionContext.StepWorkingDir = workspace.ResolveVisibleWorkingDir(visibleWorkspace, executionContext.ExecutionRequest.WorkingDir)
+	env := cloneEnv(executionContext.ExecutionRequest.Env)
+	env[runner.EnvWorkspace] = visibleWorkspace
+	if executionContext.ExecutionRequest.BuildID != "" {
+		env[runner.EnvBuildID] = executionContext.ExecutionRequest.BuildID
+	}
+	if executionContext.ExecutionRequest.StepID != "" {
+		env[runner.EnvStepID] = executionContext.ExecutionRequest.StepID
+	}
+
+	trigger := domain.NormalizeBuildTrigger(executionContext.Build.Trigger)
+	if trigger.Kind == domain.BuildTriggerKindArtifact {
+		relativePath, relativeErr := workspace.TriggerArtifactRelativePath(readOptionalString(trigger.ArtifactPath))
+		if relativeErr == nil {
+			env[runner.EnvTriggerArtifactLocalRelative] = relativePath
+			env[runner.EnvTriggerArtifactLocalDir] = workspace.ResolveVisiblePath(visibleWorkspace, workspace.TriggerArtifactsRelativeRoot)
+			if path.Clean(strings.ReplaceAll(visibleWorkspace, "\\", "/")) == workspace.DefaultContainerRoot {
+				env[runner.EnvTriggerArtifactLocalPath] = path.Join(visibleWorkspace, relativePath)
+			} else {
+				env[runner.EnvTriggerArtifactLocalPath] = workspace.ResolveVisiblePath(visibleWorkspace, relativePath)
+			}
+		}
+	}
+
+	executionContext.ExecutionRequest.Env = env
+	return executionContext
 }
 
 func (s *BuildService) resolveExecutionImage(build domain.Build) string {

--- a/backend/internal/service/build/prep_test.go
+++ b/backend/internal/service/build/prep_test.go
@@ -11,12 +11,17 @@ package build
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/radiation/coyote-ci/backend/internal/artifact"
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/source"
 )
@@ -306,5 +311,189 @@ func TestPrepareBuildExecution_EmitsOneTimeBuildPrepLogMessages(t *testing.T) {
 		if !slices.Contains(logSink.lines, message) {
 			t.Fatalf("expected build prep log message %q, got %#v", message, logSink.lines)
 		}
+	}
+}
+
+func TestPrepareBuildExecution_HandsOffTriggerArtifactIntoWorkspace(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	body := []byte("artifact-body")
+	checksumBytes := sha256.Sum256(body)
+	checksum := hex.EncodeToString(checksumBytes[:])
+	store := artifact.NewFilesystemStore(storageRoot)
+	if _, saveErr := store.Save(ctx, "producer/dist/app.tgz", strings.NewReader(string(body))); saveErr != nil {
+		t.Fatalf("seed artifact store: %v", saveErr)
+	}
+
+	producerProjectID := "project-1"
+	producerBuildID := "build-upstream"
+	artifactID := "artifact-1"
+	artifactPath := "dist/app.tgz"
+	repo := &fakeBuildRepository{build: domain.Build{
+		ID:        "build-downstream",
+		ProjectID: producerProjectID,
+		Status:    domain.BuildStatusQueued,
+		Trigger: domain.BuildTrigger{
+			Kind:                   domain.BuildTriggerKindArtifact,
+			ProducerProjectID:      &producerProjectID,
+			ProducerBuildID:        &producerBuildID,
+			ArtifactID:             &artifactID,
+			ArtifactPath:           &artifactPath,
+			ArtifactChecksumSHA256: &checksum,
+		},
+	}}
+	artifactRepo := &fakeArtifactRepository{artifacts: map[string][]domain.BuildArtifact{
+		producerBuildID: {{
+			ID:              artifactID,
+			BuildID:         producerBuildID,
+			LogicalPath:     artifactPath,
+			StorageKey:      "producer/dist/app.tgz",
+			StorageProvider: domain.StorageProviderFilesystem,
+			SizeBytes:       int64(len(body)),
+			ChecksumSHA256:  &checksum,
+		}},
+	}}
+	logSink := &fakeLogSink{}
+
+	svc := NewBuildService(repo, nil, logSink)
+	svc.SetArtifactPersistence(artifactRepo, testStoreResolver(store), workspaceRoot)
+
+	build, prepErr := svc.PrepareBuildExecution(ctx, "build-downstream")
+	if prepErr != nil {
+		t.Fatalf("prepare build execution: %v", prepErr)
+	}
+	if build.Status != domain.BuildStatusRunning {
+		t.Fatalf("expected running build after handoff, got %q", build.Status)
+	}
+
+	handedOffPath := filepath.Join(workspaceRoot, "build-downstream", ".coyote", "trigger-artifacts", "dist", "app.tgz")
+	handedOffBody, readErr := os.ReadFile(handedOffPath)
+	if readErr != nil {
+		t.Fatalf("read handed off artifact: %v", readErr)
+	}
+	if string(handedOffBody) != string(body) {
+		t.Fatalf("expected handed off artifact body %q, got %q", string(body), string(handedOffBody))
+	}
+	if !slices.Contains(logSink.lines, "Preparing trigger artifact handoff") || !slices.Contains(logSink.lines, "Trigger artifact handoff complete") {
+		t.Fatalf("expected trigger handoff log lines, got %#v", logSink.lines)
+	}
+}
+
+func TestPrepareBuildExecution_FailsBuildWhenTriggerArtifactMissing(t *testing.T) {
+	producerProjectID := "project-1"
+	producerBuildID := "build-upstream"
+	artifactID := "artifact-1"
+	artifactPath := "dist/app.tgz"
+	repo := &fakeBuildRepository{build: domain.Build{
+		ID:        "build-downstream",
+		ProjectID: producerProjectID,
+		Status:    domain.BuildStatusQueued,
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: &producerProjectID,
+			ProducerBuildID:   &producerBuildID,
+			ArtifactID:        &artifactID,
+			ArtifactPath:      &artifactPath,
+		},
+	}}
+
+	svc := NewBuildService(repo, nil, &fakeLogSink{})
+	svc.SetArtifactPersistence(&fakeArtifactRepository{}, testStoreResolver(artifact.NewFilesystemStore(t.TempDir())), t.TempDir())
+
+	build, prepErr := svc.PrepareBuildExecution(context.Background(), "build-downstream")
+	if prepErr != nil {
+		t.Fatalf("expected build failure without hard error, got %v", prepErr)
+	}
+	if build.Status != domain.BuildStatusFailed {
+		t.Fatalf("expected failed build when trigger artifact is missing, got %q", build.Status)
+	}
+	if build.ErrorMessage == nil || !strings.Contains(*build.ErrorMessage, "artifact not found") {
+		t.Fatalf("expected missing artifact error message, got %v", build.ErrorMessage)
+	}
+}
+
+func TestPrepareBuildExecution_FailsBuildWhenTriggerArtifactChecksumMismatches(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	store := artifact.NewFilesystemStore(storageRoot)
+	if _, saveErr := store.Save(ctx, "producer/dist/app.tgz", strings.NewReader("artifact-body")); saveErr != nil {
+		t.Fatalf("seed artifact store: %v", saveErr)
+	}
+
+	producerProjectID := "project-1"
+	producerBuildID := "build-upstream"
+	artifactID := "artifact-1"
+	artifactPath := "dist/app.tgz"
+	wrongChecksum := strings.Repeat("a", 64)
+	repo := &fakeBuildRepository{build: domain.Build{
+		ID:        "build-downstream",
+		ProjectID: producerProjectID,
+		Status:    domain.BuildStatusQueued,
+		Trigger: domain.BuildTrigger{
+			Kind:                   domain.BuildTriggerKindArtifact,
+			ProducerProjectID:      &producerProjectID,
+			ProducerBuildID:        &producerBuildID,
+			ArtifactID:             &artifactID,
+			ArtifactPath:           &artifactPath,
+			ArtifactChecksumSHA256: &wrongChecksum,
+		},
+	}}
+	artifactRepo := &fakeArtifactRepository{artifacts: map[string][]domain.BuildArtifact{
+		producerBuildID: {{
+			ID:              artifactID,
+			BuildID:         producerBuildID,
+			LogicalPath:     artifactPath,
+			StorageKey:      "producer/dist/app.tgz",
+			StorageProvider: domain.StorageProviderFilesystem,
+		}},
+	}}
+
+	svc := NewBuildService(repo, nil, &fakeLogSink{})
+	svc.SetArtifactPersistence(artifactRepo, testStoreResolver(store), workspaceRoot)
+
+	build, prepErr := svc.PrepareBuildExecution(ctx, "build-downstream")
+	if prepErr != nil {
+		t.Fatalf("expected build failure without hard error, got %v", prepErr)
+	}
+	if build.Status != domain.BuildStatusFailed {
+		t.Fatalf("expected failed build on checksum mismatch, got %q", build.Status)
+	}
+	if build.ErrorMessage == nil || !strings.Contains(*build.ErrorMessage, "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch error, got %v", build.ErrorMessage)
+	}
+}
+
+func TestPrepareBuildExecution_FailsBuildWhenTriggerProducerProjectMismatches(t *testing.T) {
+	producerProjectID := "project-1"
+	producerBuildID := "build-upstream"
+	artifactID := "artifact-1"
+	artifactPath := "dist/app.tgz"
+	repo := &fakeBuildRepository{build: domain.Build{
+		ID:        "build-downstream",
+		ProjectID: "project-2",
+		Status:    domain.BuildStatusQueued,
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: &producerProjectID,
+			ProducerBuildID:   &producerBuildID,
+			ArtifactID:        &artifactID,
+			ArtifactPath:      &artifactPath,
+		},
+	}}
+
+	svc := NewBuildService(repo, nil, &fakeLogSink{})
+	svc.SetArtifactPersistence(&fakeArtifactRepository{}, testStoreResolver(artifact.NewFilesystemStore(t.TempDir())), t.TempDir())
+
+	build, prepErr := svc.PrepareBuildExecution(context.Background(), "build-downstream")
+	if prepErr != nil {
+		t.Fatalf("expected build failure without hard error, got %v", prepErr)
+	}
+	if build.Status != domain.BuildStatusFailed {
+		t.Fatalf("expected failed build on producer project mismatch, got %q", build.Status)
+	}
+	if build.ErrorMessage == nil || !strings.Contains(*build.ErrorMessage, "producer project mismatch") {
+		t.Fatalf("expected producer project mismatch error, got %v", build.ErrorMessage)
 	}
 }

--- a/backend/internal/service/build/service_execution_test.go
+++ b/backend/internal/service/build/service_execution_test.go
@@ -7,6 +7,8 @@ package build
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
@@ -641,6 +643,105 @@ func TestBuildService_RunStep_InprocessRunner_PersistsArtifactsToStorageRoot(t *
 		if _, statErr := os.Stat(storagePath); statErr != nil {
 			t.Fatalf("expected persisted artifact at %s (logical=%s), stat failed: %v", storagePath, a.LogicalPath, statErr)
 		}
+	}
+}
+
+func TestBuildService_RunStep_InprocessRunner_ReadsTriggerArtifactFromInjectedLocalPath(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	body := []byte("artifact-body")
+	checksumBytes := sha256.Sum256(body)
+	checksum := hex.EncodeToString(checksumBytes[:])
+	store := artifact.NewFilesystemStore(storageRoot)
+	if _, saveErr := store.Save(ctx, "producer/dist/app.tgz", strings.NewReader(string(body))); saveErr != nil {
+		t.Fatalf("seed artifact store: %v", saveErr)
+	}
+
+	projectID := "project-1"
+	producerBuildID := "build-upstream"
+	downstreamBuildID := "build-downstream"
+	artifactID := "artifact-1"
+	artifactPath := "dist/app.tgz"
+	claimToken := "claim-active"
+
+	repo := &fakeBuildRepository{
+		build: domain.Build{
+			ID:        downstreamBuildID,
+			ProjectID: projectID,
+			Status:    domain.BuildStatusQueued,
+			Trigger: domain.BuildTrigger{
+				Kind:                   domain.BuildTriggerKindArtifact,
+				ProducerProjectID:      &projectID,
+				ProducerBuildID:        &producerBuildID,
+				ArtifactID:             &artifactID,
+				ArtifactPath:           &artifactPath,
+				ArtifactChecksumSHA256: &checksum,
+			},
+		},
+		steps: []domain.BuildStep{{StepIndex: 0, Name: "consume", Status: domain.BuildStepStatusRunning, ClaimToken: &claimToken}},
+	}
+	artifactRepo := &fakeArtifactRepository{artifacts: map[string][]domain.BuildArtifact{
+		producerBuildID: {{
+			ID:              artifactID,
+			BuildID:         producerBuildID,
+			LogicalPath:     artifactPath,
+			StorageKey:      "producer/dist/app.tgz",
+			StorageProvider: domain.StorageProviderFilesystem,
+			SizeBytes:       int64(len(body)),
+			ChecksumSHA256:  &checksum,
+		}},
+	}}
+
+	svc := NewBuildService(repo, inprocessrunner.NewWithWorkspaceRoot(workspaceRoot), &fakeLogSink{})
+	svc.SetArtifactPersistence(artifactRepo, testStoreResolver(store), workspaceRoot)
+
+	preparedBuild, prepErr := svc.PrepareBuildExecution(ctx, downstreamBuildID)
+	if prepErr != nil {
+		t.Fatalf("prepare build execution: %v", prepErr)
+	}
+	if preparedBuild.Status != domain.BuildStatusRunning {
+		t.Fatalf("expected running build after prep, got %q", preparedBuild.Status)
+	}
+
+	result, report, runErr := svc.RunStep(ctx, steprunner.RunStepRequest{
+		BuildID:    downstreamBuildID,
+		StepIndex:  0,
+		StepName:   "consume",
+		ClaimToken: claimToken,
+		WorkingDir: ".",
+		Command:    "sh",
+		Args: []string{
+			"-c",
+			`printf '%s\n%s\n%s\n' "$COYOTE_TRIGGER_ARTIFACT_LOCAL_PATH" "$COYOTE_TRIGGER_ARTIFACT_LOCAL_DIR" "$COYOTE_TRIGGER_ARTIFACT_LOCAL_RELATIVE_PATH" && cat "$COYOTE_TRIGGER_ARTIFACT_LOCAL_PATH"`,
+		},
+	})
+	if runErr != nil {
+		t.Fatalf("run step failed: %v", runErr)
+	}
+	if report.CompletionOutcome != repository.StepCompletionCompleted {
+		t.Fatalf("expected completed outcome, got %q", report.CompletionOutcome)
+	}
+	if report.SideEffectErr != nil {
+		t.Fatalf("expected nil side effect error, got %v", report.SideEffectErr)
+	}
+	if result.Status != steprunner.RunStepStatusSuccess {
+		t.Fatalf("expected successful result, got %q", result.Status)
+	}
+
+	expectedLocalDir := filepath.Join(workspaceRoot, downstreamBuildID, ".coyote", "trigger-artifacts")
+	expectedLocalPath := filepath.Join(expectedLocalDir, "dist", "app.tgz")
+	if !strings.Contains(result.Stdout, expectedLocalPath) {
+		t.Fatalf("expected stdout to include trigger artifact local path %q, got %q", expectedLocalPath, result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, expectedLocalDir) {
+		t.Fatalf("expected stdout to include trigger artifact local dir %q, got %q", expectedLocalDir, result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, ".coyote/trigger-artifacts/dist/app.tgz") {
+		t.Fatalf("expected stdout to include trigger artifact relative path, got %q", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, string(body)) {
+		t.Fatalf("expected stdout to include handed off artifact body %q, got %q", string(body), result.Stdout)
 	}
 }
 

--- a/backend/internal/service/build/source.go
+++ b/backend/internal/service/build/source.go
@@ -252,6 +252,21 @@ func (s *BuildService) PrepareBuildExecution(ctx context.Context, id string) (do
 		}
 		s.emitBuildPreparationLog(ctx, buildID, "Source checkout complete")
 	}
+	if domain.NormalizeBuildTrigger(build.Trigger).Kind == domain.BuildTriggerKindArtifact {
+		s.emitBuildPreparationLog(ctx, buildID, "Preparing trigger artifact handoff")
+		if handoffErr := s.prepareTriggerArtifactHandoff(ctx, build); handoffErr != nil {
+			s.emitBuildPreparationLog(ctx, buildID, "Trigger artifact handoff failed")
+			s.emitBuildPreparationLog(ctx, buildID, formatFailureReasonLine(handoffErr.Error()))
+			message := handoffErr.Error()
+			failed, updateErr := s.persistBuildStatus(ctx, buildID, domain.BuildStatusFailed, &message)
+			if updateErr != nil {
+				return domain.Build{}, mapRepoErr(updateErr)
+			}
+			log.Printf("build preparation failed: build_id=%s duration_ms=%d reason=%q", buildID, time.Since(prepStartedAt).Milliseconds(), handoffErr.Error())
+			return failed, nil
+		}
+		s.emitBuildPreparationLog(ctx, buildID, "Trigger artifact handoff complete")
+	}
 	s.emitBuildPreparationLog(ctx, buildID, "Build workspace ready")
 
 	runningBuild, transitionErr := s.transitionBuildStatus(ctx, buildID, domain.BuildStatusRunning, nil)

--- a/backend/internal/service/build/trigger_handoff.go
+++ b/backend/internal/service/build/trigger_handoff.go
@@ -1,0 +1,128 @@
+package build
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/workspace"
+)
+
+func readOptionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func (s *BuildService) prepareTriggerArtifactHandoff(ctx context.Context, build domain.Build) error {
+	trigger := domain.NormalizeBuildTrigger(build.Trigger)
+	if trigger.Kind != domain.BuildTriggerKindArtifact {
+		return nil
+	}
+
+	producerProjectID := readOptionalString(trigger.ProducerProjectID)
+	if producerProjectID == "" {
+		return fmt.Errorf("artifact trigger producer project id is required")
+	}
+	if strings.TrimSpace(build.ProjectID) == "" {
+		return fmt.Errorf("build project id is required")
+	}
+	if producerProjectID != strings.TrimSpace(build.ProjectID) {
+		return fmt.Errorf("artifact trigger producer project mismatch")
+	}
+
+	producerBuildID := readOptionalString(trigger.ProducerBuildID)
+	artifactID := readOptionalString(trigger.ArtifactID)
+	artifactPath := readOptionalString(trigger.ArtifactPath)
+	if producerBuildID == "" || artifactID == "" || artifactPath == "" {
+		return fmt.Errorf("artifact trigger provenance is incomplete")
+	}
+
+	relativePath, err := workspace.TriggerArtifactRelativePath(artifactPath)
+	if err != nil {
+		return fmt.Errorf("invalid trigger artifact path: %w", err)
+	}
+
+	workspaceRoot := s.currentWorkspaceRoot()
+	if workspaceRoot == "" {
+		return ErrExecutionWorkspaceRootNotConfigured
+	}
+	buildWorkspace := workspace.New(build.ID, filepath.Join(workspaceRoot, strings.TrimSpace(build.ID)))
+	destinationPath, err := buildWorkspace.ResolveRelativePath(relativePath)
+	if err != nil {
+		return fmt.Errorf("resolve trigger artifact handoff path: %w", err)
+	}
+	if _, statErr := os.Stat(destinationPath); statErr == nil {
+		return fmt.Errorf("trigger artifact handoff path already exists: %s", relativePath)
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("stat trigger artifact handoff path: %w", statErr)
+	}
+
+	meta, reader, err := s.OpenBuildArtifact(ctx, producerBuildID, artifactID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	if strings.TrimSpace(meta.LogicalPath) != artifactPath {
+		return fmt.Errorf("trigger artifact path mismatch: expected %s, got %s", artifactPath, strings.TrimSpace(meta.LogicalPath))
+	}
+
+	expectedChecksum := readOptionalString(trigger.ArtifactChecksumSHA256)
+	if expectedChecksum == "" {
+		expectedChecksum = readOptionalString(meta.ChecksumSHA256)
+	}
+	if err := copyTriggerArtifactToWorkspace(destinationPath, reader, expectedChecksum); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyTriggerArtifactToWorkspace(destinationPath string, src io.Reader, expectedChecksum string) error {
+	if mkdirErr := os.MkdirAll(filepath.Dir(destinationPath), 0o755); mkdirErr != nil {
+		return fmt.Errorf("creating trigger artifact directory: %w", mkdirErr)
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(destinationPath), ".trigger-artifact-*")
+	if err != nil {
+		return fmt.Errorf("creating trigger artifact temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmpFile, hasher), src); err != nil {
+		return fmt.Errorf("writing trigger artifact content: %w", err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return fmt.Errorf("syncing trigger artifact content: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("closing trigger artifact temp file: %w", err)
+	}
+
+	trimmedExpected := strings.TrimSpace(expectedChecksum)
+	if trimmedExpected != "" {
+		actualChecksum := hex.EncodeToString(hasher.Sum(nil))
+		if !strings.EqualFold(actualChecksum, trimmedExpected) {
+			return fmt.Errorf("trigger artifact checksum mismatch: expected %s, got %s", trimmedExpected, actualChecksum)
+		}
+	}
+
+	if err := os.Rename(tmpPath, destinationPath); err != nil {
+		return fmt.Errorf("moving trigger artifact into place: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/service/build/trigger_handoff.go
+++ b/backend/internal/service/build/trigger_handoff.go
@@ -73,26 +73,36 @@ func (s *BuildService) prepareTriggerArtifactHandoff(ctx context.Context, build 
 		_ = reader.Close()
 	}()
 	if strings.TrimSpace(meta.LogicalPath) != artifactPath {
-		return fmt.Errorf("trigger artifact path mismatch: expected %s, got %s", artifactPath, strings.TrimSpace(meta.LogicalPath))
+		return fmt.Errorf("trigger artifact path mismatch: expected %q, got %q", artifactPath, strings.TrimSpace(meta.LogicalPath))
 	}
 
 	expectedChecksum := readOptionalString(trigger.ArtifactChecksumSHA256)
 	if expectedChecksum == "" {
 		expectedChecksum = readOptionalString(meta.ChecksumSHA256)
 	}
-	if err := copyTriggerArtifactToWorkspace(destinationPath, reader, expectedChecksum); err != nil {
+	if err := copyTriggerArtifactToWorkspace(buildWorkspace.HostRoot, destinationPath, reader, expectedChecksum); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func copyTriggerArtifactToWorkspace(destinationPath string, src io.Reader, expectedChecksum string) error {
-	if mkdirErr := os.MkdirAll(filepath.Dir(destinationPath), 0o755); mkdirErr != nil {
+func copyTriggerArtifactToWorkspace(workspaceRoot string, destinationPath string, src io.Reader, expectedChecksum string) error {
+	if mkdirErr := os.MkdirAll(workspaceRoot, 0o755); mkdirErr != nil {
+		return fmt.Errorf("creating build workspace root: %w", mkdirErr)
+	}
+	destinationDir := filepath.Dir(destinationPath)
+	if err := ensurePathUsesWorkspaceRoot(workspaceRoot, destinationDir); err != nil {
+		return err
+	}
+	if mkdirErr := os.MkdirAll(destinationDir, 0o755); mkdirErr != nil {
 		return fmt.Errorf("creating trigger artifact directory: %w", mkdirErr)
 	}
+	if err := ensurePathUsesWorkspaceRoot(workspaceRoot, destinationDir); err != nil {
+		return err
+	}
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(destinationPath), ".trigger-artifact-*")
+	tmpFile, err := os.CreateTemp(destinationDir, ".trigger-artifact-*")
 	if err != nil {
 		return fmt.Errorf("creating trigger artifact temp file: %w", err)
 	}
@@ -125,4 +135,51 @@ func copyTriggerArtifactToWorkspace(destinationPath string, src io.Reader, expec
 		return fmt.Errorf("moving trigger artifact into place: %w", err)
 	}
 	return nil
+}
+
+func ensurePathUsesWorkspaceRoot(workspaceRoot string, targetPath string) error {
+	trimmedRoot := strings.TrimSpace(workspaceRoot)
+	if trimmedRoot == "" {
+		return fmt.Errorf("workspace root is required")
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(filepath.Clean(trimmedRoot))
+	if err != nil {
+		return fmt.Errorf("resolve workspace root: %w", err)
+	}
+
+	resolvedTarget, err := resolveExistingPathWithinTarget(targetPath)
+	if err != nil {
+		return err
+	}
+
+	rel, err := filepath.Rel(resolvedRoot, resolvedTarget)
+	if err != nil {
+		return fmt.Errorf("compare trigger artifact path against workspace root: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("trigger artifact handoff path escapes workspace root")
+	}
+	return nil
+}
+
+func resolveExistingPathWithinTarget(targetPath string) (string, error) {
+	current := filepath.Clean(targetPath)
+	for {
+		_, statErr := os.Lstat(current)
+		if statErr == nil {
+			resolvedPath, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", fmt.Errorf("resolve trigger artifact path: %w", err)
+			}
+			return resolvedPath, nil
+		}
+		if !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("stat trigger artifact path: %w", statErr)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("resolve trigger artifact path: no existing ancestor for %q", targetPath)
+		}
+		current = parent
+	}
 }

--- a/backend/internal/service/build/trigger_handoff_test.go
+++ b/backend/internal/service/build/trigger_handoff_test.go
@@ -1,0 +1,266 @@
+package build
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/radiation/coyote-ci/backend/internal/artifact"
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+)
+
+func TestReadOptionalString(t *testing.T) {
+	if got := readOptionalString(nil); got != "" {
+		t.Fatalf("expected empty string for nil pointer, got %q", got)
+	}
+	value := " value "
+	if got := readOptionalString(&value); got != "value" {
+		t.Fatalf("expected trimmed string, got %q", got)
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_NonArtifactNoop(t *testing.T) {
+	svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+	if err := svc.prepareTriggerArtifactHandoff(context.Background(), domain.Build{Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}); err != nil {
+		t.Fatalf("expected non-artifact trigger to no-op, got %v", err)
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   domain.Build
+		wantErr string
+	}{
+		{
+			name: "missing producer project",
+			build: domain.Build{ProjectID: "project-1", Trigger: domain.BuildTrigger{
+				Kind: domain.BuildTriggerKindArtifact,
+			}},
+			wantErr: "producer project id is required",
+		},
+		{
+			name: "missing build project",
+			build: domain.Build{Trigger: domain.BuildTrigger{
+				Kind:              domain.BuildTriggerKindArtifact,
+				ProducerProjectID: testStringPtr("project-1"),
+			}},
+			wantErr: "build project id is required",
+		},
+		{
+			name: "incomplete provenance",
+			build: domain.Build{ProjectID: "project-1", Trigger: domain.BuildTrigger{
+				Kind:              domain.BuildTriggerKindArtifact,
+				ProducerProjectID: testStringPtr("project-1"),
+			}},
+			wantErr: "provenance is incomplete",
+		},
+		{
+			name: "invalid artifact path",
+			build: domain.Build{ProjectID: "project-1", Trigger: domain.BuildTrigger{
+				Kind:              domain.BuildTriggerKindArtifact,
+				ProducerProjectID: testStringPtr("project-1"),
+				ProducerBuildID:   testStringPtr("build-upstream"),
+				ArtifactID:        testStringPtr("artifact-1"),
+				ArtifactPath:      testStringPtr("../secret.txt"),
+			}},
+			wantErr: "invalid trigger artifact path",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+			err := svc.prepareTriggerArtifactHandoff(context.Background(), tc.build)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_RequiresWorkspaceRoot(t *testing.T) {
+	svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+	err := svc.prepareTriggerArtifactHandoff(context.Background(), domain.Build{
+		ID:        "build-downstream",
+		ProjectID: "project-1",
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: testStringPtr("project-1"),
+			ProducerBuildID:   testStringPtr("build-upstream"),
+			ArtifactID:        testStringPtr("artifact-1"),
+			ArtifactPath:      testStringPtr("dist/app.tgz"),
+		},
+	})
+	if !errors.Is(err, ErrExecutionWorkspaceRootNotConfigured) {
+		t.Fatalf("expected workspace root error, got %v", err)
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_DestinationAlreadyExists(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	destination := filepath.Join(workspaceRoot, "build-downstream", ".coyote", "trigger-artifacts", "dist")
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		t.Fatalf("mkdir destination: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destination, "app.tgz"), []byte("already"), 0o644); err != nil {
+		t.Fatalf("seed existing handoff file: %v", err)
+	}
+
+	svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+	svc.SetExecutionWorkspaceRoot(workspaceRoot)
+	err := svc.prepareTriggerArtifactHandoff(context.Background(), domain.Build{
+		ID:        "build-downstream",
+		ProjectID: "project-1",
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: testStringPtr("project-1"),
+			ProducerBuildID:   testStringPtr("build-upstream"),
+			ArtifactID:        testStringPtr("artifact-1"),
+			ArtifactPath:      testStringPtr("dist/app.tgz"),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected existing destination error, got %v", err)
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_PathMismatch(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	store := artifact.NewFilesystemStore(storageRoot)
+	if _, err := store.Save(ctx, "producer/dist/app.tgz", strings.NewReader("artifact-body")); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	artifactRepo := &fakeArtifactRepository{artifacts: map[string][]domain.BuildArtifact{
+		"build-upstream": {{
+			ID:              "artifact-1",
+			BuildID:         "build-upstream",
+			LogicalPath:     "dist/other.tgz",
+			StorageKey:      "producer/dist/app.tgz",
+			StorageProvider: domain.StorageProviderFilesystem,
+		}},
+	}}
+	svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+	svc.SetExecutionWorkspaceRoot(workspaceRoot)
+	svc.SetArtifactPersistence(artifactRepo, testStoreResolver(store), workspaceRoot)
+	err := svc.prepareTriggerArtifactHandoff(ctx, domain.Build{
+		ID:        "build-downstream",
+		ProjectID: "project-1",
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: testStringPtr("project-1"),
+			ProducerBuildID:   testStringPtr("build-upstream"),
+			ArtifactID:        testStringPtr("artifact-1"),
+			ArtifactPath:      testStringPtr("dist/app.tgz"),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "path mismatch") {
+		t.Fatalf("expected path mismatch error, got %v", err)
+	}
+}
+
+func TestPrepareTriggerArtifactHandoff_UsesMetadataChecksumFallback(t *testing.T) {
+	ctx := context.Background()
+	workspaceRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	body := []byte("artifact-body")
+	sum := sha256.Sum256(body)
+	checksum := hex.EncodeToString(sum[:])
+	store := artifact.NewFilesystemStore(storageRoot)
+	if _, err := store.Save(ctx, "producer/dist/app.tgz", strings.NewReader(string(body))); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	artifactRepo := &fakeArtifactRepository{artifacts: map[string][]domain.BuildArtifact{
+		"build-upstream": {{
+			ID:              "artifact-1",
+			BuildID:         "build-upstream",
+			LogicalPath:     "dist/app.tgz",
+			StorageKey:      "producer/dist/app.tgz",
+			StorageProvider: domain.StorageProviderFilesystem,
+			ChecksumSHA256:  &checksum,
+		}},
+	}}
+	svc := NewBuildService(&fakeBuildRepository{}, nil, nil)
+	svc.SetExecutionWorkspaceRoot(workspaceRoot)
+	svc.SetArtifactPersistence(artifactRepo, testStoreResolver(store), workspaceRoot)
+	err := svc.prepareTriggerArtifactHandoff(ctx, domain.Build{
+		ID:        "build-downstream",
+		ProjectID: "project-1",
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: testStringPtr("project-1"),
+			ProducerBuildID:   testStringPtr("build-upstream"),
+			ArtifactID:        testStringPtr("artifact-1"),
+			ArtifactPath:      testStringPtr("dist/app.tgz"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected checksum fallback success, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workspaceRoot, "build-downstream", ".coyote", "trigger-artifacts", "dist", "app.tgz")); statErr != nil {
+		t.Fatalf("expected handed off file, stat failed: %v", statErr)
+	}
+}
+
+func TestCopyTriggerArtifactToWorkspace_NoChecksumSuccess(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	destination := filepath.Join(workspaceRoot, "dist", "app.tgz")
+	if err := copyTriggerArtifactToWorkspace(workspaceRoot, destination, strings.NewReader("artifact-body"), ""); err != nil {
+		t.Fatalf("expected copy success without checksum, got %v", err)
+	}
+	body, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(body) != "artifact-body" {
+		t.Fatalf("unexpected destination body %q", string(body))
+	}
+}
+
+func TestCopyTriggerArtifactToWorkspace_CopyFailure(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	err := copyTriggerArtifactToWorkspace(workspaceRoot, filepath.Join(workspaceRoot, "dist", "app.tgz"), failingReader{err: errors.New("read failed")}, "")
+	if err == nil || !strings.Contains(err.Error(), "writing trigger artifact content") {
+		t.Fatalf("expected copy failure, got %v", err)
+	}
+}
+
+func TestCopyTriggerArtifactToWorkspace_RejectsSymlinkTraversal(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "build"), 0o755); err != nil {
+		t.Fatalf("mkdir build workspace: %v", err)
+	}
+	linkPath := filepath.Join(workspaceRoot, "build", ".coyote")
+	if err := os.Symlink(outsideRoot, linkPath); err != nil {
+		t.Fatalf("create .coyote symlink: %v", err)
+	}
+	destination := filepath.Join(workspaceRoot, "build", ".coyote", "trigger-artifacts", "dist", "app.tgz")
+	err := copyTriggerArtifactToWorkspace(filepath.Join(workspaceRoot, "build"), destination, strings.NewReader("artifact-body"), "")
+	if err == nil || !strings.Contains(err.Error(), "escapes workspace root") {
+		t.Fatalf("expected symlink traversal rejection, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outsideRoot, "trigger-artifacts")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no writes outside workspace, got stat err=%v", statErr)
+	}
+}
+
+type failingReader struct{ err error }
+
+func (f failingReader) Read(_ []byte) (int, error) {
+	return 0, f.err
+}
+
+func testStringPtr(value string) *string {
+	return &value
+}
+
+var _ io.Reader = failingReader{}

--- a/backend/internal/service/execution/components_test.go
+++ b/backend/internal/service/execution/components_test.go
@@ -296,6 +296,44 @@ func TestExecutionLogOutput_ClassifiesFailuresAndWritesOutput(t *testing.T) {
 	}
 }
 
+func TestExecutionLogManager_EmitExecutionStart_UsesWorkspaceEnvAndFallback(t *testing.T) {
+	logSink := &recordingLogSink{}
+	executionContext := testExecutionContext(nil)
+	executionContext.Build.StartedAt = nil
+	executionContext.ExecutionRequest.Env = map[string]string{runner.EnvWorkspace: "/tmp/build-1"}
+	logManager := NewExecutionLogManager(logSink, executionContext)
+	logManager.EmitExecutionStart(context.Background())
+	if len(logSink.lines) == 0 || logSink.lines[2] != "Workspace: /tmp/build-1" {
+		t.Fatalf("expected workspace line from env, got %#v", logSink.lines)
+	}
+
+	fallbackSink := &recordingLogSink{}
+	fallbackContext := testExecutionContext(nil)
+	fallbackContext.Build.StartedAt = nil
+	fallbackContext.ExecutionRequest.Env = map[string]string{}
+	NewExecutionLogManager(fallbackSink, fallbackContext).EmitExecutionStart(context.Background())
+	if len(fallbackSink.lines) == 0 || fallbackSink.lines[2] != "Workspace: /workspace" {
+		t.Fatalf("expected fallback workspace line, got %#v", fallbackSink.lines)
+	}
+}
+
+func TestExecutionLogManager_PersistRunnerChunk_NoAppenderAndApplyBufferedErrors(t *testing.T) {
+	ctx := context.Background()
+	logSink := &recordingLogSink{writeErr: errors.New("write failed")}
+	executionContext := testExecutionContext(nil)
+	executionContext.ExecutionRequest.Env = map[string]string{}
+	manager := NewExecutionLogManager(logSink, executionContext)
+	if err := manager.PersistRunnerChunk(ctx, runner.StepOutputChunk{Stream: runner.StepOutputStreamStdout, ChunkText: "output"}); err != nil {
+		t.Fatalf("expected no error when no appender is present, got %v", err)
+	}
+	manager.EmitSystemLine(ctx, "system line")
+	report := &StepCompletionReport{}
+	manager.ApplyBufferedErrors(report)
+	if !errors.Is(report.SideEffectErr, logSink.writeErr) {
+		t.Fatalf("expected buffered visibility error in report, got %v", report.SideEffectErr)
+	}
+}
+
 func TestSourceSpecFromBuild_PrefersSnapshotAndFallsBackToLegacyFields(t *testing.T) {
 	sourceRef := " main "
 	sourceCommit := " abc123 "

--- a/backend/internal/service/execution/log_manager.go
+++ b/backend/internal/service/execution/log_manager.go
@@ -50,7 +50,11 @@ func (m *ExecutionLogManager) EmitSystemLines(ctx context.Context, lines []strin
 
 func (m *ExecutionLogManager) EmitExecutionStart(ctx context.Context) {
 	if m.executionContext.StepNumber == 1 && (m.executionContext.Build.StartedAt == nil || m.executionContext.Build.StartedAt.IsZero()) {
-		m.EmitSystemLines(ctx, formatBuildStartLines(m.executionContext.ExecutionImage, workspace.DefaultContainerRoot, m.executionContext.TotalSteps))
+		workspacePath := strings.TrimSpace(m.executionContext.ExecutionRequest.Env[runner.EnvWorkspace])
+		if workspacePath == "" {
+			workspacePath = workspace.DefaultContainerRoot
+		}
+		m.EmitSystemLines(ctx, formatBuildStartLines(m.executionContext.ExecutionImage, workspacePath, m.executionContext.TotalSteps))
 	}
 	if m.executionContext.StepNumber == 1 {
 		m.EmitSystemLine(ctx, "Executing pipeline steps")

--- a/backend/internal/workspace/workspace.go
+++ b/backend/internal/workspace/workspace.go
@@ -8,6 +8,7 @@ import (
 )
 
 const DefaultContainerRoot = "/workspace"
+const TriggerArtifactsRelativeRoot = ".coyote/trigger-artifacts"
 
 // Workspace defines the host/container path contract for one build workspace.
 type Workspace struct {
@@ -61,10 +62,83 @@ func (w Workspace) ContainerWorkingDir(requested string) string {
 	return containerRoot
 }
 
+func TriggerArtifactRelativePath(logicalPath string) (string, error) {
+	trimmed := strings.TrimSpace(logicalPath)
+	if trimmed == "" {
+		return "", fmt.Errorf("trigger artifact path is required")
+	}
+	if looksLikeWindowsDrivePath(trimmed) {
+		return "", fmt.Errorf("trigger artifact path must be workspace-relative")
+	}
+
+	validator := New("", "")
+	if err := validator.ValidateArtifactPath(trimmed); err != nil {
+		return "", err
+	}
+
+	cleanRel := path.Clean(strings.ReplaceAll(trimmed, "\\", "/"))
+	return path.Clean(path.Join(TriggerArtifactsRelativeRoot, cleanRel)), nil
+}
+
+func ResolveVisiblePath(workspaceRoot string, relativePath string) string {
+	trimmedRoot := strings.TrimSpace(workspaceRoot)
+	if trimmedRoot == "" {
+		return ""
+	}
+	trimmedRel := strings.TrimSpace(relativePath)
+	if trimmedRel == "" || trimmedRel == "." {
+		if isContainerWorkspaceRoot(trimmedRoot) {
+			return path.Clean(trimmedRoot)
+		}
+		return filepath.Clean(trimmedRoot)
+	}
+
+	cleanRel := path.Clean(strings.ReplaceAll(trimmedRel, "\\", "/"))
+	if isContainerWorkspaceRoot(trimmedRoot) {
+		return path.Join(trimmedRoot, cleanRel)
+	}
+	return filepath.Join(filepath.Clean(trimmedRoot), filepath.FromSlash(cleanRel))
+}
+
+func ResolveVisibleWorkingDir(workspaceRoot string, requested string) string {
+	trimmedRoot := strings.TrimSpace(workspaceRoot)
+	if trimmedRoot == "" {
+		trimmedRoot = DefaultContainerRoot
+	}
+	if isContainerWorkspaceRoot(trimmedRoot) {
+		ws := Workspace{ContainerRoot: trimmedRoot}
+		return ws.ContainerWorkingDir(requested)
+	}
+
+	hostRoot := filepath.Clean(trimmedRoot)
+	ws := Workspace{HostRoot: hostRoot}
+	trimmedRequested := strings.TrimSpace(requested)
+	if trimmedRequested == "" || trimmedRequested == "." {
+		return hostRoot
+	}
+	if filepath.IsAbs(trimmedRequested) || looksLikeWindowsDrivePath(trimmedRequested) {
+		resolved := filepath.Clean(trimmedRequested)
+		relCheck, err := filepath.Rel(hostRoot, resolved)
+		if err == nil && relCheck != ".." && !strings.HasPrefix(relCheck, ".."+string(filepath.Separator)) {
+			return resolved
+		}
+		return hostRoot
+	}
+
+	resolved, err := ws.ResolveRelativePath(trimmedRequested)
+	if err != nil {
+		return hostRoot
+	}
+	return resolved
+}
+
 func (w Workspace) ValidateArtifactPath(rel string) error {
 	trimmed := strings.TrimSpace(rel)
 	if trimmed == "" {
 		return fmt.Errorf("artifact path is required")
+	}
+	if looksLikeWindowsDrivePath(trimmed) {
+		return fmt.Errorf("artifact path must be workspace-relative")
 	}
 
 	normalized := strings.ReplaceAll(trimmed, "\\", "/")
@@ -107,4 +181,17 @@ func (w Workspace) ResolveRelativePath(rel string) (string, error) {
 	}
 
 	return resolved, nil
+}
+
+func looksLikeWindowsDrivePath(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 2 || trimmed[1] != ':' {
+		return false
+	}
+	first := trimmed[0]
+	return (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z')
+}
+
+func isContainerWorkspaceRoot(root string) bool {
+	return path.Clean(strings.ReplaceAll(strings.TrimSpace(root), "\\", "/")) == DefaultContainerRoot
 }

--- a/backend/internal/workspace/workspace.go
+++ b/backend/internal/workspace/workspace.go
@@ -85,19 +85,28 @@ func ResolveVisiblePath(workspaceRoot string, relativePath string) string {
 	if trimmedRoot == "" {
 		return ""
 	}
+	cleanRoot := filepath.Clean(trimmedRoot)
+	containerRoot := path.Clean(trimmedRoot)
 	trimmedRel := strings.TrimSpace(relativePath)
 	if trimmedRel == "" || trimmedRel == "." {
 		if isContainerWorkspaceRoot(trimmedRoot) {
-			return path.Clean(trimmedRoot)
+			return containerRoot
 		}
-		return filepath.Clean(trimmedRoot)
+		return cleanRoot
+	}
+
+	if err := (Workspace{}).ValidateArtifactPath(trimmedRel); err != nil {
+		if isContainerWorkspaceRoot(trimmedRoot) {
+			return containerRoot
+		}
+		return cleanRoot
 	}
 
 	cleanRel := path.Clean(strings.ReplaceAll(trimmedRel, "\\", "/"))
 	if isContainerWorkspaceRoot(trimmedRoot) {
 		return path.Join(trimmedRoot, cleanRel)
 	}
-	return filepath.Join(filepath.Clean(trimmedRoot), filepath.FromSlash(cleanRel))
+	return filepath.Join(cleanRoot, filepath.FromSlash(cleanRel))
 }
 
 func ResolveVisibleWorkingDir(workspaceRoot string, requested string) string {

--- a/backend/internal/workspace/workspace_test.go
+++ b/backend/internal/workspace/workspace_test.go
@@ -85,3 +85,33 @@ func TestWorkspace_ResolveRelativePath_EmptyHostRootErrors(t *testing.T) {
 		t.Fatal("expected resolve to fail when host root is empty")
 	}
 }
+
+func TestTriggerArtifactRelativePath(t *testing.T) {
+	relativePath, err := TriggerArtifactRelativePath("dist/app.tar.gz")
+	if err != nil {
+		t.Fatalf("expected valid trigger artifact path, got %v", err)
+	}
+	if relativePath != ".coyote/trigger-artifacts/dist/app.tar.gz" {
+		t.Fatalf("unexpected relative handoff path %q", relativePath)
+	}
+
+	invalid := []string{"../secret.txt", "/tmp/secret.txt", `C:\\temp\\secret.txt`}
+	for _, item := range invalid {
+		if _, err := TriggerArtifactRelativePath(item); err == nil {
+			t.Fatalf("expected invalid trigger artifact path %q to fail", item)
+		}
+	}
+}
+
+func TestResolveVisibleWorkingDir_LocalWorkspace(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	resolved := ResolveVisibleWorkingDir(workspaceRoot, "backend")
+	want := filepath.Join(workspaceRoot, "backend")
+	if resolved != want {
+		t.Fatalf("expected %q, got %q", want, resolved)
+	}
+
+	if got := ResolveVisibleWorkingDir(workspaceRoot, "../../etc"); got != workspaceRoot {
+		t.Fatalf("expected escape attempt to clamp to workspace root, got %q", got)
+	}
+}

--- a/backend/internal/workspace/workspace_test.go
+++ b/backend/internal/workspace/workspace_test.go
@@ -103,6 +103,34 @@ func TestTriggerArtifactRelativePath(t *testing.T) {
 	}
 }
 
+func TestResolveVisiblePath(t *testing.T) {
+	if got := ResolveVisiblePath("", "dist/app.tgz"); got != "" {
+		t.Fatalf("expected empty path when workspace root is empty, got %q", got)
+	}
+	if got := ResolveVisiblePath("/workspace", ""); got != "/workspace" {
+		t.Fatalf("expected container workspace root, got %q", got)
+	}
+	if got := ResolveVisiblePath("/workspace", ".coyote/trigger-artifacts/dist/app.tgz"); got != "/workspace/.coyote/trigger-artifacts/dist/app.tgz" {
+		t.Fatalf("unexpected container visible path %q", got)
+	}
+	root := t.TempDir()
+	if got := ResolveVisiblePath(root, ".coyote/trigger-artifacts/dist/app.tgz"); got != filepath.Join(root, ".coyote", "trigger-artifacts", "dist", "app.tgz") {
+		t.Fatalf("unexpected local visible path %q", got)
+	}
+	if got := ResolveVisiblePath("/workspace", "../etc"); got != "/workspace" {
+		t.Fatalf("expected container traversal to clamp to workspace root, got %q", got)
+	}
+	if got := ResolveVisiblePath(root, "../etc"); got != filepath.Clean(root) {
+		t.Fatalf("expected local traversal to clamp to workspace root, got %q", got)
+	}
+	if got := ResolveVisiblePath("/workspace", "/etc/passwd"); got != "/workspace" {
+		t.Fatalf("expected container absolute path to clamp to workspace root, got %q", got)
+	}
+	if got := ResolveVisiblePath(root, `C:\\temp\\bad`); got != filepath.Clean(root) {
+		t.Fatalf("expected windows-style path to clamp to workspace root, got %q", got)
+	}
+}
+
 func TestResolveVisibleWorkingDir_LocalWorkspace(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	resolved := ResolveVisibleWorkingDir(workspaceRoot, "backend")
@@ -113,5 +141,22 @@ func TestResolveVisibleWorkingDir_LocalWorkspace(t *testing.T) {
 
 	if got := ResolveVisibleWorkingDir(workspaceRoot, "../../etc"); got != workspaceRoot {
 		t.Fatalf("expected escape attempt to clamp to workspace root, got %q", got)
+	}
+}
+
+func TestResolveVisibleWorkingDir_ContainerAndAbsoluteLocal(t *testing.T) {
+	if got := ResolveVisibleWorkingDir("", "backend"); got != "/workspace/backend" {
+		t.Fatalf("expected default container workspace path, got %q", got)
+	}
+	if got := ResolveVisibleWorkingDir("/workspace", "/etc"); got != "/workspace" {
+		t.Fatalf("expected container absolute path outside workspace to clamp, got %q", got)
+	}
+	workspaceRoot := t.TempDir()
+	inside := filepath.Join(workspaceRoot, "backend")
+	if got := ResolveVisibleWorkingDir(workspaceRoot, inside); got != inside {
+		t.Fatalf("expected local absolute path inside workspace, got %q", got)
+	}
+	if got := ResolveVisibleWorkingDir(workspaceRoot, `C:\\temp\\bad`); got != workspaceRoot {
+		t.Fatalf("expected Windows-style path to clamp to workspace root, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Adds worker-side handoff for artifact-triggered downstream builds so consumers can safely read the triggering artifact from the local workspace without user-managed credentials, API tokens, or signed URLs.

## What Changed

- Predownloads the triggering artifact during downstream build preparation.
- Materializes the artifact under a reserved workspace-relative path:

 ```
 .coyote/trigger-artifacts/<safe logical artifact path>
```
Injects runner-visible handoff environment variables:

```
COYOTE_TRIGGER_ARTIFACT_LOCAL_RELATIVE_PATH
COYOTE_TRIGGER_ARTIFACT_LOCAL_DIR
COYOTE_TRIGGER_ARTIFACT_LOCAL_PATH
```

- Resolves local handoff paths per runner mode so Docker and in-process steps receive paths that are actually visible to the running step.
- Preserves the existing artifact-trigger provenance contract from V1.
- Validates same-project provenance before materializing artifact bytes.
- Rejects unsafe artifact paths before writing to the workspace.
- Verifies SHA-256 checksums when available.
- Fails the downstream build before step execution if handoff fails, rather than letting consumer steps fail mysteriously.
- Updates the artifact-download-chain smoke consumer to prefer the local handoff file.
- Documents the local handoff behavior and fallback path in the fixture README.

## Validation

- Added targeted backend tests for:
- trigger artifact handoff preparation;
- workspace path helpers;
- Docker runner env/path derivation;
- in-process runner env/path behavior;
- downstream consumption through COYOTE_TRIGGER_ARTIFACT_LOCAL_PATH.
- Verified direct in-process runner tests after env handling changes.
- Confirmed touched backend files have no remaining diagnostics.
- Notes

This keeps the V1.1 scope intentionally narrow:

- no scoped token injection;
- no signed URLs;
- no cross-project triggers;
- no DAG scheduler;
- no UI or Slack changes.

The result is the intended artifact-native workflow:

producer uploads artifact
  -> artifact trigger queues downstream build
  -> worker materializes the triggering artifact locally