### PR TITLE
Add better CLI visibility for build artifacts

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -567,6 +567,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/builds/{buildID}/artifact-triggers": {
+            "get": {
+                "description": "Returns persisted producer-side artifact trigger delivery records for a build.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "builds"
+                ],
+                "summary": "List build artifact trigger deliveries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Build ID",
+                        "name": "buildID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BuildArtifactTriggerDeliveriesEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/builds/{buildID}/artifacts": {
             "get": {
                 "description": "Returns persisted artifact metadata for a build.",
@@ -4245,6 +4292,101 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/api.VersionTagResponse"
                     }
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveriesEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveriesResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveriesResponse": {
+            "type": "object",
+            "properties": {
+                "build_id": {
+                    "type": "string"
+                },
+                "build_trigger_kind": {
+                    "type": "string"
+                },
+                "deliveries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryResponse"
+                    }
+                },
+                "recursive_dispatch_blocked": {
+                    "type": "boolean"
+                },
+                "summary": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliverySummaryResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryResponse": {
+            "type": "object",
+            "properties": {
+                "artifact_id": {
+                    "type": "string"
+                },
+                "artifact_name": {
+                    "type": "string"
+                },
+                "artifact_path": {
+                    "type": "string"
+                },
+                "artifact_size_bytes": {
+                    "type": "integer"
+                },
+                "consumer_job_id": {
+                    "type": "string"
+                },
+                "consumer_job_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "delivery_id": {
+                    "type": "string"
+                },
+                "downstream_build_id": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "producer_build_id": {
+                    "type": "string"
+                },
+                "producer_job_id": {
+                    "type": "string"
+                },
+                "producer_project_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliverySummaryResponse": {
+            "type": "object",
+            "properties": {
+                "delivery_count": {
+                    "type": "integer"
+                },
+                "failed_count": {
+                    "type": "integer"
+                },
+                "queued_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -563,6 +563,53 @@
                 }
             }
         },
+        "/builds/{buildID}/artifact-triggers": {
+            "get": {
+                "description": "Returns persisted producer-side artifact trigger delivery records for a build.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "builds"
+                ],
+                "summary": "List build artifact trigger deliveries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Build ID",
+                        "name": "buildID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BuildArtifactTriggerDeliveriesEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/builds/{buildID}/artifacts": {
             "get": {
                 "description": "Returns persisted artifact metadata for a build.",
@@ -4241,6 +4288,101 @@
                     "items": {
                         "$ref": "#/definitions/api.VersionTagResponse"
                     }
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveriesEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveriesResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveriesResponse": {
+            "type": "object",
+            "properties": {
+                "build_id": {
+                    "type": "string"
+                },
+                "build_trigger_kind": {
+                    "type": "string"
+                },
+                "deliveries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryResponse"
+                    }
+                },
+                "recursive_dispatch_blocked": {
+                    "type": "boolean"
+                },
+                "summary": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliverySummaryResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryResponse": {
+            "type": "object",
+            "properties": {
+                "artifact_id": {
+                    "type": "string"
+                },
+                "artifact_name": {
+                    "type": "string"
+                },
+                "artifact_path": {
+                    "type": "string"
+                },
+                "artifact_size_bytes": {
+                    "type": "integer"
+                },
+                "consumer_job_id": {
+                    "type": "string"
+                },
+                "consumer_job_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "delivery_id": {
+                    "type": "string"
+                },
+                "downstream_build_id": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "producer_build_id": {
+                    "type": "string"
+                },
+                "producer_job_id": {
+                    "type": "string"
+                },
+                "producer_project_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliverySummaryResponse": {
+            "type": "object",
+            "properties": {
+                "delivery_count": {
+                    "type": "integer"
+                },
+                "failed_count": {
+                    "type": "integer"
+                },
+                "queued_count": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -305,6 +305,68 @@ definitions:
           $ref: '#/definitions/api.VersionTagResponse'
         type: array
     type: object
+  api.BuildArtifactTriggerDeliveriesEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.BuildArtifactTriggerDeliveriesResponse'
+    type: object
+  api.BuildArtifactTriggerDeliveriesResponse:
+    properties:
+      build_id:
+        type: string
+      build_trigger_kind:
+        type: string
+      deliveries:
+        items:
+          $ref: '#/definitions/api.BuildArtifactTriggerDeliveryResponse'
+        type: array
+      recursive_dispatch_blocked:
+        type: boolean
+      summary:
+        $ref: '#/definitions/api.BuildArtifactTriggerDeliverySummaryResponse'
+    type: object
+  api.BuildArtifactTriggerDeliveryResponse:
+    properties:
+      artifact_id:
+        type: string
+      artifact_name:
+        type: string
+      artifact_path:
+        type: string
+      artifact_size_bytes:
+        type: integer
+      consumer_job_id:
+        type: string
+      consumer_job_name:
+        type: string
+      created_at:
+        type: string
+      delivery_id:
+        type: string
+      downstream_build_id:
+        type: string
+      error_message:
+        type: string
+      producer_build_id:
+        type: string
+      producer_job_id:
+        type: string
+      producer_project_id:
+        type: string
+      status:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  api.BuildArtifactTriggerDeliverySummaryResponse:
+    properties:
+      delivery_count:
+        type: integer
+      failed_count:
+        type: integer
+      queued_count:
+        type: integer
+    type: object
   api.BuildArtifactsEnvelope:
     properties:
       data:
@@ -1931,6 +1993,38 @@ paths:
           schema:
             $ref: '#/definitions/api.ErrorResponse'
       summary: Get build
+      tags:
+      - builds
+  /builds/{buildID}/artifact-triggers:
+    get:
+      description: Returns persisted producer-side artifact trigger delivery records
+        for a build.
+      parameters:
+      - description: Build ID
+        in: path
+        name: buildID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BuildArtifactTriggerDeliveriesEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: List build artifact trigger deliveries
       tags:
       - builds
   /builds/{buildID}/artifacts:

--- a/backend/internal/api/build_dto.go
+++ b/backend/internal/api/build_dto.go
@@ -102,6 +102,10 @@ type BuildArtifactsEnvelope struct {
 	Data BuildArtifactsResponse `json:"data"`
 }
 
+type BuildArtifactTriggerDeliveriesEnvelope struct {
+	Data BuildArtifactTriggerDeliveriesResponse `json:"data"`
+}
+
 type StepLogsEnvelope struct {
 	Data StepLogsResponse `json:"data"`
 }
@@ -338,4 +342,36 @@ type BuildArtifactResponse struct {
 type BuildArtifactsResponse struct {
 	BuildID   string                  `json:"build_id"`
 	Artifacts []BuildArtifactResponse `json:"artifacts"`
+}
+
+type BuildArtifactTriggerDeliverySummaryResponse struct {
+	DeliveryCount int `json:"delivery_count"`
+	QueuedCount   int `json:"queued_count"`
+	FailedCount   int `json:"failed_count"`
+}
+
+type BuildArtifactTriggerDeliveryResponse struct {
+	DeliveryID        string  `json:"delivery_id"`
+	Status            string  `json:"status"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+	ProducerBuildID   string  `json:"producer_build_id"`
+	ProducerProjectID string  `json:"producer_project_id"`
+	ProducerJobID     string  `json:"producer_job_id"`
+	ArtifactID        string  `json:"artifact_id"`
+	ArtifactPath      string  `json:"artifact_path"`
+	ArtifactName      *string `json:"artifact_name,omitempty"`
+	ArtifactSizeBytes *int64  `json:"artifact_size_bytes,omitempty"`
+	ConsumerJobID     string  `json:"consumer_job_id"`
+	ConsumerJobName   *string `json:"consumer_job_name,omitempty"`
+	DownstreamBuildID *string `json:"downstream_build_id,omitempty"`
+	ErrorMessage      *string `json:"error_message,omitempty"`
+}
+
+type BuildArtifactTriggerDeliveriesResponse struct {
+	BuildID                  string                                      `json:"build_id"`
+	BuildTriggerKind         string                                      `json:"build_trigger_kind"`
+	RecursiveDispatchBlocked bool                                        `json:"recursive_dispatch_blocked"`
+	Summary                  BuildArtifactTriggerDeliverySummaryResponse `json:"summary"`
+	Deliveries               []BuildArtifactTriggerDeliveryResponse      `json:"deliveries"`
 }

--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -367,6 +367,14 @@ func (c *Client) ListBuildArtifacts(ctx context.Context, buildID string) (api.Bu
 	return envelope.Data, nil
 }
 
+func (c *Client) ListBuildArtifactTriggers(ctx context.Context, buildID string) (api.BuildArtifactTriggerDeliveriesResponse, error) {
+	var envelope api.BuildArtifactTriggerDeliveriesEnvelope
+	if err := c.doJSON(ctx, http.MethodGet, buildResourcePath(buildID, "/artifact-triggers"), nil, &envelope); err != nil {
+		return api.BuildArtifactTriggerDeliveriesResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
 func (c *Client) DownloadBuildArtifact(ctx context.Context, buildID string, artifactID string, writer io.Writer) error {
 	requestURL, err := resolveRequestURL(c.baseURL, buildArtifactDownloadPath(buildID, artifactID))
 	if err != nil {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -438,6 +438,11 @@ func TestClient_BuildArtifactMethods(t *testing.T) {
 				t.Fatalf("expected bearer header, got %q", got)
 			}
 			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","artifacts":[{"id":"artifact-1","build_id":"build-1","name":"report.xml","path":"reports/report.xml","size_bytes":42,"content_type":"application/xml","storage_provider":"filesystem","download_url_path":"/builds/build-1/artifacts/artifact-1/download","created_at":"2026-07-05T00:00:00Z"}]}}`))
+		case "/api/builds/build-1/artifact-triggers":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("expected bearer header, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","build_trigger_kind":"manual","recursive_dispatch_blocked":false,"summary":{"delivery_count":1,"queued_count":1,"failed_count":0},"deliveries":[{"delivery_id":"delivery-1","status":"queued","created_at":"2026-07-05T00:00:01Z","updated_at":"2026-07-05T00:00:02Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-1","artifact_path":"reports/report.xml","artifact_name":"report.xml","artifact_size_bytes":42,"consumer_job_id":"job-downstream","consumer_job_name":"deploy","downstream_build_id":"build-2"}]}}`))
 		case "/api/builds/build-1/artifacts/artifact-1/download":
 			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
 				t.Fatalf("expected bearer header, got %q", got)
@@ -461,6 +466,16 @@ func TestClient_BuildArtifactMethods(t *testing.T) {
 	}
 	if artifacts.BuildID != "build-1" || len(artifacts.Artifacts) != 1 || artifacts.Artifacts[0].Path != "reports/report.xml" {
 		t.Fatalf("unexpected artifacts response: %+v", artifacts)
+	}
+	artifactTriggers, triggersErr := client.ListBuildArtifactTriggers(context.Background(), "build-1")
+	if triggersErr != nil {
+		t.Fatalf("list build artifact triggers: %v", triggersErr)
+	}
+	if artifactTriggers.BuildID != "build-1" || artifactTriggers.BuildTriggerKind != "manual" || artifactTriggers.RecursiveDispatchBlocked || artifactTriggers.Summary.DeliveryCount != 1 || len(artifactTriggers.Deliveries) != 1 {
+		t.Fatalf("unexpected artifact trigger response: %+v", artifactTriggers)
+	}
+	if artifactTriggers.Deliveries[0].ConsumerJobName == nil || *artifactTriggers.Deliveries[0].ConsumerJobName != "deploy" {
+		t.Fatalf("unexpected artifact trigger delivery payload: %+v", artifactTriggers.Deliveries[0])
 	}
 
 	var body bytes.Buffer
@@ -510,6 +525,29 @@ func TestClient_ListBuildArtifactsReturnsTypedError(t *testing.T) {
 	}
 
 	_, err = client.ListBuildArtifacts(context.Background(), "build-1")
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindAuthorization || apiErr.Code != "missing_token_scope" {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
+func TestClient_ListBuildArtifactTriggersReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:read"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.ListBuildArtifactTriggers(context.Background(), "build-1")
 	var apiErr *Error
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected typed api error, got %T", err)

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -84,6 +84,38 @@ type buildArtifactsPayload struct {
 	Artifacts []buildArtifactListView `json:"artifacts"`
 }
 
+type buildArtifactTriggerDeliveriesPayload struct {
+	BuildID                  string                             `json:"build_id"`
+	BuildTriggerKind         string                             `json:"build_trigger_kind"`
+	RecursiveDispatchBlocked bool                               `json:"recursive_dispatch_blocked"`
+	Summary                  buildArtifactTriggerSummaryView    `json:"summary"`
+	Deliveries               []buildArtifactTriggerDeliveryView `json:"deliveries"`
+}
+
+type buildArtifactTriggerSummaryView struct {
+	DeliveryCount int `json:"delivery_count"`
+	QueuedCount   int `json:"queued_count"`
+	FailedCount   int `json:"failed_count"`
+}
+
+type buildArtifactTriggerDeliveryView struct {
+	DeliveryID        string  `json:"delivery_id"`
+	Status            string  `json:"status"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+	ProducerBuildID   string  `json:"producer_build_id"`
+	ProducerProjectID string  `json:"producer_project_id"`
+	ProducerJobID     string  `json:"producer_job_id"`
+	ArtifactID        string  `json:"artifact_id"`
+	ArtifactPath      string  `json:"artifact_path"`
+	ArtifactName      *string `json:"artifact_name,omitempty"`
+	ArtifactSizeBytes *int64  `json:"artifact_size_bytes,omitempty"`
+	ConsumerJobID     string  `json:"consumer_job_id"`
+	ConsumerJobName   *string `json:"consumer_job_name,omitempty"`
+	DownstreamBuildID *string `json:"downstream_build_id,omitempty"`
+	ErrorMessage      *string `json:"error_message,omitempty"`
+}
+
 type buildArtifactListView struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name,omitempty"`
@@ -148,6 +180,7 @@ func (a *app) newBuildCommand() *cobra.Command {
 	command.AddCommand(a.newBuildStatusCommand())
 	command.AddCommand(a.newBuildWatchCommand())
 	command.AddCommand(a.newBuildLogsCommand())
+	command.AddCommand(a.newBuildArtifactTriggersCommand())
 	command.AddCommand(a.newBuildArtifactsCommand())
 	command.AddCommand(a.newBuildRetryCommand())
 	return command
@@ -213,6 +246,34 @@ func (a *app) newBuildArtifactsCommand() *cobra.Command {
 	}
 	command.AddCommand(a.newBuildArtifactsDownloadCommand())
 	return command
+}
+
+func (a *app) newBuildArtifactTriggersCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "artifact-triggers <build-id>",
+		Short: "Inspect artifact-trigger deliveries for a build",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+
+			response, responseErr := client.ListBuildArtifactTriggers(cmd.Context(), args[0])
+			if responseErr != nil {
+				return mapCommandError(responseErr)
+			}
+
+			payload := makeBuildArtifactTriggerDeliveriesPayload(args[0], response)
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildArtifactTriggersHuman(w, payload)
+			}, payload)
+		},
+	}
 }
 
 func (a *app) newBuildArtifactsDownloadCommand() *cobra.Command {
@@ -712,6 +773,44 @@ func makeBuildArtifactsPayload(buildID string, artifacts []api.BuildArtifactResp
 	return buildArtifactsPayload{BuildID: resolvedBuildID, Artifacts: items}
 }
 
+func makeBuildArtifactTriggerDeliveriesPayload(buildID string, response api.BuildArtifactTriggerDeliveriesResponse) buildArtifactTriggerDeliveriesPayload {
+	deliveries := make([]buildArtifactTriggerDeliveryView, 0, len(response.Deliveries))
+	for _, delivery := range response.Deliveries {
+		deliveries = append(deliveries, buildArtifactTriggerDeliveryView{
+			DeliveryID:        delivery.DeliveryID,
+			Status:            delivery.Status,
+			CreatedAt:         delivery.CreatedAt,
+			UpdatedAt:         delivery.UpdatedAt,
+			ProducerBuildID:   delivery.ProducerBuildID,
+			ProducerProjectID: delivery.ProducerProjectID,
+			ProducerJobID:     delivery.ProducerJobID,
+			ArtifactID:        delivery.ArtifactID,
+			ArtifactPath:      delivery.ArtifactPath,
+			ArtifactName:      trimStringPtr(delivery.ArtifactName),
+			ArtifactSizeBytes: delivery.ArtifactSizeBytes,
+			ConsumerJobID:     delivery.ConsumerJobID,
+			ConsumerJobName:   trimStringPtr(delivery.ConsumerJobName),
+			DownstreamBuildID: trimStringPtr(delivery.DownstreamBuildID),
+			ErrorMessage:      trimStringPtr(delivery.ErrorMessage),
+		})
+	}
+	resolvedBuildID := strings.TrimSpace(buildID)
+	if strings.TrimSpace(response.BuildID) != "" {
+		resolvedBuildID = response.BuildID
+	}
+	return buildArtifactTriggerDeliveriesPayload{
+		BuildID:                  resolvedBuildID,
+		BuildTriggerKind:         strings.TrimSpace(response.BuildTriggerKind),
+		RecursiveDispatchBlocked: response.RecursiveDispatchBlocked,
+		Summary: buildArtifactTriggerSummaryView{
+			DeliveryCount: response.Summary.DeliveryCount,
+			QueuedCount:   response.Summary.QueuedCount,
+			FailedCount:   response.Summary.FailedCount,
+		},
+		Deliveries: deliveries,
+	}
+}
+
 func makeBuildStatusPayload(serverURL string, build api.BuildResponse, steps []api.BuildStepResponse) buildStatusPayload {
 	jobName := firstNonEmptyPtr(build.JobName, firstJobName(steps))
 	refValue := firstNonEmptyPtr(build.SourceRef, build.TriggerRef)
@@ -905,6 +1004,48 @@ func writeBuildArtifactsHuman(w io.Writer, payload buildArtifactsPayload) error 
 	return nil
 }
 
+func writeBuildArtifactTriggersHuman(w io.Writer, payload buildArtifactTriggerDeliveriesPayload) error {
+	if _, err := fmt.Fprintf(w, "Artifact trigger deliveries for build %s\n", payload.BuildID); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Trigger: %s\n", displayTriggerKind(payload.BuildTriggerKind)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Summary: %d deliveries, %d queued, %d failed\n", payload.Summary.DeliveryCount, payload.Summary.QueuedCount, payload.Summary.FailedCount); err != nil {
+		return err
+	}
+	if len(payload.Deliveries) == 0 {
+		if payload.RecursiveDispatchBlocked {
+			_, err := fmt.Fprintln(w, "\nRecursive artifact-trigger dispatch is blocked for artifact-triggered builds.")
+			return err
+		}
+		_, err := fmt.Fprintln(w, "\nNo artifact-trigger deliveries were recorded for this build.")
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "STATUS\tARTIFACT\tCONSUMER JOB\tDOWNSTREAM BUILD\tERROR"); err != nil {
+		return err
+	}
+	for _, delivery := range payload.Deliveries {
+		errorValue := "-"
+		if delivery.ErrorMessage != nil {
+			errorValue = *delivery.ErrorMessage
+		}
+		downstreamBuild := "-"
+		if delivery.DownstreamBuildID != nil {
+			downstreamBuild = *delivery.DownstreamBuildID
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", delivery.Status, displayArtifactTriggerArtifact(delivery), displayArtifactTriggerConsumerJob(delivery), downstreamBuild, errorValue); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
 func makeBuildRetryPayload(serverURL string, sourceBuildID string, build api.BuildResponse) buildRetryPayload {
 	return buildRetryPayload{
 		Retried: buildRetryView{
@@ -951,6 +1092,31 @@ func writeBuildArtifactDownloadHuman(w io.Writer, payload buildArtifactDownloadP
 		}
 	}
 	return nil
+}
+
+func displayArtifactTriggerArtifact(delivery buildArtifactTriggerDeliveryView) string {
+	if delivery.ArtifactName != nil {
+		return *delivery.ArtifactName
+	}
+	if trimmed := strings.TrimSpace(delivery.ArtifactPath); trimmed != "" {
+		return trimmed
+	}
+	return delivery.ArtifactID
+}
+
+func displayArtifactTriggerConsumerJob(delivery buildArtifactTriggerDeliveryView) string {
+	if delivery.ConsumerJobName != nil {
+		return *delivery.ConsumerJobName
+	}
+	return delivery.ConsumerJobID
+}
+
+func displayTriggerKind(kind string) string {
+	trimmed := strings.TrimSpace(kind)
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
 }
 
 func (a *app) confirmBuildRetry(buildID string, mode output.Mode, assumeYes bool) error {

--- a/backend/internal/cli/build.go
+++ b/backend/internal/cli/build.go
@@ -795,8 +795,8 @@ func makeBuildArtifactTriggerDeliveriesPayload(buildID string, response api.Buil
 		})
 	}
 	resolvedBuildID := strings.TrimSpace(buildID)
-	if strings.TrimSpace(response.BuildID) != "" {
-		resolvedBuildID = response.BuildID
+	if trimmedResponseBuildID := strings.TrimSpace(response.BuildID); trimmedResponseBuildID != "" {
+		resolvedBuildID = trimmedResponseBuildID
 	}
 	return buildArtifactTriggerDeliveriesPayload{
 		BuildID:                  resolvedBuildID,

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -223,6 +223,47 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 	if retryPayload.Retried.SourceBuildID != "build-1" || retryPayload.Retried.BuildID != "build-2" || !strings.Contains(retryPayload.Retried.WebURL, "/base/builds/build-2") {
 		t.Fatalf("unexpected retry payload: %+v", retryPayload)
 	}
+
+	artifactTriggersPayload := makeBuildArtifactTriggerDeliveriesPayload("build-1", api.BuildArtifactTriggerDeliveriesResponse{
+		BuildID:                  "build-1",
+		BuildTriggerKind:         "manual",
+		RecursiveDispatchBlocked: false,
+		Summary:                  api.BuildArtifactTriggerDeliverySummaryResponse{DeliveryCount: 2, QueuedCount: 1, FailedCount: 1},
+		Deliveries: []api.BuildArtifactTriggerDeliveryResponse{
+			{DeliveryID: "delivery-1", Status: "queued", ArtifactID: "artifact-1", ArtifactName: stringPtr("report.xml"), ArtifactPath: "reports/report.xml", ConsumerJobID: "job-1", ConsumerJobName: stringPtr("deploy"), DownstreamBuildID: stringPtr("build-2")},
+			{DeliveryID: "delivery-2", Status: "failed", ArtifactID: "artifact-2", ArtifactPath: "docs/summary.txt", ConsumerJobID: "job-2", ErrorMessage: stringPtr("queue failed")},
+		},
+	})
+	if artifactTriggersPayload.Summary.DeliveryCount != 2 || len(artifactTriggersPayload.Deliveries) != 2 || artifactTriggersPayload.Deliveries[0].ConsumerJobName == nil || *artifactTriggersPayload.Deliveries[0].ConsumerJobName != "deploy" {
+		t.Fatalf("unexpected artifact trigger payload: %+v", artifactTriggersPayload)
+	}
+	buf.Reset()
+	if err := writeBuildArtifactTriggersHuman(buf, artifactTriggersPayload); err != nil {
+		t.Fatalf("writeBuildArtifactTriggersHuman failed: %v", err)
+	}
+	artifactTriggersOut := buf.String()
+	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "queued", "report.xml", "deploy", "build-2", "queue failed"} {
+		if !strings.Contains(artifactTriggersOut, want) {
+			t.Fatalf("expected %q in artifact trigger output, got %s", want, artifactTriggersOut)
+		}
+	}
+	buf.Reset()
+	if err := writeBuildArtifactTriggersHuman(buf, buildArtifactTriggerDeliveriesPayload{BuildID: "build-1", BuildTriggerKind: "artifact", RecursiveDispatchBlocked: true, Summary: buildArtifactTriggerSummaryView{}}); err != nil {
+		t.Fatalf("writeBuildArtifactTriggersHuman blocked-empty failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Recursive artifact-trigger dispatch is blocked for artifact-triggered builds.") {
+		t.Fatalf("unexpected blocked-empty output: %s", buf.String())
+	}
+	buf.Reset()
+	if err := writeBuildArtifactTriggersHuman(buf, buildArtifactTriggerDeliveriesPayload{BuildID: "build-1", BuildTriggerKind: "manual", Summary: buildArtifactTriggerSummaryView{}}); err != nil {
+		t.Fatalf("writeBuildArtifactTriggersHuman empty failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No artifact-trigger deliveries were recorded for this build.") {
+		t.Fatalf("unexpected empty output: %s", buf.String())
+	}
+	if err := writeBuildArtifactTriggersHuman(failWriter{}, artifactTriggersPayload); err == nil {
+		t.Fatal("expected writeBuildArtifactTriggersHuman to surface write errors")
+	}
 	buf.Reset()
 	if err := writeBuildRetryHuman(buf, retryPayload); err != nil {
 		t.Fatalf("writeBuildRetryHuman failed: %v", err)

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -237,6 +237,40 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 	if artifactTriggersPayload.Summary.DeliveryCount != 2 || len(artifactTriggersPayload.Deliveries) != 2 || artifactTriggersPayload.Deliveries[0].ConsumerJobName == nil || *artifactTriggersPayload.Deliveries[0].ConsumerJobName != "deploy" {
 		t.Fatalf("unexpected artifact trigger payload: %+v", artifactTriggersPayload)
 	}
+	trimmedTriggerPayload := makeBuildArtifactTriggerDeliveriesPayload(" build-fallback ", api.BuildArtifactTriggerDeliveriesResponse{
+		BuildID:                  "",
+		BuildTriggerKind:         "  ",
+		RecursiveDispatchBlocked: false,
+		Summary:                  api.BuildArtifactTriggerDeliverySummaryResponse{},
+		Deliveries:               []api.BuildArtifactTriggerDeliveryResponse{{ArtifactID: "artifact-1", ArtifactPath: "  path/from/api.tgz  ", ArtifactName: stringPtr("  "), ConsumerJobID: "job-1", ConsumerJobName: stringPtr("  "), DownstreamBuildID: stringPtr("  "), ErrorMessage: stringPtr("  ")}},
+	})
+	if trimmedTriggerPayload.BuildID != "build-fallback" || trimmedTriggerPayload.BuildTriggerKind != "" {
+		t.Fatalf("unexpected fallback trigger payload metadata: %+v", trimmedTriggerPayload)
+	}
+	if trimmedTriggerPayload.Deliveries[0].ArtifactName != nil || trimmedTriggerPayload.Deliveries[0].ConsumerJobName != nil || trimmedTriggerPayload.Deliveries[0].DownstreamBuildID != nil || trimmedTriggerPayload.Deliveries[0].ErrorMessage != nil {
+		t.Fatalf("expected blank optional fields to be trimmed away, got %+v", trimmedTriggerPayload.Deliveries[0])
+	}
+	if got := displayArtifactTriggerArtifact(buildArtifactTriggerDeliveryView{ArtifactName: stringPtr("artifact-name"), ArtifactPath: "path", ArtifactID: "id"}); got != "artifact-name" {
+		t.Fatalf("unexpected artifact display from name: %s", got)
+	}
+	if got := displayArtifactTriggerArtifact(buildArtifactTriggerDeliveryView{ArtifactPath: " path/from/delivery.tgz ", ArtifactID: "id"}); got != "path/from/delivery.tgz" {
+		t.Fatalf("unexpected artifact display from path: %s", got)
+	}
+	if got := displayArtifactTriggerArtifact(buildArtifactTriggerDeliveryView{ArtifactID: "artifact-id"}); got != "artifact-id" {
+		t.Fatalf("unexpected artifact display from id fallback: %s", got)
+	}
+	if got := displayArtifactTriggerConsumerJob(buildArtifactTriggerDeliveryView{ConsumerJobName: stringPtr("deploy"), ConsumerJobID: "job-1"}); got != "deploy" {
+		t.Fatalf("unexpected consumer job display from name: %s", got)
+	}
+	if got := displayArtifactTriggerConsumerJob(buildArtifactTriggerDeliveryView{ConsumerJobID: "job-1"}); got != "job-1" {
+		t.Fatalf("unexpected consumer job display fallback: %s", got)
+	}
+	if got := displayTriggerKind("  "); got != "unknown" {
+		t.Fatalf("unexpected trigger kind fallback: %s", got)
+	}
+	if got := displayTriggerKind(" manual "); got != "manual" {
+		t.Fatalf("unexpected trigger kind trim: %s", got)
+	}
 	buf.Reset()
 	if err := writeBuildArtifactTriggersHuman(buf, artifactTriggersPayload); err != nil {
 		t.Fatalf("writeBuildArtifactTriggersHuman failed: %v", err)

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -751,6 +751,117 @@ func TestBuildArtifactsBulkDownloadCommand_NoArtifacts(t *testing.T) {
 	}
 }
 
+func TestBuildArtifactTriggersCommand(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifact-triggers":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","build_trigger_kind":"manual","recursive_dispatch_blocked":false,"summary":{"delivery_count":2,"queued_count":1,"failed_count":1},"deliveries":[{"delivery_id":"delivery-1","status":"queued","created_at":"2026-07-05T00:00:01Z","updated_at":"2026-07-05T00:00:02Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-1","artifact_path":"reports/report.xml","artifact_name":"report.xml","artifact_size_bytes":42,"consumer_job_id":"job-deploy","consumer_job_name":"deploy","downstream_build_id":"build-2"},{"delivery_id":"delivery-2","status":"failed","created_at":"2026-07-05T00:00:03Z","updated_at":"2026-07-05T00:00:04Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-2","artifact_path":"docs/summary.txt","consumer_job_id":"job-docs","error_message":"queue failed"}]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-1"}}); code != 0 {
+		t.Fatalf("build artifact-triggers exit code %d stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "report.xml", "deploy", "build-2", "queue failed"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected %q in human output, got %s", want, stdout.String())
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-1", "--json"}}); code != 0 {
+		t.Fatalf("build artifact-triggers json exit code %d stderr=%s", code, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode build artifact triggers json: %v", err)
+	}
+	if payload["build_id"] != "build-1" || payload["build_trigger_kind"] != "manual" || payload["recursive_dispatch_blocked"] != false {
+		t.Fatalf("unexpected artifact trigger payload: %+v", payload)
+	}
+	summary, ok := payload["summary"].(map[string]any)
+	if !ok || summary["delivery_count"] != float64(2) || summary["queued_count"] != float64(1) || summary["failed_count"] != float64(1) {
+		t.Fatalf("unexpected artifact trigger summary: %+v", payload)
+	}
+	deliveries, ok := payload["deliveries"].([]any)
+	if !ok || len(deliveries) != 2 {
+		t.Fatalf("unexpected artifact trigger deliveries: %+v", payload)
+	}
+	first, ok := deliveries[0].(map[string]any)
+	if !ok || first["consumer_job_name"] != "deploy" || first["artifact_name"] != "report.xml" {
+		t.Fatalf("unexpected first artifact trigger delivery: %+v", first)
+	}
+	if strings.Contains(stdout.String(), "Artifact trigger deliveries for build") {
+		t.Fatalf("unexpected human prose in artifact trigger JSON: %s", stdout.String())
+	}
+}
+
+func TestBuildArtifactTriggersCommand_EmptyStates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-blocked/artifact-triggers":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-blocked","build_trigger_kind":"artifact","recursive_dispatch_blocked":true,"summary":{"delivery_count":0,"queued_count":0,"failed_count":0},"deliveries":[]}}`))
+		case "/api/builds/build-empty/artifact-triggers":
+			_, _ = w.Write([]byte(`{"data":{"build_id":"build-empty","build_trigger_kind":"manual","recursive_dispatch_blocked":false,"summary":{"delivery_count":0,"queued_count":0,"failed_count":0},"deliveries":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-blocked"}}); code != 0 {
+		t.Fatalf("build artifact-triggers blocked exit code %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Recursive artifact-trigger dispatch is blocked for artifact-triggered builds.") {
+		t.Fatalf("unexpected blocked output: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-empty"}}); code != 0 {
+		t.Fatalf("build artifact-triggers empty exit code %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No artifact-trigger deliveries were recorded for this build.") {
+		t.Fatalf("unexpected empty output: %s", stdout.String())
+	}
+}
+
 func TestBuildArtifactsBulkDownloadMidFailureDoesNotEmitPartialJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -862,6 +862,47 @@ func TestBuildArtifactTriggersCommand_EmptyStates(t *testing.T) {
 	}
 }
 
+func TestBuildArtifactTriggersCommand_MissingScope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/builds/build-1/artifact-triggers":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"missing_token_scope","message":"api token does not have the required scope: build:read"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configStore := config.NewStore(filepath.Join(t.TempDir(), "config.json"))
+	if err := configStore.Save(config.File{
+		CurrentContext: "local",
+		Contexts: map[string]config.Context{
+			"local": {Name: "local", ServerURL: server.URL, CredentialRef: "context:local"},
+		},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	creds := credentials.NewMemoryStore()
+	if setErr := creds.Set("context:local", "stored-token"); setErr != nil {
+		t.Fatalf("set token: %v", setErr)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-1"}})
+	if code != 5 {
+		t.Fatalf("expected missing scope exit code 5, got %d stderr=%s", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on missing scope, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "build:read") {
+		t.Fatalf("expected build:read scope error in stderr, got %s", stderr.String())
+	}
+}
+
 func TestBuildArtifactsBulkDownloadMidFailureDoesNotEmitPartialJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {

--- a/backend/internal/http/handler/authz_handlers_test.go
+++ b/backend/internal/http/handler/authz_handlers_test.go
@@ -372,6 +372,7 @@ func TestBuildHandler_HeaderModeAuthorizationAndFiltering(t *testing.T) {
 	}
 
 	h := NewBuildHandler(fixture.buildService)
+	h.SetJobService(fixture.jobService)
 	h.SetAuthorization(auth.ModeHeader, fixture.membershipService)
 
 	createReq := httptest.NewRequest(http.MethodPost, "/builds", bytes.NewBufferString(`{"project_id":"`+fixture.projectViewer.ID+`","steps":[{"name":"build","command":"go","args":["test","./..."]}]}`))
@@ -521,6 +522,7 @@ func TestBuildHandler_RetryJobAuthorizesSourceBuildBeforeMutation(t *testing.T) 
 		t.Fatalf("list builds before retry failed: %v", err)
 	}
 	h := NewBuildHandler(fixture.buildService)
+	h.SetJobService(fixture.jobService)
 	h.SetAuthorization(auth.ModeHeader, fixture.membershipService)
 
 	retryReq := addURLParam(httptest.NewRequest(http.MethodPost, "/builds/jobs/"+failedJob.ID+"/retry", nil), "jobID", failedJob.ID)
@@ -551,6 +553,7 @@ func TestScopedAPITokenRouteEnforcement(t *testing.T) {
 		t.Fatalf("create fixture build failed: %v", err)
 	}
 	h := NewBuildHandler(fixture.buildService)
+	h.SetJobService(fixture.jobService)
 	h.SetAuthorization(auth.ModeHeader, fixture.membershipService)
 	job, err := fixture.jobService.CreateJob(ctx, service.CreateJobInput{
 		ProjectID:     fixture.projectViewer.ID,
@@ -609,6 +612,22 @@ func TestScopedAPITokenRouteEnforcement(t *testing.T) {
 	h.GetBuildArtifacts(artifactRes, artifactReq)
 	if artifactRes.Code != http.StatusForbidden {
 		t.Fatalf("expected missing artifact:read scope status %d, got %d body=%s", http.StatusForbidden, artifactRes.Code, artifactRes.Body.String())
+	}
+
+	artifactTriggersReq := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/"+build.ID+"/artifact-triggers", nil), build.ID)
+	artifactTriggersReq = withScopedAPIToken(artifactTriggersReq, fixture.viewer, domain.APITokenScopeBuildRead)
+	artifactTriggersRes := httptest.NewRecorder()
+	h.GetBuildArtifactTriggers(artifactTriggersRes, artifactTriggersReq)
+	if artifactTriggersRes.Code != http.StatusOK {
+		t.Fatalf("expected build:read artifact trigger status %d, got %d body=%s", http.StatusOK, artifactTriggersRes.Code, artifactTriggersRes.Body.String())
+	}
+
+	artifactTriggersWrongScopeReq := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/"+build.ID+"/artifact-triggers", nil), build.ID)
+	artifactTriggersWrongScopeReq = withScopedAPIToken(artifactTriggersWrongScopeReq, fixture.viewer, domain.APITokenScopeArtifactRead)
+	artifactTriggersWrongScopeRes := httptest.NewRecorder()
+	h.GetBuildArtifactTriggers(artifactTriggersWrongScopeRes, artifactTriggersWrongScopeReq)
+	if artifactTriggersWrongScopeRes.Code != http.StatusForbidden {
+		t.Fatalf("expected missing build:read for artifact triggers status %d, got %d body=%s", http.StatusForbidden, artifactTriggersWrongScopeRes.Code, artifactTriggersWrongScopeRes.Body.String())
 	}
 
 	queueReq := addBuildIDParam(httptest.NewRequest(http.MethodPost, "/builds/"+build.ID+"/queue", nil), build.ID)
@@ -719,12 +738,13 @@ func newHandlerAuthzFixture(t *testing.T) handlerAuthzFixture {
 	now := time.Now().UTC()
 	jobRepo := repositorymemory.NewJobRepository()
 	buildRepo := repositorymemory.NewBuildRepository()
+	deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
 	projectRepo := repositorymemory.NewProjectRepository(jobRepo)
 	userRepo := repositorymemory.NewUserRepository()
 	membershipRepo := repositorymemory.NewProjectMembershipRepository(projectRepo, userRepo)
 	buildService := buildsvc.NewBuildService(buildRepo, nil, logs.NewNoopSink())
 	projectService := service.NewProjectService(projectRepo)
-	jobService := service.NewJobService(jobRepo, buildService).WithProjectRepository(projectRepo)
+	jobService := service.NewJobService(jobRepo, buildService).WithProjectRepository(projectRepo).WithArtifactTriggerDeliveryRepository(deliveryRepo)
 	membershipService := service.NewProjectMembershipService(projectRepo, membershipRepo)
 
 	projectViewer, err := projectService.CreateProject(ctx, service.CreateProjectInput{Name: "Platform", Slug: "platform"})

--- a/backend/internal/http/handler/build_handler_artifact_triggers.go
+++ b/backend/internal/http/handler/build_handler_artifact_triggers.go
@@ -1,0 +1,124 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/service"
+)
+
+// GetBuildArtifactTriggers godoc
+// @Summary List build artifact trigger deliveries
+// @Description Returns persisted producer-side artifact trigger delivery records for a build.
+// @Tags builds
+// @Produce json
+// @Param buildID path string true "Build ID"
+// @Success 200 {object} api.BuildArtifactTriggerDeliveriesEnvelope
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /builds/{buildID}/artifact-triggers [get]
+func (h *BuildHandler) GetBuildArtifactTriggers(w http.ResponseWriter, r *http.Request) {
+	buildID := chi.URLParam(r, "buildID")
+	if buildID == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "build id is required")
+		return
+	}
+	build, ok := h.authorizeBuildRead(w, r, buildID)
+	if !ok {
+		return
+	}
+	if !requireAPITokenScope(w, r, domain.APITokenScopeBuildRead) {
+		return
+	}
+	if h.jobs == nil {
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "job service is not configured")
+		return
+	}
+
+	artifacts, err := h.buildService.GetBuildArtifacts(r.Context(), buildID)
+	if err != nil {
+		h.writeServiceError(w, err)
+		return
+	}
+	views, err := h.jobs.ListArtifactTriggerDeliveriesByProducerBuildID(r.Context(), buildID)
+	if err != nil {
+		if err == service.ErrJobArtifactTriggerDeliveryRepositoryNotConfigured {
+			writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "artifact trigger delivery repository is not configured")
+			return
+		}
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+
+	artifactsByID := make(map[string]domain.BuildArtifact, len(artifacts))
+	for _, artifact := range artifacts {
+		artifactsByID[artifact.ID] = artifact
+	}
+
+	deliveries := make([]api.BuildArtifactTriggerDeliveryResponse, 0, len(views))
+	summary := api.BuildArtifactTriggerDeliverySummaryResponse{}
+	for _, view := range views {
+		delivery := view.Delivery
+		summary.DeliveryCount++
+		switch delivery.Status {
+		case domain.ArtifactTriggerDeliveryStatusQueued:
+			summary.QueuedCount++
+		case domain.ArtifactTriggerDeliveryStatusFailed:
+			summary.FailedCount++
+		}
+
+		var artifactName *string
+		var artifactSizeBytes *int64
+		if artifact, ok := artifactsByID[delivery.ArtifactID]; ok {
+			artifactName = trimOptionalArtifactTriggerString(&artifact.Name)
+			sizeBytes := artifact.SizeBytes
+			artifactSizeBytes = &sizeBytes
+		}
+
+		deliveries = append(deliveries, api.BuildArtifactTriggerDeliveryResponse{
+			DeliveryID:        delivery.ID,
+			Status:            string(delivery.Status),
+			CreatedAt:         delivery.CreatedAt.Format(timeFormatRFC3339()),
+			UpdatedAt:         delivery.UpdatedAt.Format(timeFormatRFC3339()),
+			ProducerBuildID:   delivery.ProducerBuildID,
+			ProducerProjectID: delivery.ProducerProjectID,
+			ProducerJobID:     delivery.ProducerJobID,
+			ArtifactID:        delivery.ArtifactID,
+			ArtifactPath:      delivery.ArtifactPath,
+			ArtifactName:      artifactName,
+			ArtifactSizeBytes: artifactSizeBytes,
+			ConsumerJobID:     delivery.ConsumerJobID,
+			ConsumerJobName:   view.ConsumerJobName,
+			DownstreamBuildID: delivery.QueuedBuildID,
+			ErrorMessage:      trimOptionalArtifactTriggerString(delivery.ErrorMessage),
+		})
+	}
+
+	writeDataJSON(w, http.StatusOK, api.BuildArtifactTriggerDeliveriesResponse{
+		BuildID:                  strings.TrimSpace(buildID),
+		BuildTriggerKind:         string(build.Trigger.Kind),
+		RecursiveDispatchBlocked: build.Trigger.Kind == domain.BuildTriggerKindArtifact,
+		Summary:                  summary,
+		Deliveries:               deliveries,
+	})
+}
+
+func timeFormatRFC3339() string {
+	return "2006-01-02T15:04:05Z07:00"
+}
+
+func trimOptionalArtifactTriggerString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/backend/internal/http/handler/build_handler_test.go
+++ b/backend/internal/http/handler/build_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -110,6 +111,12 @@ func (r *fakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifa
 
 func (r *fakeArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]domain.BuildArtifact, error) {
 	items := r.artifactsByBuild[buildID]
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
 	out := make([]domain.BuildArtifact, len(items))
 	copy(out, items)
 	return out, nil
@@ -1442,6 +1449,98 @@ func TestBuildHandler_GetBuildIncludesJobNameAndCurrentSteps(t *testing.T) {
 	}
 	if _, ok := first["started_at"]; !ok {
 		t.Fatalf("expected started_at on current step, got %+v", first)
+	}
+}
+
+func TestBuildHandler_GetBuildArtifactTriggers(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}}
+	artifactRepo := &fakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{
+		"build-1": {{ID: "artifact-1", BuildID: "build-1", Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}},
+	}}
+	buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+	buildService.SetArtifactPersistence(artifactRepo, nil, "")
+	jobRepo := repositorymemory.NewJobRepository()
+	deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
+	jobService := service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream job failed: %v", err)
+	}
+	errorMessage := "queue failed"
+	queuedBuildID := "build-2"
+	if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", QueuedBuildID: &queuedBuildID, Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create queued delivery failed: %v", err)
+	}
+	if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-2", ArtifactID: "artifact-missing", ConsumerJobID: "job-missing", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/docs.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)}); err != nil {
+		t.Fatalf("create failed delivery failed: %v", err)
+	}
+
+	h := NewBuildHandler(buildService)
+	h.SetJobService(jobService)
+
+	req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+	rr := httptest.NewRecorder()
+	h.GetBuildArtifactTriggers(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	data := decodeDataMap(t, rr)
+	if data["build_id"] != "build-1" || data["build_trigger_kind"] != "manual" || data["recursive_dispatch_blocked"] != false {
+		t.Fatalf("unexpected response metadata: %+v", data)
+	}
+	summary, ok := data["summary"].(map[string]any)
+	if !ok || summary["delivery_count"] != float64(2) || summary["queued_count"] != float64(1) || summary["failed_count"] != float64(1) {
+		t.Fatalf("unexpected summary: %+v", data["summary"])
+	}
+	deliveries, ok := data["deliveries"].([]any)
+	if !ok || len(deliveries) != 2 {
+		t.Fatalf("unexpected deliveries: %+v", data["deliveries"])
+	}
+	first, ok := deliveries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first delivery object, got %T", deliveries[0])
+	}
+	if first["delivery_id"] != "delivery-1" || first["consumer_job_name"] != "downstream" || first["artifact_name"] != "app.tgz" || first["artifact_size_bytes"] != float64(42) || first["downstream_build_id"] != "build-2" {
+		t.Fatalf("unexpected first delivery: %+v", first)
+	}
+	second, ok := deliveries[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected second delivery object, got %T", deliveries[1])
+	}
+	if second["delivery_id"] != "delivery-2" || second["status"] != "failed" || second["error_message"] != "queue failed" {
+		t.Fatalf("unexpected second delivery: %+v", second)
+	}
+	if _, ok := second["artifact_name"]; ok {
+		t.Fatalf("did not expect artifact_name for missing artifact metadata, got %+v", second)
+	}
+}
+
+func TestBuildHandler_GetBuildArtifactTriggersRecursiveBlockedEmpty(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindArtifact}}}
+	buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+	jobService := service.NewJobService(repositorymemory.NewJobRepository(), buildService).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository())
+
+	h := NewBuildHandler(buildService)
+	h.SetJobService(jobService)
+
+	req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+	rr := httptest.NewRecorder()
+	h.GetBuildArtifactTriggers(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	data := decodeDataMap(t, rr)
+	if data["recursive_dispatch_blocked"] != true {
+		t.Fatalf("expected recursive_dispatch_blocked true, got %+v", data)
+	}
+	summary, ok := data["summary"].(map[string]any)
+	if !ok || summary["delivery_count"] != float64(0) {
+		t.Fatalf("unexpected summary: %+v", data["summary"])
+	}
+	deliveries, ok := data["deliveries"].([]any)
+	if !ok || len(deliveries) != 0 {
+		t.Fatalf("expected empty deliveries, got %+v", data["deliveries"])
 	}
 }
 

--- a/backend/internal/http/handler/build_handler_test.go
+++ b/backend/internal/http/handler/build_handler_test.go
@@ -99,6 +99,7 @@ func (r *failingProjectRepo) Delete(_ context.Context, _ string) error {
 
 type fakeArtifactRepo struct {
 	artifactsByBuild map[string][]domain.BuildArtifact
+	listByBuildErr   error
 }
 
 func (r *fakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifact) (domain.BuildArtifact, error) {
@@ -110,6 +111,9 @@ func (r *fakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifa
 }
 
 func (r *fakeArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]domain.BuildArtifact, error) {
+	if r.listByBuildErr != nil {
+		return nil, r.listByBuildErr
+	}
 	items := r.artifactsByBuild[buildID]
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
@@ -120,6 +124,15 @@ func (r *fakeArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]d
 	out := make([]domain.BuildArtifact, len(items))
 	copy(out, items)
 	return out, nil
+}
+
+type erroringArtifactTriggerJobRepo struct {
+	*repositorymemory.JobRepository
+	getByIDsErr error
+}
+
+func (r *erroringArtifactTriggerJobRepo) GetByIDs(_ context.Context, _ []string) ([]domain.Job, error) {
+	return nil, r.getByIDsErr
 }
 
 func (r *fakeArtifactRepo) Browse(_ context.Context, _ repository.BrowseArtifactsParams) ([]domain.ArtifactBrowseRecord, error) {
@@ -1541,6 +1554,93 @@ func TestBuildHandler_GetBuildArtifactTriggersRecursiveBlockedEmpty(t *testing.T
 	deliveries, ok := data["deliveries"].([]any)
 	if !ok || len(deliveries) != 0 {
 		t.Fatalf("expected empty deliveries, got %+v", data["deliveries"])
+	}
+}
+
+func TestBuildHandler_GetBuildArtifactTriggersErrorPaths(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("missing build id", func(t *testing.T) {
+		h := NewBuildHandler(buildsvc.NewBuildService(&fakeRepo{}, nil, nil))
+		rr := httptest.NewRecorder()
+		h.GetBuildArtifactTriggers(rr, httptest.NewRequest(http.MethodGet, "/builds//artifact-triggers", nil))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected status %d, got %d body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("missing job service", func(t *testing.T) {
+		buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}}
+		h := NewBuildHandler(buildsvc.NewBuildService(buildRepo, nil, nil))
+		req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+		rr := httptest.NewRecorder()
+		h.GetBuildArtifactTriggers(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "job service is not configured") {
+			t.Fatalf("unexpected missing job service response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("missing delivery repository", func(t *testing.T) {
+		buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}}
+		buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+		h := NewBuildHandler(buildService)
+		h.SetJobService(service.NewJobService(repositorymemory.NewJobRepository(), buildService))
+		req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+		rr := httptest.NewRecorder()
+		h.GetBuildArtifactTriggers(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "artifact trigger delivery repository is not configured") {
+			t.Fatalf("unexpected missing delivery repo response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("artifact lookup failure maps through service error writer", func(t *testing.T) {
+		buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}}
+		artifactRepo := &fakeArtifactRepo{listByBuildErr: repository.ErrBuildNotFound}
+		buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+		buildService.SetArtifactPersistence(artifactRepo, nil, "")
+		h := NewBuildHandler(buildService)
+		h.SetJobService(service.NewJobService(repositorymemory.NewJobRepository(), buildService).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository()))
+		req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+		rr := httptest.NewRecorder()
+		h.GetBuildArtifactTriggers(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "internal server error") {
+			t.Fatalf("unexpected artifact lookup failure response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("job lookup failure becomes generic internal error", func(t *testing.T) {
+		buildRepo := &fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}}
+		artifactRepo := &fakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{"build-1": {{ID: "artifact-1", BuildID: "build-1", Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}}}}
+		buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+		buildService.SetArtifactPersistence(artifactRepo, nil, "")
+		jobRepo := &erroringArtifactTriggerJobRepo{JobRepository: repositorymemory.NewJobRepository(), getByIDsErr: errors.New("lookup failed")}
+		deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
+		if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("create delivery failed: %v", err)
+		}
+		h := NewBuildHandler(buildService)
+		h.SetJobService(service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo))
+		req := addBuildIDParam(httptest.NewRequest(http.MethodGet, "/builds/build-1/artifact-triggers", nil), "build-1")
+		rr := httptest.NewRecorder()
+		h.GetBuildArtifactTriggers(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "internal server error") {
+			t.Fatalf("unexpected generic internal error response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+func TestArtifactTriggerHandlerHelpers(t *testing.T) {
+	if got := timeFormatRFC3339(); got != time.RFC3339 {
+		t.Fatalf("expected RFC3339 layout, got %q", got)
+	}
+	if got := trimOptionalArtifactTriggerString(nil); got != nil {
+		t.Fatalf("expected nil for nil input, got %v", got)
+	}
+	if got := trimOptionalArtifactTriggerString(stringPtr("   ")); got != nil {
+		t.Fatalf("expected nil for blank input, got %v", got)
+	}
+	if got := trimOptionalArtifactTriggerString(stringPtr(" value ")); got == nil || *got != "value" {
+		t.Fatalf("expected trimmed value, got %v", got)
 	}
 }
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -198,6 +198,7 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 				r.Post("/jobs/{jobID}/retry", buildHandler.RetryJob)
 				r.Get("/", buildHandler.ListBuilds)
 				r.Get("/{buildID}", buildHandler.GetBuild)
+				r.Get("/{buildID}/artifact-triggers", buildHandler.GetBuildArtifactTriggers)
 				r.Post("/{buildID}/rerun", buildHandler.RerunBuild)
 				r.Get("/{buildID}/steps", buildHandler.GetBuildSteps)
 				r.Get("/{buildID}/steps/{stepIndex}/logs", buildHandler.GetBuildStepLogs)

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -86,7 +86,8 @@ func TestNewRouter_HealthAndNotFound(t *testing.T) {
 	jobRepo := repositorymemory.NewJobRepository()
 	buildSvc := buildsvc.NewBuildService(buildRepo, nil, nil)
 	h := handler.NewBuildHandler(buildSvc)
-	jobSvc := service.NewJobService(jobRepo, buildSvc)
+	jobSvc := service.NewJobService(jobRepo, buildSvc).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository())
+	h.SetJobService(jobSvc)
 	jh := handler.NewJobHandler(jobSvc)
 	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
@@ -650,7 +651,8 @@ func TestNewRouter_BuildRoutes(t *testing.T) {
 	jobRepo := repositorymemory.NewJobRepository()
 	buildSvc := buildsvc.NewBuildService(buildRepo, nil, nil)
 	h := handler.NewBuildHandler(buildSvc)
-	jobSvc := service.NewJobService(jobRepo, buildSvc)
+	jobSvc := service.NewJobService(jobRepo, buildSvc).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository())
+	h.SetJobService(jobSvc)
 	jh := handler.NewJobHandler(jobSvc)
 	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
@@ -683,6 +685,7 @@ func TestNewRouter_BuildRoutes(t *testing.T) {
 	}{
 		{name: "list builds", method: http.MethodGet, path: "/api/builds/", statusCode: http.StatusOK},
 		{name: "get build", method: http.MethodGet, path: "/api/builds/" + id, statusCode: http.StatusOK},
+		{name: "build artifact triggers", method: http.MethodGet, path: "/api/builds/" + id + "/artifact-triggers", statusCode: http.StatusOK},
 		{name: "build steps", method: http.MethodGet, path: "/api/builds/" + id + "/steps", statusCode: http.StatusOK},
 		{name: "build step logs", method: http.MethodGet, path: "/api/builds/" + id + "/steps/0/logs", statusCode: http.StatusOK},
 		{name: "build logs", method: http.MethodGet, path: "/api/builds/" + id + "/logs", statusCode: http.StatusOK},

--- a/backend/internal/repository/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/artifact_trigger_delivery_repository.go
@@ -13,5 +13,6 @@ var ErrArtifactTriggerDeliveryDuplicate = errors.New("artifact trigger delivery 
 type ArtifactTriggerDeliveryRepository interface {
 	Create(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error)
 	GetByArtifactIDAndConsumerJobID(ctx context.Context, artifactID string, consumerJobID string) (domain.ArtifactTriggerDelivery, error)
+	ListByProducerBuildID(ctx context.Context, producerBuildID string) ([]domain.ArtifactTriggerDelivery, error)
 	Update(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error)
 }

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -56,6 +57,29 @@ func (r *ArtifactTriggerDeliveryRepository) GetByArtifactIDAndConsumerJobID(_ co
 		return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryNotFound
 	}
 	return r.deliveries[id], nil
+}
+
+func (r *ArtifactTriggerDeliveryRepository) ListByProducerBuildID(_ context.Context, producerBuildID string) ([]domain.ArtifactTriggerDelivery, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	trimmedProducerBuildID := producerBuildID
+	out := make([]domain.ArtifactTriggerDelivery, 0)
+	for _, delivery := range r.deliveries {
+		if delivery.ProducerBuildID != trimmedProducerBuildID {
+			continue
+		}
+		out = append(out, delivery)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+
+	return out, nil
 }
 
 func (r *ArtifactTriggerDeliveryRepository) Update(_ context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error) {

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,7 +64,7 @@ func (r *ArtifactTriggerDeliveryRepository) ListByProducerBuildID(_ context.Cont
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	trimmedProducerBuildID := producerBuildID
+	trimmedProducerBuildID := strings.TrimSpace(producerBuildID)
 	out := make([]domain.ArtifactTriggerDelivery, 0)
 	for _, delivery := range r.deliveries {
 		if delivery.ProducerBuildID != trimmedProducerBuildID {

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
@@ -113,6 +113,14 @@ func TestArtifactTriggerDeliveryRepository_CreateDuplicateGetAndUpdate(t *testin
 		t.Fatalf("unexpected build-2 deliveries: %+v", deliveries)
 	}
 
+	paddedDeliveries, err := repo.ListByProducerBuildID(context.Background(), " build-1 ")
+	if err != nil {
+		t.Fatalf("list by padded producer build failed: %v", err)
+	}
+	if len(paddedDeliveries) != 2 || paddedDeliveries[0].ID != created.ID || paddedDeliveries[1].ID != other.ID {
+		t.Fatalf("unexpected padded build-1 deliveries: %+v", paddedDeliveries)
+	}
+
 	deliveries, err = repo.ListByProducerBuildID(context.Background(), "missing-build")
 	if err != nil {
 		t.Fatalf("list by missing producer build failed: %v", err)

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
@@ -112,4 +112,12 @@ func TestArtifactTriggerDeliveryRepository_CreateDuplicateGetAndUpdate(t *testin
 	if len(deliveries) != 1 || deliveries[0].ID != third.ID {
 		t.Fatalf("unexpected build-2 deliveries: %+v", deliveries)
 	}
+
+	deliveries, err = repo.ListByProducerBuildID(context.Background(), "missing-build")
+	if err != nil {
+		t.Fatalf("list by missing producer build failed: %v", err)
+	}
+	if len(deliveries) != 0 {
+		t.Fatalf("expected no deliveries for missing build, got %+v", deliveries)
+	}
 }

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
@@ -68,4 +68,48 @@ func TestArtifactTriggerDeliveryRepository_CreateDuplicateGetAndUpdate(t *testin
 	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
 		t.Fatalf("expected update not found, got %v", err)
 	}
+
+	other, err := repo.Create(context.Background(), domain.ArtifactTriggerDelivery{
+		ArtifactID:        "artifact-2",
+		ConsumerJobID:     "job-2",
+		ProducerBuildID:   "build-1",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "producer-1",
+		ArtifactPath:      "dist/docs.tgz",
+		Status:            domain.ArtifactTriggerDeliveryStatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("create second delivery failed: %v", err)
+	}
+	third, err := repo.Create(context.Background(), domain.ArtifactTriggerDelivery{
+		ArtifactID:        "artifact-3",
+		ConsumerJobID:     "job-3",
+		ProducerBuildID:   "build-2",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "producer-1",
+		ArtifactPath:      "dist/other.tgz",
+		Status:            domain.ArtifactTriggerDeliveryStatusQueued,
+	})
+	if err != nil {
+		t.Fatalf("create third delivery failed: %v", err)
+	}
+
+	deliveries, err := repo.ListByProducerBuildID(context.Background(), "build-1")
+	if err != nil {
+		t.Fatalf("list by producer build failed: %v", err)
+	}
+	if len(deliveries) != 2 {
+		t.Fatalf("expected 2 deliveries for build-1, got %d", len(deliveries))
+	}
+	if deliveries[0].ID != created.ID || deliveries[1].ID != other.ID {
+		t.Fatalf("unexpected delivery order: %+v", deliveries)
+	}
+
+	deliveries, err = repo.ListByProducerBuildID(context.Background(), "build-2")
+	if err != nil {
+		t.Fatalf("list by second producer build failed: %v", err)
+	}
+	if len(deliveries) != 1 || deliveries[0].ID != third.ID {
+		t.Fatalf("unexpected build-2 deliveries: %+v", deliveries)
+	}
 }

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
@@ -95,8 +95,8 @@ func (r *ArtifactTriggerDeliveryRepository) ListByProducerBuildID(ctx context.Co
 		}
 		result = append(result, delivery)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, rowsErr
 	}
 	return result, nil
 }

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
@@ -69,6 +69,38 @@ func (r *ArtifactTriggerDeliveryRepository) GetByArtifactIDAndConsumerJobID(ctx 
 	return delivery, nil
 }
 
+func (r *ArtifactTriggerDeliveryRepository) ListByProducerBuildID(ctx context.Context, producerBuildID string) (result []domain.ArtifactTriggerDelivery, err error) {
+	const query = `
+		SELECT ` + artifactTriggerDeliveryColumns + `
+		FROM artifact_trigger_deliveries
+		WHERE producer_build_id = $1
+		ORDER BY created_at ASC, id ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, strings.TrimSpace(producerBuildID))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	result = make([]domain.ArtifactTriggerDelivery, 0)
+	for rows.Next() {
+		delivery, scanErr := scanArtifactTriggerDelivery(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		result = append(result, delivery)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (r *ArtifactTriggerDeliveryRepository) Update(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error) {
 	const query = `
 		UPDATE artifact_trigger_deliveries

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,34 @@ func TestArtifactTriggerDeliveryRepository_CreateGetAndUpdate(t *testing.T) {
 	}
 	if deliveries[0].ID != "delivery-1" || deliveries[1].ID != "delivery-2" {
 		t.Fatalf("unexpected listed deliveries: %+v", deliveries)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestArtifactTriggerDeliveryRepository_ListByProducerBuildIDErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+
+	repo := NewArtifactTriggerDeliveryRepository(db)
+
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("build-1").WillReturnError(errors.New("query failed"))
+	_, err = repo.ListByProducerBuildID(context.Background(), "build-1")
+	if err == nil || err.Error() != "query failed" {
+		t.Fatalf("expected query failure, got %v", err)
+	}
+
+	row := []string{"id", "artifact_id", "consumer_job_id", "producer_build_id", "producer_project_id", "producer_job_id", "artifact_path", "queued_build_id", "error_message", "status", "created_at", "updated_at"}
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("build-2").WillReturnRows(sqlmock.NewRows(row).AddRow(
+		"delivery-1", "artifact-1", "job-1", "build-2", "project-1", "producer-1", "dist/app.tgz", nil, nil, "queued", "not-a-time", "not-a-time",
+	))
+	_, err = repo.ListByProducerBuildID(context.Background(), "build-2")
+	if err == nil || !strings.Contains(err.Error(), "Scan") {
+		t.Fatalf("expected scan failure, got %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
@@ -94,6 +94,20 @@ func TestArtifactTriggerDeliveryRepository_CreateGetAndUpdate(t *testing.T) {
 		t.Fatalf("expected update not found, got %v", err)
 	}
 
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("build-1").WillReturnRows(sqlmock.NewRows(row).
+		AddRow("delivery-1", "artifact-1", "job-1", "build-1", "project-1", "producer-1", "dist/app.tgz", queuedBuildID, nil, "queued", now, now).
+		AddRow("delivery-2", "artifact-2", "job-2", "build-1", "project-1", "producer-1", "dist/docs.tgz", nil, errorMessage, "failed", now.Add(time.Second), now.Add(time.Second)))
+	deliveries, err := repo.ListByProducerBuildID(context.Background(), " build-1 ")
+	if err != nil {
+		t.Fatalf("list by producer build failed: %v", err)
+	}
+	if len(deliveries) != 2 {
+		t.Fatalf("expected 2 deliveries, got %d", len(deliveries))
+	}
+	if deliveries[0].ID != "delivery-1" || deliveries[1].ID != "delivery-2" {
+		t.Fatalf("unexpected listed deliveries: %+v", deliveries)
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}

--- a/backend/internal/service/job_service_artifact_triggers.go
+++ b/backend/internal/service/job_service_artifact_triggers.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+)
+
+var ErrJobArtifactTriggerDeliveryRepositoryNotConfigured = errors.New("job artifact trigger delivery repository not configured")
+
+type ArtifactTriggerDeliveryView struct {
+	Delivery        domain.ArtifactTriggerDelivery
+	ConsumerJobName *string
+}
+
+func (s *JobService) ListArtifactTriggerDeliveriesByProducerBuildID(ctx context.Context, producerBuildID string) ([]ArtifactTriggerDeliveryView, error) {
+	if s.artifactTriggerDeliveries == nil {
+		return nil, ErrJobArtifactTriggerDeliveryRepositoryNotConfigured
+	}
+
+	deliveries, err := s.artifactTriggerDeliveries.ListByProducerBuildID(ctx, strings.TrimSpace(producerBuildID))
+	if err != nil {
+		return nil, err
+	}
+	if len(deliveries) == 0 {
+		return []ArtifactTriggerDeliveryView{}, nil
+	}
+
+	jobNames := map[string]*string{}
+	if s.jobRepo != nil {
+		jobIDs := make([]string, 0, len(deliveries))
+		for _, delivery := range deliveries {
+			jobIDs = append(jobIDs, delivery.ConsumerJobID)
+		}
+		jobs, jobErr := s.jobRepo.GetByIDs(ctx, jobIDs)
+		if jobErr != nil {
+			return nil, jobErr
+		}
+		for _, job := range jobs {
+			name := strings.TrimSpace(job.Name)
+			if name == "" {
+				continue
+			}
+			value := name
+			jobNames[job.ID] = &value
+		}
+	}
+
+	views := make([]ArtifactTriggerDeliveryView, 0, len(deliveries))
+	for _, delivery := range deliveries {
+		views = append(views, ArtifactTriggerDeliveryView{
+			Delivery:        delivery,
+			ConsumerJobName: jobNames[delivery.ConsumerJobID],
+		})
+	}
+	return views, nil
+}

--- a/backend/internal/service/job_service_test.go
+++ b/backend/internal/service/job_service_test.go
@@ -46,6 +46,15 @@ type fakeServiceManagedImageRefresher struct {
 	err     error
 }
 
+type erroringArtifactTriggerJobRepo struct {
+	*memory.JobRepository
+	getByIDsErr error
+}
+
+func (r *erroringArtifactTriggerJobRepo) GetByIDs(_ context.Context, _ []string) ([]domain.Job, error) {
+	return nil, r.getByIDsErr
+}
+
 func (f *fakeServiceManagedImageRefresher) RefreshManagedPipelineImage(_ context.Context, req buildsvc.ManagedImageRefreshInput) (buildsvc.ManagedImageRefreshResult, error) {
 	f.calls++
 	f.lastReq = req
@@ -672,6 +681,71 @@ func TestJobService_ListArtifactTriggerDeliveriesByProducerBuildID(t *testing.T)
 	if len(emptyViews) != 0 {
 		t.Fatalf("expected no delivery views, got %+v", emptyViews)
 	}
+}
+
+func TestJobService_ListArtifactTriggerDeliveriesByProducerBuildID_Branches(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing delivery repository", func(t *testing.T) {
+		jobService := NewJobService(memory.NewJobRepository(), nil)
+		_, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, "build-1")
+		if !errors.Is(err, ErrJobArtifactTriggerDeliveryRepositoryNotConfigured) {
+			t.Fatalf("expected missing delivery repo error, got %v", err)
+		}
+	})
+
+	t.Run("nil job repository leaves consumer name empty", func(t *testing.T) {
+		deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+		jobService := NewJobService(nil, nil).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+		now := time.Now().UTC()
+		if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("create delivery failed: %v", err)
+		}
+
+		views, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, "build-1")
+		if err != nil {
+			t.Fatalf("list artifact trigger deliveries failed: %v", err)
+		}
+		if len(views) != 1 || views[0].ConsumerJobName != nil {
+			t.Fatalf("expected nil consumer job name without job repo, got %+v", views)
+		}
+	})
+
+	t.Run("blank job name is omitted", func(t *testing.T) {
+		jobRepo := memory.NewJobRepository()
+		deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+		jobService := NewJobService(jobRepo, nil).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+		now := time.Now().UTC()
+		if _, err := jobRepo.Create(ctx, domain.Job{ID: "job-blank", ProjectID: "project-1", Name: "   ", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("create blank-name job failed: %v", err)
+		}
+		if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-blank", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("create delivery failed: %v", err)
+		}
+
+		views, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, "build-1")
+		if err != nil {
+			t.Fatalf("list artifact trigger deliveries failed: %v", err)
+		}
+		if len(views) != 1 || views[0].ConsumerJobName != nil {
+			t.Fatalf("expected blank consumer job name to be omitted, got %+v", views)
+		}
+	})
+
+	t.Run("job repository lookup failure is returned", func(t *testing.T) {
+		jobRepo := &erroringArtifactTriggerJobRepo{JobRepository: memory.NewJobRepository(), getByIDsErr: errors.New("lookup failed")}
+		deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+		jobService := NewJobService(jobRepo, nil).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+		now := time.Now().UTC()
+		if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("create delivery failed: %v", err)
+		}
+
+		_, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, "build-1")
+		if err == nil || err.Error() != "lookup failed" {
+			t.Fatalf("expected lookup error, got %v", err)
+		}
+	})
 }
 
 func TestJobService_CreateJobAcceptsLegacyProjectSlugInProjectID(t *testing.T) {

--- a/backend/internal/service/job_service_test.go
+++ b/backend/internal/service/job_service_test.go
@@ -612,6 +612,68 @@ func TestJobService_DispatchArtifactTriggers_RetriesFailedDelivery(t *testing.T)
 	}
 }
 
+func TestJobService_ListArtifactTriggerDeliveriesByProducerBuildID(t *testing.T) {
+	ctx := context.Background()
+	jobRepo := memory.NewJobRepository()
+	deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+	jobService := NewJobService(jobRepo, nil).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+
+	now := time.Now().UTC()
+	if _, err := jobRepo.Create(ctx, domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream job failed: %v", err)
+	}
+	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{
+		ID:                "delivery-1",
+		ArtifactID:        "artifact-1",
+		ConsumerJobID:     "job-downstream",
+		ProducerBuildID:   "build-upstream",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "job-upstream",
+		ArtifactPath:      "dist/app.tgz",
+		Status:            domain.ArtifactTriggerDeliveryStatusQueued,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}); err != nil {
+		t.Fatalf("create delivery failed: %v", err)
+	}
+	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{
+		ID:                "delivery-2",
+		ArtifactID:        "artifact-2",
+		ConsumerJobID:     "job-missing",
+		ProducerBuildID:   "build-other",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "job-upstream",
+		ArtifactPath:      "dist/other.tgz",
+		Status:            domain.ArtifactTriggerDeliveryStatusFailed,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}); err != nil {
+		t.Fatalf("create second delivery failed: %v", err)
+	}
+
+	views, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, " build-upstream ")
+	if err != nil {
+		t.Fatalf("list artifact trigger deliveries failed: %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("expected one delivery view, got %d", len(views))
+	}
+	if views[0].Delivery.ID != "delivery-1" {
+		t.Fatalf("expected delivery-1, got %+v", views[0])
+	}
+	if views[0].ConsumerJobName == nil || *views[0].ConsumerJobName != "downstream" {
+		t.Fatalf("expected downstream consumer job name, got %+v", views[0].ConsumerJobName)
+	}
+
+	emptyViews, err := jobService.ListArtifactTriggerDeliveriesByProducerBuildID(ctx, "missing-build")
+	if err != nil {
+		t.Fatalf("list empty artifact trigger deliveries failed: %v", err)
+	}
+	if len(emptyViews) != 0 {
+		t.Fatalf("expected no delivery views, got %+v", emptyViews)
+	}
+}
+
 func TestJobService_CreateJobAcceptsLegacyProjectSlugInProjectID(t *testing.T) {
 	jobRepo := memory.NewJobRepository()
 	buildRepo := memory.NewBuildRepository()


### PR DESCRIPTION
## Summary

Adds a dedicated build-scoped inspection surface for artifact-trigger deliveries so humans and IDE agents can understand what downstream work was triggered by a producer build’s artifacts.

## What Changed

- Added backend endpoint:

  ```text
  GET /api/builds/{buildID}/artifact-triggers
  ```

- Protects artifact-trigger delivery inspection with `build:read`.
- Returns a focused visibility payload with:
  - producer build ID;
  - summary counts;
  - flat `deliveries[]`;
  - delivery status;
  - artifact metadata;
  - consumer job/build metadata;
  - error details when enqueueing fails;
  - `recursive_dispatch_blocked` semantics for artifact-triggered producer builds.
- Added API client support for artifact-trigger delivery inspection.
- Added CLI command:

  ```bash
  coyote build artifact-triggers <build-id>
  coyote build artifact-triggers <build-id> --json
  ```

- Human output summarizes delivery state and downstream build linkage.
- JSON output gives IDE agents a stable producer-side way to inspect artifact-trigger behavior.
- Added empty-state messaging for:
  - builds with no recorded artifact-trigger deliveries;
  - artifact-triggered builds where recursive artifact-trigger dispatch is intentionally blocked.

## Validation

- Added backend, API, client, and CLI coverage for the new inspection surface.
- Verified the touched slice with:

  ```bash
  go test ./internal/repository/memory ./internal/repository/postgres ./internal/service ./internal/http/handler ./internal/http ./internal/api ./internal/apiclient ./internal/cli
  ```

## Notes

This is intentionally visibility-only:

- no retry/recovery command yet;
- no UI or Slack changes;
- no cross-project triggers;
- no glob/prefix matching;
- no changes to worker-side artifact handoff.

This gives users and automation a clear answer to:

> This build uploaded artifacts — what downstream work did those artifacts trigger?
