### PR TITLE
Add artifact trigger retry for CLI

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -15,6 +15,59 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/artifact-trigger-deliveries/{deliveryID}/retry": {
+            "post": {
+                "description": "Retries a failed artifact-trigger delivery by delivery id.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "artifact-trigger-deliveries"
+                ],
+                "summary": "Retry artifact trigger delivery",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Delivery ID",
+                        "name": "deliveryID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryRetryEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/artifacts": {
             "get": {
                 "description": "Returns logical artifacts grouped with their available versions for artifact repository browsing.",
@@ -4372,6 +4425,28 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryRetryEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryRetryResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryRetryResponse": {
+            "type": "object",
+            "properties": {
+                "delivery": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryResponse"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "result": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -11,6 +11,59 @@
     },
     "basePath": "/api",
     "paths": {
+        "/artifact-trigger-deliveries/{deliveryID}/retry": {
+            "post": {
+                "description": "Retries a failed artifact-trigger delivery by delivery id.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "artifact-trigger-deliveries"
+                ],
+                "summary": "Retry artifact trigger delivery",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Delivery ID",
+                        "name": "deliveryID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryRetryEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/artifacts": {
             "get": {
                 "description": "Returns logical artifacts grouped with their available versions for artifact repository browsing.",
@@ -4368,6 +4421,28 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryRetryEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryRetryResponse"
+                }
+            }
+        },
+        "api.BuildArtifactTriggerDeliveryRetryResponse": {
+            "type": "object",
+            "properties": {
+                "delivery": {
+                    "$ref": "#/definitions/api.BuildArtifactTriggerDeliveryResponse"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "result": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -358,6 +358,20 @@ definitions:
       updated_at:
         type: string
     type: object
+  api.BuildArtifactTriggerDeliveryRetryEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.BuildArtifactTriggerDeliveryRetryResponse'
+    type: object
+  api.BuildArtifactTriggerDeliveryRetryResponse:
+    properties:
+      delivery:
+        $ref: '#/definitions/api.BuildArtifactTriggerDeliveryResponse'
+      message:
+        type: string
+      result:
+        type: string
+    type: object
   api.BuildArtifactTriggerDeliverySummaryResponse:
     properties:
       delivery_count:
@@ -1721,6 +1735,41 @@ info:
   title: Coyote CI API
   version: "0.1"
 paths:
+  /artifact-trigger-deliveries/{deliveryID}/retry:
+    post:
+      description: Retries a failed artifact-trigger delivery by delivery id.
+      parameters:
+      - description: Delivery ID
+        in: path
+        name: deliveryID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BuildArtifactTriggerDeliveryRetryEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Retry artifact trigger delivery
+      tags:
+      - artifact-trigger-deliveries
   /artifacts:
     get:
       description: Returns logical artifacts grouped with their available versions

--- a/backend/internal/api/build_dto.go
+++ b/backend/internal/api/build_dto.go
@@ -106,6 +106,10 @@ type BuildArtifactTriggerDeliveriesEnvelope struct {
 	Data BuildArtifactTriggerDeliveriesResponse `json:"data"`
 }
 
+type BuildArtifactTriggerDeliveryRetryEnvelope struct {
+	Data BuildArtifactTriggerDeliveryRetryResponse `json:"data"`
+}
+
 type StepLogsEnvelope struct {
 	Data StepLogsResponse `json:"data"`
 }
@@ -374,4 +378,10 @@ type BuildArtifactTriggerDeliveriesResponse struct {
 	RecursiveDispatchBlocked bool                                        `json:"recursive_dispatch_blocked"`
 	Summary                  BuildArtifactTriggerDeliverySummaryResponse `json:"summary"`
 	Deliveries               []BuildArtifactTriggerDeliveryResponse      `json:"deliveries"`
+}
+
+type BuildArtifactTriggerDeliveryRetryResponse struct {
+	Result   string                               `json:"result"`
+	Message  string                               `json:"message,omitempty"`
+	Delivery BuildArtifactTriggerDeliveryResponse `json:"delivery"`
 }

--- a/backend/internal/apiclient/client.go
+++ b/backend/internal/apiclient/client.go
@@ -375,6 +375,14 @@ func (c *Client) ListBuildArtifactTriggers(ctx context.Context, buildID string) 
 	return envelope.Data, nil
 }
 
+func (c *Client) RetryArtifactTriggerDelivery(ctx context.Context, deliveryID string) (api.BuildArtifactTriggerDeliveryRetryResponse, error) {
+	var envelope api.BuildArtifactTriggerDeliveryRetryEnvelope
+	if err := c.doJSON(ctx, http.MethodPost, artifactTriggerDeliveryResourcePath(deliveryID, "/retry"), nil, &envelope); err != nil {
+		return api.BuildArtifactTriggerDeliveryRetryResponse{}, err
+	}
+	return envelope.Data, nil
+}
+
 func (c *Client) DownloadBuildArtifact(ctx context.Context, buildID string, artifactID string, writer io.Writer) error {
 	requestURL, err := resolveRequestURL(c.baseURL, buildArtifactDownloadPath(buildID, artifactID))
 	if err != nil {
@@ -548,6 +556,10 @@ func projectResourcePath(selector string, suffix string) string {
 
 func jobResourcePath(selector string, suffix string) string {
 	return "api/jobs/" + url.PathEscape(strings.TrimSpace(selector)) + suffix
+}
+
+func artifactTriggerDeliveryResourcePath(deliveryID string, suffix string) string {
+	return "api/artifact-trigger-deliveries/" + url.PathEscape(strings.TrimSpace(deliveryID)) + suffix
 }
 
 func looksLikeDirectJobID(selector string) bool {

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -443,6 +443,11 @@ func TestClient_BuildArtifactMethods(t *testing.T) {
 				t.Fatalf("expected bearer header, got %q", got)
 			}
 			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","build_trigger_kind":"manual","recursive_dispatch_blocked":false,"summary":{"delivery_count":1,"queued_count":1,"failed_count":0},"deliveries":[{"delivery_id":"delivery-1","status":"queued","created_at":"2026-07-05T00:00:01Z","updated_at":"2026-07-05T00:00:02Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-1","artifact_path":"reports/report.xml","artifact_name":"report.xml","artifact_size_bytes":42,"consumer_job_id":"job-downstream","consumer_job_name":"deploy","downstream_build_id":"build-2"}]}}`))
+		case "/api/artifact-trigger-deliveries/delivery-1/retry":
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				t.Fatalf("expected bearer header, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"result":"retried","message":"queued downstream build","delivery":{"delivery_id":"delivery-1","status":"queued","created_at":"2026-07-05T00:00:01Z","updated_at":"2026-07-05T00:00:03Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-1","artifact_path":"reports/report.xml","artifact_name":"report.xml","artifact_size_bytes":42,"consumer_job_id":"job-downstream","consumer_job_name":"deploy","downstream_build_id":"build-2"}}}`))
 		case "/api/builds/build-1/artifacts/artifact-1/download":
 			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
 				t.Fatalf("expected bearer header, got %q", got)
@@ -476,6 +481,13 @@ func TestClient_BuildArtifactMethods(t *testing.T) {
 	}
 	if artifactTriggers.Deliveries[0].ConsumerJobName == nil || *artifactTriggers.Deliveries[0].ConsumerJobName != "deploy" {
 		t.Fatalf("unexpected artifact trigger delivery payload: %+v", artifactTriggers.Deliveries[0])
+	}
+	retryResult, retryErr := client.RetryArtifactTriggerDelivery(context.Background(), "delivery-1")
+	if retryErr != nil {
+		t.Fatalf("retry artifact trigger delivery: %v", retryErr)
+	}
+	if retryResult.Result != "retried" || retryResult.Delivery.DeliveryID != "delivery-1" || retryResult.Delivery.DownstreamBuildID == nil || *retryResult.Delivery.DownstreamBuildID != "build-2" {
+		t.Fatalf("unexpected artifact trigger retry response: %+v", retryResult)
 	}
 
 	var body bytes.Buffer

--- a/backend/internal/apiclient/client_test.go
+++ b/backend/internal/apiclient/client_test.go
@@ -569,6 +569,32 @@ func TestClient_ListBuildArtifactTriggersReturnsTypedError(t *testing.T) {
 	}
 }
 
+func TestClient_RetryArtifactTriggerDeliveryReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/artifact-trigger-deliveries/delivery-1/retry" {
+			t.Fatalf("unexpected retry path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"artifact_trigger_delivery_not_retryable","message":"artifact trigger delivery retry is not supported for this delivery state"}}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "test-token", "coyote/dev", nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.RetryArtifactTriggerDelivery(context.Background(), " delivery-1 ")
+	var apiErr *Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected typed api error, got %T", err)
+	}
+	if apiErr.Kind != ErrorKindConflict || apiErr.Code != "artifact_trigger_delivery_not_retryable" {
+		t.Fatalf("unexpected api error: %+v", apiErr)
+	}
+}
+
 func TestClient_DownloadBuildArtifactNilWriterAndWriterFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Request-ID", "req-alt")

--- a/backend/internal/cli/build_artifact_triggers.go
+++ b/backend/internal/cli/build_artifact_triggers.go
@@ -13,11 +13,14 @@ import (
 )
 
 func (a *app) newBuildArtifactTriggersCommand() *cobra.Command {
-	return &cobra.Command{
+	command := &cobra.Command{
 		Use:   "artifact-triggers <build-id>",
 		Short: "Inspect artifact-trigger deliveries for a build",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return err
+			}
 			resolved, err := a.resolveTarget()
 			if err != nil {
 				return err
@@ -35,6 +38,54 @@ func (a *app) newBuildArtifactTriggersCommand() *cobra.Command {
 			payload := makeBuildArtifactTriggerDeliveriesPayload(args[0], response)
 			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
 				return writeBuildArtifactTriggersHuman(w, payload)
+			}, payload)
+		},
+	}
+	command.AddCommand(a.newBuildArtifactTriggersRetryCommand())
+	return command
+}
+
+func (a *app) newBuildArtifactTriggersRetryCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "retry <delivery-id>",
+		Short: "Retry a failed artifact-trigger delivery by delivery id",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := a.resolveTarget()
+			if err != nil {
+				return err
+			}
+			client, err := a.newClient(resolved)
+			if err != nil {
+				return &ExitError{Code: 3, Err: err}
+			}
+			response, retryErr := client.RetryArtifactTriggerDelivery(cmd.Context(), args[0])
+			if retryErr != nil {
+				return mapCommandError(retryErr)
+			}
+			payload := buildArtifactTriggerRetryPayload{
+				Result:  strings.TrimSpace(response.Result),
+				Message: strings.TrimSpace(response.Message),
+				Delivery: buildArtifactTriggerDeliveryView{
+					DeliveryID:        response.Delivery.DeliveryID,
+					Status:            response.Delivery.Status,
+					CreatedAt:         response.Delivery.CreatedAt,
+					UpdatedAt:         response.Delivery.UpdatedAt,
+					ProducerBuildID:   response.Delivery.ProducerBuildID,
+					ProducerProjectID: response.Delivery.ProducerProjectID,
+					ProducerJobID:     response.Delivery.ProducerJobID,
+					ArtifactID:        response.Delivery.ArtifactID,
+					ArtifactPath:      response.Delivery.ArtifactPath,
+					ArtifactName:      trimStringPtr(response.Delivery.ArtifactName),
+					ArtifactSizeBytes: response.Delivery.ArtifactSizeBytes,
+					ConsumerJobID:     response.Delivery.ConsumerJobID,
+					ConsumerJobName:   trimStringPtr(response.Delivery.ConsumerJobName),
+					DownstreamBuildID: trimStringPtr(response.Delivery.DownstreamBuildID),
+					ErrorMessage:      trimStringPtr(response.Delivery.ErrorMessage),
+				},
+			}
+			return output.Write(resolved.OutputMode, a.stdout, func(w io.Writer) error {
+				return writeBuildArtifactTriggerRetryHuman(w, payload)
 			}, payload)
 		},
 	}
@@ -101,7 +152,7 @@ func writeBuildArtifactTriggersHuman(w io.Writer, payload buildArtifactTriggerDe
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "STATUS\tARTIFACT\tCONSUMER JOB\tDOWNSTREAM BUILD\tERROR"); err != nil {
+	if _, err := fmt.Fprintln(tw, "DELIVERY ID\tSTATUS\tARTIFACT\tCONSUMER JOB\tDOWNSTREAM BUILD\tERROR"); err != nil {
 		return err
 	}
 	for _, delivery := range payload.Deliveries {
@@ -113,11 +164,37 @@ func writeBuildArtifactTriggersHuman(w io.Writer, payload buildArtifactTriggerDe
 		if delivery.DownstreamBuildID != nil {
 			downstreamBuild = *delivery.DownstreamBuildID
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", delivery.Status, displayArtifactTriggerArtifact(delivery), displayArtifactTriggerConsumerJob(delivery), downstreamBuild, errorValue); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", delivery.DeliveryID, delivery.Status, displayArtifactTriggerArtifact(delivery), displayArtifactTriggerConsumerJob(delivery), downstreamBuild, errorValue); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
+}
+
+func writeBuildArtifactTriggerRetryHuman(w io.Writer, payload buildArtifactTriggerRetryPayload) error {
+	delivery := payload.Delivery
+	if payload.Result == "already_satisfied" && delivery.DownstreamBuildID != nil {
+		if _, err := fmt.Fprintf(w, "Artifact-trigger delivery %s already points at downstream build %s; no new build created.\n", delivery.DeliveryID, *delivery.DownstreamBuildID); err != nil {
+			return err
+		}
+	} else if delivery.DownstreamBuildID != nil {
+		if _, err := fmt.Fprintf(w, "Retried artifact-trigger delivery %s -> %s\n", delivery.DeliveryID, *delivery.DownstreamBuildID); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "Retried artifact-trigger delivery %s\n", delivery.DeliveryID); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "Status: %s\n", delivery.Status); err != nil {
+		return err
+	}
+	if payload.Message != "" {
+		if _, err := fmt.Fprintf(w, "Message: %s\n", payload.Message); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func displayArtifactTriggerArtifact(delivery buildArtifactTriggerDeliveryView) string {

--- a/backend/internal/cli/build_shared.go
+++ b/backend/internal/cli/build_shared.go
@@ -99,6 +99,12 @@ type buildArtifactTriggerDeliveryView struct {
 	ErrorMessage      *string `json:"error_message,omitempty"`
 }
 
+type buildArtifactTriggerRetryPayload struct {
+	Result   string                           `json:"result"`
+	Message  string                           `json:"message,omitempty"`
+	Delivery buildArtifactTriggerDeliveryView `json:"delivery"`
+}
+
 type buildArtifactListView struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name,omitempty"`

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -290,6 +290,13 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 		t.Fatalf("unexpected artifact trigger retry output: %s", got)
 	}
 	buf.Reset()
+	if err := writeBuildArtifactTriggerRetryHuman(buf, buildArtifactTriggerRetryPayload{Result: "retried", Delivery: buildArtifactTriggerDeliveryView{DeliveryID: "delivery-3", Status: "pending"}}); err != nil {
+		t.Fatalf("writeBuildArtifactTriggerRetryHuman no-downstream failed: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Retried artifact-trigger delivery delivery-3\n") || !strings.Contains(got, "Status: pending") || strings.Contains(got, "Message:") {
+		t.Fatalf("unexpected no-downstream retry output: %s", got)
+	}
+	buf.Reset()
 	if err := writeBuildArtifactTriggerRetryHuman(buf, buildArtifactTriggerRetryPayload{Result: "already_satisfied", Message: "artifact trigger delivery already points at a downstream build", Delivery: buildArtifactTriggerDeliveryView{DeliveryID: "delivery-2", Status: "queued", DownstreamBuildID: stringPtr("build-9")}}); err != nil {
 		t.Fatalf("writeBuildArtifactTriggerRetryHuman already satisfied failed: %v", err)
 	}

--- a/backend/internal/cli/build_test.go
+++ b/backend/internal/cli/build_test.go
@@ -237,6 +237,7 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 	if artifactTriggersPayload.Summary.DeliveryCount != 2 || len(artifactTriggersPayload.Deliveries) != 2 || artifactTriggersPayload.Deliveries[0].ConsumerJobName == nil || *artifactTriggersPayload.Deliveries[0].ConsumerJobName != "deploy" {
 		t.Fatalf("unexpected artifact trigger payload: %+v", artifactTriggersPayload)
 	}
+	retryTriggerPayload := buildArtifactTriggerRetryPayload{Result: "retried", Message: "queued downstream build", Delivery: buildArtifactTriggerDeliveryView{DeliveryID: "delivery-1", Status: "queued", DownstreamBuildID: stringPtr("build-2")}}
 	trimmedTriggerPayload := makeBuildArtifactTriggerDeliveriesPayload(" build-fallback ", api.BuildArtifactTriggerDeliveriesResponse{
 		BuildID:                  "",
 		BuildTriggerKind:         "  ",
@@ -276,10 +277,27 @@ func TestBuildHelperFormattingAndFallbacks(t *testing.T) {
 		t.Fatalf("writeBuildArtifactTriggersHuman failed: %v", err)
 	}
 	artifactTriggersOut := buf.String()
-	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "queued", "report.xml", "deploy", "build-2", "queue failed"} {
+	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "delivery-1", "delivery-2", "queued", "report.xml", "deploy", "build-2", "queue failed"} {
 		if !strings.Contains(artifactTriggersOut, want) {
 			t.Fatalf("expected %q in artifact trigger output, got %s", want, artifactTriggersOut)
 		}
+	}
+	buf.Reset()
+	if err := writeBuildArtifactTriggerRetryHuman(buf, retryTriggerPayload); err != nil {
+		t.Fatalf("writeBuildArtifactTriggerRetryHuman failed: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Retried artifact-trigger delivery delivery-1 -> build-2") || !strings.Contains(got, "Status: queued") {
+		t.Fatalf("unexpected artifact trigger retry output: %s", got)
+	}
+	buf.Reset()
+	if err := writeBuildArtifactTriggerRetryHuman(buf, buildArtifactTriggerRetryPayload{Result: "already_satisfied", Message: "artifact trigger delivery already points at a downstream build", Delivery: buildArtifactTriggerDeliveryView{DeliveryID: "delivery-2", Status: "queued", DownstreamBuildID: stringPtr("build-9")}}); err != nil {
+		t.Fatalf("writeBuildArtifactTriggerRetryHuman already satisfied failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "already points at downstream build build-9") {
+		t.Fatalf("unexpected already satisfied retry output: %s", buf.String())
+	}
+	if err := writeBuildArtifactTriggerRetryHuman(failWriter{}, retryTriggerPayload); err == nil {
+		t.Fatal("expected writeBuildArtifactTriggerRetryHuman to surface write errors")
 	}
 	buf.Reset()
 	if err := writeBuildArtifactTriggersHuman(buf, buildArtifactTriggerDeliveriesPayload{BuildID: "build-1", BuildTriggerKind: "artifact", RecursiveDispatchBlocked: true, Summary: buildArtifactTriggerSummaryView{}}); err != nil {

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -756,6 +756,8 @@ func TestBuildArtifactTriggersCommand(t *testing.T) {
 		switch r.URL.String() {
 		case "/api/builds/build-1/artifact-triggers":
 			_, _ = w.Write([]byte(`{"data":{"build_id":"build-1","build_trigger_kind":"manual","recursive_dispatch_blocked":false,"summary":{"delivery_count":2,"queued_count":1,"failed_count":1},"deliveries":[{"delivery_id":"delivery-1","status":"queued","created_at":"2026-07-05T00:00:01Z","updated_at":"2026-07-05T00:00:02Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-1","artifact_path":"reports/report.xml","artifact_name":"report.xml","artifact_size_bytes":42,"consumer_job_id":"job-deploy","consumer_job_name":"deploy","downstream_build_id":"build-2"},{"delivery_id":"delivery-2","status":"failed","created_at":"2026-07-05T00:00:03Z","updated_at":"2026-07-05T00:00:04Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-2","artifact_path":"docs/summary.txt","consumer_job_id":"job-docs","error_message":"queue failed"}]}}`))
+		case "/api/artifact-trigger-deliveries/delivery-2/retry":
+			_, _ = w.Write([]byte(`{"data":{"result":"retried","message":"queued downstream build","delivery":{"delivery_id":"delivery-2","status":"queued","created_at":"2026-07-05T00:00:03Z","updated_at":"2026-07-05T00:00:05Z","producer_build_id":"build-1","producer_project_id":"project-1","producer_job_id":"job-upstream","artifact_id":"artifact-2","artifact_path":"docs/summary.txt","consumer_job_id":"job-docs","downstream_build_id":"build-3"}}}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -781,7 +783,7 @@ func TestBuildArtifactTriggersCommand(t *testing.T) {
 	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "build-1"}}); code != 0 {
 		t.Fatalf("build artifact-triggers exit code %d stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "report.xml", "deploy", "build-2", "queue failed"} {
+	for _, want := range []string{"Artifact trigger deliveries for build build-1", "Summary: 2 deliveries, 1 queued, 1 failed", "delivery-1", "delivery-2", "report.xml", "deploy", "build-2", "queue failed"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("expected %q in human output, got %s", want, stdout.String())
 		}
@@ -813,6 +815,28 @@ func TestBuildArtifactTriggersCommand(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Artifact trigger deliveries for build") {
 		t.Fatalf("unexpected human prose in artifact trigger JSON: %s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "retry", "delivery-2"}}); code != 0 {
+		t.Fatalf("build artifact-triggers retry exit code %d stderr=%s", code, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "Retried artifact-trigger delivery delivery-2 -> build-3") || !strings.Contains(got, "Status: queued") {
+		t.Fatalf("unexpected artifact trigger retry output: %s", got)
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	if code := Run(Dependencies{Stdout: stdout, Stderr: stderr, ConfigStore: configStore, Credentials: creds, Args: []string{"build", "artifact-triggers", "retry", "delivery-2", "--json"}}); code != 0 {
+		t.Fatalf("build artifact-triggers retry json exit code %d stderr=%s", code, stderr.String())
+	}
+	payload = map[string]any{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode build artifact trigger retry json: %v", err)
+	}
+	if payload["result"] != "retried" {
+		t.Fatalf("unexpected artifact trigger retry payload: %+v", payload)
 	}
 }
 

--- a/backend/internal/http/handler/authz_handlers_test.go
+++ b/backend/internal/http/handler/authz_handlers_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/auth"
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/logs"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
 	"github.com/radiation/coyote-ci/backend/internal/service"
 	artifactsvc "github.com/radiation/coyote-ci/backend/internal/service/artifact"
@@ -630,6 +632,51 @@ func TestScopedAPITokenRouteEnforcement(t *testing.T) {
 		t.Fatalf("expected missing build:read for artifact triggers status %d, got %d body=%s", http.StatusForbidden, artifactTriggersWrongScopeRes.Code, artifactTriggersWrongScopeRes.Body.String())
 	}
 
+	retryArtifactRepo := &authzFakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{}}
+	retryBuildRepo := repositorymemory.NewBuildRepository()
+	retryJobRepo := repositorymemory.NewJobRepository()
+	retryDeliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
+	retryBuildService := buildsvc.NewBuildService(retryBuildRepo, nil, logs.NewNoopSink())
+	retryBuildService.SetArtifactPersistence(retryArtifactRepo, nil, "")
+	retryJobService := service.NewJobService(retryJobRepo, retryBuildService).WithArtifactTriggerDeliveryRepository(retryDeliveryRepo)
+	retryHandler := NewBuildHandler(retryBuildService)
+	retryHandler.SetJobService(retryJobService)
+	retryHandler.SetAuthorization(auth.ModeHeader, fixture.membershipService)
+	retryProducerJob, createErr := retryJobRepo.Create(ctx, domain.Job{ID: "job-retry-upstream", ProjectID: fixture.projectViewer.ID, Name: "retry-upstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: build\n    run: echo build\n", Enabled: true, CreatedAt: fixture.now, UpdatedAt: fixture.now})
+	if createErr != nil {
+		t.Fatalf("create retry producer job failed: %v", createErr)
+	}
+	retryConsumerJob, createErr := retryJobRepo.Create(ctx, domain.Job{ID: "job-retry-consumer", ProjectID: fixture.projectViewer.ID, Name: "retry-consumer", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: consume\n    run: echo consume\n", Enabled: true, CreatedAt: fixture.now, UpdatedAt: fixture.now})
+	if createErr != nil {
+		t.Fatalf("create retry consumer job failed: %v", createErr)
+	}
+	retryProducerBuild, createErr := retryBuildRepo.CreateQueuedBuild(ctx, domain.Build{ID: "build-retry-upstream", ProjectID: fixture.projectViewer.ID, JobID: &retryProducerJob.ID, Status: domain.BuildStatusQueued, CreatedAt: fixture.now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}, nil)
+	if createErr != nil {
+		t.Fatalf("create retry producer build failed: %v", createErr)
+	}
+	if _, createErr := retryArtifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-retry-1", BuildID: retryProducerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: fixture.now}); createErr != nil {
+		t.Fatalf("create retry artifact failed: %v", createErr)
+	}
+	errorMessage := "queue failed"
+	if _, createErr := retryDeliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-retry-1", ArtifactID: "artifact-retry-1", ConsumerJobID: retryConsumerJob.ID, ProducerBuildID: retryProducerBuild.ID, ProducerProjectID: fixture.projectViewer.ID, ProducerJobID: retryProducerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: fixture.now, UpdatedAt: fixture.now}); createErr != nil {
+		t.Fatalf("create retry delivery failed: %v", createErr)
+	}
+	retryWrongScopeReq := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-retry-1/retry", nil), "deliveryID", "delivery-retry-1")
+	retryWrongScopeReq = withScopedAPIToken(retryWrongScopeReq, fixture.maintainer, domain.APITokenScopeBuildRead)
+	retryWrongScopeRes := httptest.NewRecorder()
+	retryHandler.RetryArtifactTriggerDelivery(retryWrongScopeRes, retryWrongScopeReq)
+	if retryWrongScopeRes.Code != http.StatusForbidden {
+		t.Fatalf("expected missing build:run for artifact trigger retry status %d, got %d body=%s", http.StatusForbidden, retryWrongScopeRes.Code, retryWrongScopeRes.Body.String())
+	}
+
+	retryReq := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-retry-1/retry", nil), "deliveryID", "delivery-retry-1")
+	retryReq = withScopedAPIToken(retryReq, fixture.maintainer, domain.APITokenScopeBuildRun)
+	retryRes := httptest.NewRecorder()
+	retryHandler.RetryArtifactTriggerDelivery(retryRes, retryReq)
+	if retryRes.Code != http.StatusOK {
+		t.Fatalf("expected build:run artifact trigger retry status %d, got %d body=%s", http.StatusOK, retryRes.Code, retryRes.Body.String())
+	}
+
 	queueReq := addBuildIDParam(httptest.NewRequest(http.MethodPost, "/builds/"+build.ID+"/queue", nil), build.ID)
 	queueReq = withScopedAPIToken(queueReq, fixture.maintainer, domain.APITokenScopeBuildRead)
 	queueRes := httptest.NewRecorder()
@@ -805,4 +852,67 @@ func newHandlerAuthzFixture(t *testing.T) handlerAuthzFixture {
 		buildService:      buildService,
 		membershipService: membershipService,
 	}
+}
+
+type authzFakeArtifactRepo struct {
+	artifactsByBuild map[string][]domain.BuildArtifact
+}
+
+func (r *authzFakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifact) (domain.BuildArtifact, error) {
+	if r.artifactsByBuild == nil {
+		r.artifactsByBuild = map[string][]domain.BuildArtifact{}
+	}
+	r.artifactsByBuild[artifact.BuildID] = append(r.artifactsByBuild[artifact.BuildID], artifact)
+	return artifact, nil
+}
+
+func (r *authzFakeArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]domain.BuildArtifact, error) {
+	items := append([]domain.BuildArtifact(nil), r.artifactsByBuild[buildID]...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+	return items, nil
+}
+
+func (r *authzFakeArtifactRepo) Browse(_ context.Context, _ repository.BrowseArtifactsParams) ([]domain.ArtifactBrowseRecord, error) {
+	return nil, nil
+}
+
+func (r *authzFakeArtifactRepo) ListCatalog(_ context.Context, _ repository.ArtifactCatalogParams) ([]domain.ArtifactRecord, error) {
+	return nil, nil
+}
+
+func (r *authzFakeArtifactRepo) GetCatalogByID(_ context.Context, artifactID string) (domain.ArtifactRecord, error) {
+	for buildID, items := range r.artifactsByBuild {
+		for _, item := range items {
+			if item.ID == artifactID {
+				return domain.ArtifactRecord{Artifact: item, Build: domain.Build{ID: buildID}}, nil
+			}
+		}
+	}
+	return domain.ArtifactRecord{}, repository.ErrArtifactNotFound
+}
+
+func (r *authzFakeArtifactRepo) GetByID(_ context.Context, buildID string, artifactID string) (domain.BuildArtifact, error) {
+	for _, item := range r.artifactsByBuild[buildID] {
+		if item.ID == artifactID {
+			return item, nil
+		}
+	}
+	return domain.BuildArtifact{}, repository.ErrArtifactNotFound
+}
+
+func (r *authzFakeArtifactRepo) ListByStepID(_ context.Context, stepID string) ([]domain.BuildArtifact, error) {
+	var out []domain.BuildArtifact
+	for _, items := range r.artifactsByBuild {
+		for _, item := range items {
+			if item.StepID != nil && *item.StepID == stepID {
+				out = append(out, item)
+			}
+		}
+	}
+	return out, nil
 }

--- a/backend/internal/http/handler/authz_handlers_test.go
+++ b/backend/internal/http/handler/authz_handlers_test.go
@@ -195,14 +195,14 @@ func TestJobHandler_HeaderModeAuthorizationAndFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create fixture job failed: %v", err)
 	}
-	if _, err := fixture.jobService.CreateJob(context.Background(), service.CreateJobInput{
+	if _, createOtherJobErr := fixture.jobService.CreateJob(context.Background(), service.CreateJobInput{
 		ProjectID:     fixture.projectOther.ID,
 		Name:          "backend-other",
 		RepositoryURL: "https://github.com/example/other.git",
 		DefaultRef:    "main",
 		PipelineYAML:  "version: 1\nsteps:\n  - name: test\n    run: go test ./...\n",
-	}); err != nil {
-		t.Fatalf("create other job failed: %v", err)
+	}); createOtherJobErr != nil {
+		t.Fatalf("create other job failed: %v", createOtherJobErr)
 	}
 
 	h := NewJobHandler(fixture.jobService)
@@ -366,11 +366,11 @@ func TestBuildHandler_HeaderModeAuthorizationAndFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create viewer build failed: %v", err)
 	}
-	if _, err := fixture.buildService.CreateBuild(context.Background(), buildsvc.CreateBuildInput{
+	if _, createOtherBuildErr := fixture.buildService.CreateBuild(context.Background(), buildsvc.CreateBuildInput{
 		ProjectID: fixture.projectOther.ID,
 		Steps:     []buildsvc.CreateBuildStepInput{{Name: "test", Command: "go", Args: []string{"test", "./..."}}},
-	}); err != nil {
-		t.Fatalf("create other build failed: %v", err)
+	}); createOtherBuildErr != nil {
+		t.Fatalf("create other build failed: %v", createOtherBuildErr)
 	}
 
 	h := NewBuildHandler(fixture.buildService)
@@ -833,8 +833,8 @@ func newHandlerAuthzFixture(t *testing.T) handlerAuthzFixture {
 		{projectID: projectViewer.ID, userID: maintainer.ID, role: "maintainer"},
 		{projectID: projectViewer.ID, userID: owner.ID, role: "owner"},
 	} {
-		if _, err := membershipService.UpsertProjectMembership(ctx, service.UpsertProjectMembershipInput{ProjectID: membership.projectID, UserID: membership.userID, Role: membership.role}); err != nil {
-			t.Fatalf("create membership failed: %v", err)
+		if _, upsertMembershipErr := membershipService.UpsertProjectMembership(ctx, service.UpsertProjectMembershipInput{ProjectID: membership.projectID, UserID: membership.userID, Role: membership.role}); upsertMembershipErr != nil {
+			t.Fatalf("create membership failed: %v", upsertMembershipErr)
 		}
 	}
 

--- a/backend/internal/http/handler/build_handler_artifact_triggers.go
+++ b/backend/internal/http/handler/build_handler_artifact_triggers.go
@@ -1,13 +1,16 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/auth"
 	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
 	"github.com/radiation/coyote-ci/backend/internal/service"
 )
 
@@ -75,28 +78,10 @@ func (h *BuildHandler) GetBuildArtifactTriggers(w http.ResponseWriter, r *http.R
 		var artifactName *string
 		var artifactSizeBytes *int64
 		if artifact, ok := artifactsByID[delivery.ArtifactID]; ok {
-			artifactName = trimOptionalArtifactTriggerString(&artifact.Name)
-			sizeBytes := artifact.SizeBytes
-			artifactSizeBytes = &sizeBytes
+			artifactName, artifactSizeBytes = buildArtifactTriggerArtifactMetadata(artifact)
 		}
 
-		deliveries = append(deliveries, api.BuildArtifactTriggerDeliveryResponse{
-			DeliveryID:        delivery.ID,
-			Status:            string(delivery.Status),
-			CreatedAt:         delivery.CreatedAt.Format(timeFormatRFC3339()),
-			UpdatedAt:         delivery.UpdatedAt.Format(timeFormatRFC3339()),
-			ProducerBuildID:   delivery.ProducerBuildID,
-			ProducerProjectID: delivery.ProducerProjectID,
-			ProducerJobID:     delivery.ProducerJobID,
-			ArtifactID:        delivery.ArtifactID,
-			ArtifactPath:      delivery.ArtifactPath,
-			ArtifactName:      artifactName,
-			ArtifactSizeBytes: artifactSizeBytes,
-			ConsumerJobID:     delivery.ConsumerJobID,
-			ConsumerJobName:   view.ConsumerJobName,
-			DownstreamBuildID: delivery.QueuedBuildID,
-			ErrorMessage:      trimOptionalArtifactTriggerString(delivery.ErrorMessage),
-		})
+		deliveries = append(deliveries, toBuildArtifactTriggerDeliveryResponse(view, artifactName, artifactSizeBytes))
 	}
 
 	writeDataJSON(w, http.StatusOK, api.BuildArtifactTriggerDeliveriesResponse{
@@ -105,6 +90,56 @@ func (h *BuildHandler) GetBuildArtifactTriggers(w http.ResponseWriter, r *http.R
 		RecursiveDispatchBlocked: build.Trigger.Kind == domain.BuildTriggerKindArtifact,
 		Summary:                  summary,
 		Deliveries:               deliveries,
+	})
+}
+
+// RetryArtifactTriggerDelivery godoc
+// @Summary Retry artifact trigger delivery
+// @Description Retries a failed artifact-trigger delivery by delivery id.
+// @Tags artifact-trigger-deliveries
+// @Produce json
+// @Param deliveryID path string true "Delivery ID"
+// @Success 200 {object} api.BuildArtifactTriggerDeliveryRetryEnvelope
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /artifact-trigger-deliveries/{deliveryID}/retry [post]
+func (h *BuildHandler) RetryArtifactTriggerDelivery(w http.ResponseWriter, r *http.Request) {
+	deliveryID := strings.TrimSpace(chi.URLParam(r, "deliveryID"))
+	if deliveryID == "" {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "delivery id is required")
+		return
+	}
+	if h.jobs == nil {
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "job service is not configured")
+		return
+	}
+	view, err := h.jobs.GetArtifactTriggerDeliveryByID(r.Context(), deliveryID)
+	if err != nil {
+		h.writeArtifactTriggerDeliveryError(w, err)
+		return
+	}
+	if !authorizeProject(w, r, h.authMode, h.projectRoles, view.Delivery.ProducerProjectID, auth.CanTriggerBuild, "project owner or maintainer is required") {
+		return
+	}
+	if !requireAPITokenScope(w, r, domain.APITokenScopeBuildRun) {
+		return
+	}
+	retryResult, err := h.jobs.RetryArtifactTriggerDelivery(r.Context(), deliveryID)
+	if err != nil {
+		h.writeArtifactTriggerDeliveryError(w, err)
+		return
+	}
+	artifactName, artifactSizeBytes, artifactErr := h.buildArtifactTriggerArtifactMetadata(r, retryResult.View.Delivery)
+	if artifactErr != nil {
+		h.writeArtifactTriggerDeliveryError(w, artifactErr)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, api.BuildArtifactTriggerDeliveryRetryResponse{
+		Result:   retryResult.Result,
+		Message:  retryResult.Message,
+		Delivery: toBuildArtifactTriggerDeliveryResponse(retryResult.View, artifactName, artifactSizeBytes),
 	})
 }
 
@@ -121,4 +156,61 @@ func trimOptionalArtifactTriggerString(value *string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func (h *BuildHandler) buildArtifactTriggerArtifactMetadata(r *http.Request, delivery domain.ArtifactTriggerDelivery) (*string, *int64, error) {
+	artifacts, err := h.buildService.GetBuildArtifacts(r.Context(), delivery.ProducerBuildID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, artifact := range artifacts {
+		if artifact.ID == delivery.ArtifactID {
+			artifactName, artifactSizeBytes := buildArtifactTriggerArtifactMetadata(artifact)
+			return artifactName, artifactSizeBytes, nil
+		}
+	}
+	return nil, nil, nil
+}
+
+func buildArtifactTriggerArtifactMetadata(artifact domain.BuildArtifact) (*string, *int64) {
+	artifactName := trimOptionalArtifactTriggerString(&artifact.Name)
+	sizeBytes := artifact.SizeBytes
+	return artifactName, &sizeBytes
+}
+
+func toBuildArtifactTriggerDeliveryResponse(view service.ArtifactTriggerDeliveryView, artifactName *string, artifactSizeBytes *int64) api.BuildArtifactTriggerDeliveryResponse {
+	delivery := view.Delivery
+	return api.BuildArtifactTriggerDeliveryResponse{
+		DeliveryID:        delivery.ID,
+		Status:            string(delivery.Status),
+		CreatedAt:         delivery.CreatedAt.Format(timeFormatRFC3339()),
+		UpdatedAt:         delivery.UpdatedAt.Format(timeFormatRFC3339()),
+		ProducerBuildID:   delivery.ProducerBuildID,
+		ProducerProjectID: delivery.ProducerProjectID,
+		ProducerJobID:     delivery.ProducerJobID,
+		ArtifactID:        delivery.ArtifactID,
+		ArtifactPath:      delivery.ArtifactPath,
+		ArtifactName:      artifactName,
+		ArtifactSizeBytes: artifactSizeBytes,
+		ConsumerJobID:     delivery.ConsumerJobID,
+		ConsumerJobName:   view.ConsumerJobName,
+		DownstreamBuildID: delivery.QueuedBuildID,
+		ErrorMessage:      trimOptionalArtifactTriggerString(delivery.ErrorMessage),
+	}
+}
+
+func (h *BuildHandler) writeArtifactTriggerDeliveryError(w http.ResponseWriter, err error) {
+	if errors.Is(err, service.ErrJobArtifactTriggerDeliveryRepositoryNotConfigured) || errors.Is(err, service.ErrJobBuildServiceNotConfigured) {
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
+		writeErrorJSON(w, http.StatusNotFound, "artifact_trigger_delivery_not_found", "artifact trigger delivery not found")
+		return
+	}
+	if errors.Is(err, service.ErrArtifactTriggerDeliveryQueuedBuildConflict) || errors.Is(err, service.ErrArtifactTriggerDeliveryPendingRetryDeferred) || errors.Is(err, service.ErrArtifactTriggerDeliveryRetryNotSupported) {
+		writeErrorJSON(w, http.StatusConflict, "artifact_trigger_delivery_not_retryable", err.Error())
+		return
+	}
+	h.writeServiceError(w, err)
 }

--- a/backend/internal/http/handler/build_handler_test.go
+++ b/backend/internal/http/handler/build_handler_test.go
@@ -100,6 +100,7 @@ func (r *failingProjectRepo) Delete(_ context.Context, _ string) error {
 type fakeArtifactRepo struct {
 	artifactsByBuild map[string][]domain.BuildArtifact
 	listByBuildErr   error
+	listByBuildErrs  []error
 }
 
 func (r *fakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifact) (domain.BuildArtifact, error) {
@@ -111,6 +112,13 @@ func (r *fakeArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifa
 }
 
 func (r *fakeArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]domain.BuildArtifact, error) {
+	if len(r.listByBuildErrs) > 0 {
+		err := r.listByBuildErrs[0]
+		r.listByBuildErrs = r.listByBuildErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	if r.listByBuildErr != nil {
 		return nil, r.listByBuildErr
 	}
@@ -1418,11 +1426,11 @@ func TestBuildHandler_GetBuildIncludesJobNameAndCurrentSteps(t *testing.T) {
 	projectRepo := repositorymemory.NewProjectRepository(jobRepo)
 	jobService := service.NewJobService(jobRepo, nil).WithProjectRepository(projectRepo)
 	jobID := "job-1"
-	if _, err := projectRepo.Create(context.Background(), domain.Project{ID: "project-1", Name: "Default Project", Slug: "default", CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create project failed: %v", err)
+	if _, createProjectErr := projectRepo.Create(context.Background(), domain.Project{ID: "project-1", Name: "Default Project", Slug: "default", CreatedAt: now, UpdatedAt: now}); createProjectErr != nil {
+		t.Fatalf("create project failed: %v", createProjectErr)
 	}
-	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: jobID, ProjectID: "project-1", Name: "coyote-ci", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create job failed: %v", err)
+	if _, createJobErr := jobRepo.Create(context.Background(), domain.Job{ID: jobID, ProjectID: "project-1", Name: "coyote-ci", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); createJobErr != nil {
+		t.Fatalf("create job failed: %v", createJobErr)
 	}
 	repo := &fakeRepo{
 		build: domain.Build{ID: "build-1", ProjectID: "project-1", JobID: &jobID, Status: domain.BuildStatusRunning, CreatedAt: now},
@@ -1476,16 +1484,16 @@ func TestBuildHandler_GetBuildArtifactTriggers(t *testing.T) {
 	jobRepo := repositorymemory.NewJobRepository()
 	deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
 	jobService := service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
-	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create downstream job failed: %v", err)
+	if _, createDownstreamJobErr := jobRepo.Create(context.Background(), domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); createDownstreamJobErr != nil {
+		t.Fatalf("create downstream job failed: %v", createDownstreamJobErr)
 	}
 	errorMessage := "queue failed"
 	queuedBuildID := "build-2"
-	if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", QueuedBuildID: &queuedBuildID, Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create queued delivery failed: %v", err)
+	if _, createQueuedDeliveryErr := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", QueuedBuildID: &queuedBuildID, Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); createQueuedDeliveryErr != nil {
+		t.Fatalf("create queued delivery failed: %v", createQueuedDeliveryErr)
 	}
-	if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-2", ArtifactID: "artifact-missing", ConsumerJobID: "job-missing", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/docs.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)}); err != nil {
-		t.Fatalf("create failed delivery failed: %v", err)
+	if _, createFailedDeliveryErr := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-2", ArtifactID: "artifact-missing", ConsumerJobID: "job-missing", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/docs.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)}); createFailedDeliveryErr != nil {
+		t.Fatalf("create failed delivery failed: %v", createFailedDeliveryErr)
 	}
 
 	h := NewBuildHandler(buildService)
@@ -1615,8 +1623,8 @@ func TestBuildHandler_GetBuildArtifactTriggersErrorPaths(t *testing.T) {
 		buildService.SetArtifactPersistence(artifactRepo, nil, "")
 		jobRepo := &erroringArtifactTriggerJobRepo{JobRepository: repositorymemory.NewJobRepository(), getByIDsErr: errors.New("lookup failed")}
 		deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
-		if _, err := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); err != nil {
-			t.Fatalf("create delivery failed: %v", err)
+		if _, createDeliveryErr := deliveryRepo.Create(context.Background(), domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: "job-downstream", ProducerBuildID: "build-1", ProducerProjectID: "project-1", ProducerJobID: "job-upstream", ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); createDeliveryErr != nil {
+			t.Fatalf("create delivery failed: %v", createDeliveryErr)
 		}
 		h := NewBuildHandler(buildService)
 		h.SetJobService(service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo))
@@ -1646,6 +1654,13 @@ func TestArtifactTriggerHandlerHelpers(t *testing.T) {
 	if artifactName == nil || *artifactName != "app.tgz" || artifactSize == nil || *artifactSize != 42 {
 		t.Fatalf("unexpected artifact trigger helper metadata: name=%v size=%v", artifactName, artifactSize)
 	}
+	buildService := buildsvc.NewBuildService(&fakeRepo{build: domain.Build{ID: "build-1", ProjectID: "project-1", Status: domain.BuildStatusSuccess, CreatedAt: time.Now().UTC()}}, nil, nil)
+	buildService.SetArtifactPersistence(&fakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{"build-1": {}}}, nil, "")
+	h := NewBuildHandler(buildService)
+	artifactName, artifactSize, err := h.buildArtifactTriggerArtifactMetadata(httptest.NewRequest(http.MethodGet, "/", nil), domain.ArtifactTriggerDelivery{ProducerBuildID: "build-1", ArtifactID: "missing"})
+	if err != nil || artifactName != nil || artifactSize != nil {
+		t.Fatalf("expected missing artifact metadata lookup to return nil metadata without error, got name=%v size=%v err=%v", artifactName, artifactSize, err)
+	}
 }
 
 func TestBuildHandler_RetryArtifactTriggerDelivery(t *testing.T) {
@@ -1671,12 +1686,12 @@ func TestBuildHandler_RetryArtifactTriggerDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create producer build failed: %v", err)
 	}
-	if _, err := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); err != nil {
-		t.Fatalf("create artifact failed: %v", err)
+	if _, createArtifactErr := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); createArtifactErr != nil {
+		t.Fatalf("create artifact failed: %v", createArtifactErr)
 	}
 	errorMessage := "queue failed"
-	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create failed delivery failed: %v", err)
+	if _, createFailedDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); createFailedDeliveryErr != nil {
+		t.Fatalf("create failed delivery failed: %v", createFailedDeliveryErr)
 	}
 
 	h := NewBuildHandler(buildService)
@@ -1699,8 +1714,8 @@ func TestBuildHandler_RetryArtifactTriggerDelivery(t *testing.T) {
 		t.Fatalf("expected downstream build id in retry payload, got %+v", delivery)
 	}
 
-	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-pending", ArtifactID: "artifact-pending", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusPending, CreatedAt: now, UpdatedAt: now}); err != nil {
-		t.Fatalf("create pending delivery failed: %v", err)
+	if _, createPendingDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-pending", ArtifactID: "artifact-pending", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusPending, CreatedAt: now, UpdatedAt: now}); createPendingDeliveryErr != nil {
+		t.Fatalf("create pending delivery failed: %v", createPendingDeliveryErr)
 	}
 	pendingReq := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-pending/retry", nil), "deliveryID", "delivery-pending")
 	pendingRes := httptest.NewRecorder()
@@ -1715,6 +1730,89 @@ func TestBuildHandler_RetryArtifactTriggerDelivery(t *testing.T) {
 	if missingRes.Code != http.StatusNotFound {
 		t.Fatalf("expected missing status %d, got %d body=%s", http.StatusNotFound, missingRes.Code, missingRes.Body.String())
 	}
+}
+
+func TestBuildHandler_RetryArtifactTriggerDeliveryErrorPaths(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	t.Run("missing delivery id", func(t *testing.T) {
+		h := NewBuildHandler(buildsvc.NewBuildService(&fakeRepo{}, nil, nil))
+		rr := httptest.NewRecorder()
+		h.RetryArtifactTriggerDelivery(rr, httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries//retry", nil))
+		if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "delivery id is required") {
+			t.Fatalf("unexpected missing delivery id response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("missing job service", func(t *testing.T) {
+		h := NewBuildHandler(buildsvc.NewBuildService(&fakeRepo{}, nil, nil))
+		req := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-1/retry", nil), "deliveryID", "delivery-1")
+		rr := httptest.NewRecorder()
+		h.RetryArtifactTriggerDelivery(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "job service is not configured") {
+			t.Fatalf("unexpected missing job service response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("artifact metadata lookup failure after retry returns internal error", func(t *testing.T) {
+		ctx := context.Background()
+		jobRepo := repositorymemory.NewJobRepository()
+		buildRepo := repositorymemory.NewBuildRepository()
+		deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
+		artifactRepo := &fakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{}, listByBuildErrs: []error{nil, repository.ErrBuildNotFound}}
+		buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+		buildService.SetArtifactPersistence(artifactRepo, nil, "")
+		jobService := service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+		producerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-upstream", ProjectID: "project-1", Name: "upstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: build\n    run: make build\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+		if err != nil {
+			t.Fatalf("create producer job failed: %v", err)
+		}
+		consumerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: consume\n    run: echo consume\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+		if err != nil {
+			t.Fatalf("create consumer job failed: %v", err)
+		}
+		producerBuild, err := buildRepo.CreateQueuedBuild(ctx, domain.Build{ID: "build-upstream", ProjectID: "project-1", JobID: &producerJob.ID, Status: domain.BuildStatusQueued, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}, nil)
+		if err != nil {
+			t.Fatalf("create producer build failed: %v", err)
+		}
+		if _, createArtifactErr := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); createArtifactErr != nil {
+			t.Fatalf("create artifact failed: %v", createArtifactErr)
+		}
+		errorMessage := "queue failed"
+		if _, createDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); createDeliveryErr != nil {
+			t.Fatalf("create failed delivery failed: %v", createDeliveryErr)
+		}
+		h := NewBuildHandler(buildService)
+		h.SetJobService(jobService)
+		req := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-1/retry", nil), "deliveryID", "delivery-1")
+		rr := httptest.NewRecorder()
+		h.RetryArtifactTriggerDelivery(rr, req)
+		if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "internal server error") {
+			t.Fatalf("unexpected metadata lookup failure response: status=%d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("error mapper covers internal and conflict responses", func(t *testing.T) {
+		h := NewBuildHandler(buildsvc.NewBuildService(&fakeRepo{}, nil, nil))
+		for _, tc := range []struct {
+			name       string
+			err        error
+			statusCode int
+			bodyText   string
+		}{
+			{name: "missing repo", err: service.ErrJobArtifactTriggerDeliveryRepositoryNotConfigured, statusCode: http.StatusInternalServerError, bodyText: service.ErrJobArtifactTriggerDeliveryRepositoryNotConfigured.Error()},
+			{name: "missing build service", err: service.ErrJobBuildServiceNotConfigured, statusCode: http.StatusInternalServerError, bodyText: service.ErrJobBuildServiceNotConfigured.Error()},
+			{name: "conflict", err: service.ErrArtifactTriggerDeliveryRetryNotSupported, statusCode: http.StatusConflict, bodyText: service.ErrArtifactTriggerDeliveryRetryNotSupported.Error()},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				h.writeArtifactTriggerDeliveryError(rr, tc.err)
+				if rr.Code != tc.statusCode || !strings.Contains(rr.Body.String(), tc.bodyText) {
+					t.Fatalf("unexpected mapped response: status=%d body=%s", rr.Code, rr.Body.String())
+				}
+			})
+		}
+	})
 }
 
 func TestBuildHandler_GetBuildSteps_HappyPathOrdered(t *testing.T) {

--- a/backend/internal/http/handler/build_handler_test.go
+++ b/backend/internal/http/handler/build_handler_test.go
@@ -1642,6 +1642,79 @@ func TestArtifactTriggerHandlerHelpers(t *testing.T) {
 	if got := trimOptionalArtifactTriggerString(stringPtr(" value ")); got == nil || *got != "value" {
 		t.Fatalf("expected trimmed value, got %v", got)
 	}
+	artifactName, artifactSize := buildArtifactTriggerArtifactMetadata(domain.BuildArtifact{Name: " app.tgz ", SizeBytes: 42})
+	if artifactName == nil || *artifactName != "app.tgz" || artifactSize == nil || *artifactSize != 42 {
+		t.Fatalf("unexpected artifact trigger helper metadata: name=%v size=%v", artifactName, artifactSize)
+	}
+}
+
+func TestBuildHandler_RetryArtifactTriggerDelivery(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	jobRepo := repositorymemory.NewJobRepository()
+	buildRepo := repositorymemory.NewBuildRepository()
+	deliveryRepo := repositorymemory.NewArtifactTriggerDeliveryRepository()
+	artifactRepo := &fakeArtifactRepo{artifactsByBuild: map[string][]domain.BuildArtifact{}}
+	buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+	buildService.SetArtifactPersistence(artifactRepo, nil, "")
+	jobService := service.NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+
+	producerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-upstream", ProjectID: "project-1", Name: "upstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: build\n    run: make build\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("create producer job failed: %v", err)
+	}
+	consumerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: consume\n    run: echo consume\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("create consumer job failed: %v", err)
+	}
+	producerBuild, err := buildRepo.CreateQueuedBuild(ctx, domain.Build{ID: "build-upstream", ProjectID: "project-1", JobID: &producerJob.ID, Status: domain.BuildStatusQueued, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}, nil)
+	if err != nil {
+		t.Fatalf("create producer build failed: %v", err)
+	}
+	if _, err := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); err != nil {
+		t.Fatalf("create artifact failed: %v", err)
+	}
+	errorMessage := "queue failed"
+	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create failed delivery failed: %v", err)
+	}
+
+	h := NewBuildHandler(buildService)
+	h.SetJobService(jobService)
+	req := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-1/retry", nil), "deliveryID", "delivery-1")
+	rr := httptest.NewRecorder()
+	h.RetryArtifactTriggerDelivery(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	data := decodeDataMap(t, rr)
+	if data["result"] != "retried" {
+		t.Fatalf("unexpected retry response: %+v", data)
+	}
+	delivery, ok := data["delivery"].(map[string]any)
+	if !ok || delivery["delivery_id"] != "delivery-1" || delivery["status"] != "queued" || delivery["artifact_name"] != "app.tgz" {
+		t.Fatalf("unexpected delivery payload: %+v", data["delivery"])
+	}
+	if _, ok := delivery["downstream_build_id"]; !ok {
+		t.Fatalf("expected downstream build id in retry payload, got %+v", delivery)
+	}
+
+	if _, err := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-pending", ArtifactID: "artifact-pending", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusPending, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create pending delivery failed: %v", err)
+	}
+	pendingReq := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/delivery-pending/retry", nil), "deliveryID", "delivery-pending")
+	pendingRes := httptest.NewRecorder()
+	h.RetryArtifactTriggerDelivery(pendingRes, pendingReq)
+	if pendingRes.Code != http.StatusConflict {
+		t.Fatalf("expected pending conflict status %d, got %d body=%s", http.StatusConflict, pendingRes.Code, pendingRes.Body.String())
+	}
+
+	missingReq := addURLParam(httptest.NewRequest(http.MethodPost, "/artifact-trigger-deliveries/missing/retry", nil), "deliveryID", "missing")
+	missingRes := httptest.NewRecorder()
+	h.RetryArtifactTriggerDelivery(missingRes, missingReq)
+	if missingRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing status %d, got %d body=%s", http.StatusNotFound, missingRes.Code, missingRes.Body.String())
+	}
 }
 
 func TestBuildHandler_GetBuildSteps_HappyPathOrdered(t *testing.T) {

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -212,6 +212,7 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 				r.Post("/{buildID}/fail", buildHandler.FailBuild)
 				r.Post("/{buildID}/cancel", buildHandler.CancelBuild)
 			})
+			r.Post("/artifact-trigger-deliveries/{deliveryID}/retry", buildHandler.RetryArtifactTriggerDelivery)
 
 			r.Route("/jobs", func(r chi.Router) {
 				r.Post("/", jobHandler.CreateJob)

--- a/backend/internal/repository/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/artifact_trigger_delivery_repository.go
@@ -3,15 +3,19 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 )
 
 var ErrArtifactTriggerDeliveryNotFound = errors.New("artifact trigger delivery not found")
 var ErrArtifactTriggerDeliveryDuplicate = errors.New("artifact trigger delivery already exists")
+var ErrArtifactTriggerDeliveryRetryNotClaimable = errors.New("artifact trigger delivery retry not claimable")
 
 type ArtifactTriggerDeliveryRepository interface {
+	ClaimFailedForRetry(ctx context.Context, id string, updatedAt time.Time) (domain.ArtifactTriggerDelivery, error)
 	Create(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error)
+	GetByID(ctx context.Context, id string) (domain.ArtifactTriggerDelivery, error)
 	GetByArtifactIDAndConsumerJobID(ctx context.Context, artifactID string, consumerJobID string) (domain.ArtifactTriggerDelivery, error)
 	ListByProducerBuildID(ctx context.Context, producerBuildID string) ([]domain.ArtifactTriggerDelivery, error)
 	Update(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error)

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository.go
@@ -26,6 +26,29 @@ func NewArtifactTriggerDeliveryRepository() *ArtifactTriggerDeliveryRepository {
 	}
 }
 
+func (r *ArtifactTriggerDeliveryRepository) ClaimFailedForRetry(_ context.Context, id string, updatedAt time.Time) (domain.ArtifactTriggerDelivery, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delivery, ok := r.deliveries[strings.TrimSpace(id)]
+	if !ok {
+		return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryNotFound
+	}
+	if delivery.Status != domain.ArtifactTriggerDeliveryStatusFailed || delivery.QueuedBuildID != nil {
+		return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryRetryNotClaimable
+	}
+	now := updatedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	delivery.Status = domain.ArtifactTriggerDeliveryStatusPending
+	delivery.QueuedBuildID = nil
+	delivery.ErrorMessage = nil
+	delivery.UpdatedAt = now
+	r.deliveries[delivery.ID] = delivery
+	return delivery, nil
+}
+
 func (r *ArtifactTriggerDeliveryRepository) Create(_ context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -96,4 +119,15 @@ func (r *ArtifactTriggerDeliveryRepository) Update(_ context.Context, delivery d
 
 func artifactTriggerDeliveryKey(artifactID string, consumerJobID string) string {
 	return artifactID + "\x00" + consumerJobID
+}
+
+func (r *ArtifactTriggerDeliveryRepository) GetByID(_ context.Context, id string) (domain.ArtifactTriggerDelivery, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	delivery, ok := r.deliveries[strings.TrimSpace(id)]
+	if !ok {
+		return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryNotFound
+	}
+	return delivery, nil
 }

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
@@ -171,6 +171,25 @@ func TestArtifactTriggerDeliveryRepository_ClaimFailedForRetry(t *testing.T) {
 		t.Fatalf("expected retry not claimable, got %v", err)
 	}
 
+	queuedBuildID := "build-2"
+	if _, createQueuedErr := repo.Create(context.Background(), domain.ArtifactTriggerDelivery{
+		ID:                "delivery-queued",
+		ArtifactID:        "artifact-queued",
+		ConsumerJobID:     "job-queued",
+		ProducerBuildID:   "build-1",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "producer-1",
+		ArtifactPath:      "dist/queued.tgz",
+		QueuedBuildID:     &queuedBuildID,
+		Status:            domain.ArtifactTriggerDeliveryStatusFailed,
+	}); createQueuedErr != nil {
+		t.Fatalf("create queued delivery failed: %v", createQueuedErr)
+	}
+	_, err = repo.ClaimFailedForRetry(context.Background(), "delivery-queued", time.Time{})
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+		t.Fatalf("expected queued delivery retry not claimable, got %v", err)
+	}
+
 	_, err = repo.ClaimFailedForRetry(context.Background(), "missing", time.Time{})
 	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
 		t.Fatalf("expected not found, got %v", err)

--- a/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/memory/artifact_trigger_delivery_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
@@ -46,6 +47,14 @@ func TestArtifactTriggerDeliveryRepository_CreateDuplicateGetAndUpdate(t *testin
 	}
 	if got.ID != created.ID {
 		t.Fatalf("expected delivery %q, got %#v", created.ID, got)
+	}
+
+	byID, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("get by id failed: %v", err)
+	}
+	if byID.ID != created.ID {
+		t.Fatalf("expected delivery %q from get by id, got %#v", created.ID, byID)
 	}
 
 	queuedBuildID := "build-2"
@@ -127,5 +136,43 @@ func TestArtifactTriggerDeliveryRepository_CreateDuplicateGetAndUpdate(t *testin
 	}
 	if len(deliveries) != 0 {
 		t.Fatalf("expected no deliveries for missing build, got %+v", deliveries)
+	}
+}
+
+func TestArtifactTriggerDeliveryRepository_ClaimFailedForRetry(t *testing.T) {
+	repo := NewArtifactTriggerDeliveryRepository()
+	created, err := repo.Create(context.Background(), domain.ArtifactTriggerDelivery{
+		ID:                "delivery-1",
+		ArtifactID:        "artifact-1",
+		ConsumerJobID:     "job-1",
+		ProducerBuildID:   "build-1",
+		ProducerProjectID: "project-1",
+		ProducerJobID:     "producer-1",
+		ArtifactPath:      "dist/app.tgz",
+		Status:            domain.ArtifactTriggerDeliveryStatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("create failed delivery: %v", err)
+	}
+
+	claimed, err := repo.ClaimFailedForRetry(context.Background(), created.ID, created.UpdatedAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("claim failed for retry: %v", err)
+	}
+	if claimed.Status != domain.ArtifactTriggerDeliveryStatusPending {
+		t.Fatalf("expected pending after claim, got %q", claimed.Status)
+	}
+	if claimed.ErrorMessage != nil {
+		t.Fatalf("expected cleared error message, got %#v", claimed.ErrorMessage)
+	}
+
+	_, err = repo.ClaimFailedForRetry(context.Background(), created.ID, time.Time{})
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+		t.Fatalf("expected retry not claimable, got %v", err)
+	}
+
+	_, err = repo.ClaimFailedForRetry(context.Background(), "missing", time.Time{})
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
+		t.Fatalf("expected not found, got %v", err)
 	}
 }

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
@@ -19,6 +20,35 @@ func NewArtifactTriggerDeliveryRepository(db *sql.DB) *ArtifactTriggerDeliveryRe
 }
 
 const artifactTriggerDeliveryColumns = `id, artifact_id, consumer_job_id, producer_build_id, producer_project_id, producer_job_id, artifact_path, queued_build_id, error_message, status, created_at, updated_at`
+
+func (r *ArtifactTriggerDeliveryRepository) ClaimFailedForRetry(ctx context.Context, id string, updatedAt time.Time) (domain.ArtifactTriggerDelivery, error) {
+	const query = `
+		UPDATE artifact_trigger_deliveries
+		SET queued_build_id = NULL,
+			error_message = NULL,
+			status = $2,
+			updated_at = COALESCE($3, NOW())
+		WHERE id = $1 AND status = $4 AND queued_build_id IS NULL
+		RETURNING ` + artifactTriggerDeliveryColumns + `
+	`
+
+	claimed, err := scanArtifactTriggerDelivery(r.db.QueryRowContext(ctx, query,
+		strings.TrimSpace(id),
+		string(domain.ArtifactTriggerDeliveryStatusPending),
+		nullableTime(updatedAt),
+		string(domain.ArtifactTriggerDeliveryStatusFailed),
+	))
+	if err == nil {
+		return claimed, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return domain.ArtifactTriggerDelivery{}, err
+	}
+	if _, getErr := r.GetByID(ctx, id); getErr != nil {
+		return domain.ArtifactTriggerDelivery{}, getErr
+	}
+	return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryRetryNotClaimable
+}
 
 func (r *ArtifactTriggerDeliveryRepository) Create(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (domain.ArtifactTriggerDelivery, error) {
 	const query = `
@@ -50,6 +80,23 @@ func (r *ArtifactTriggerDeliveryRepository) Create(ctx context.Context, delivery
 		return domain.ArtifactTriggerDelivery{}, err
 	}
 	return created, nil
+}
+
+func (r *ArtifactTriggerDeliveryRepository) GetByID(ctx context.Context, id string) (domain.ArtifactTriggerDelivery, error) {
+	const query = `
+		SELECT ` + artifactTriggerDeliveryColumns + `
+		FROM artifact_trigger_deliveries
+		WHERE id = $1
+	`
+
+	delivery, err := scanArtifactTriggerDelivery(r.db.QueryRowContext(ctx, query, strings.TrimSpace(id)))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ArtifactTriggerDelivery{}, repository.ErrArtifactTriggerDeliveryNotFound
+		}
+		return domain.ArtifactTriggerDelivery{}, err
+	}
+	return delivery, nil
 }
 
 func (r *ArtifactTriggerDeliveryRepository) GetByArtifactIDAndConsumerJobID(ctx context.Context, artifactID string, consumerJobID string) (domain.ArtifactTriggerDelivery, error) {

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
@@ -156,6 +156,15 @@ func TestArtifactTriggerDeliveryRepository_ClaimFailedForRetry(t *testing.T) {
 	}
 
 	mock.ExpectQuery("UPDATE artifact_trigger_deliveries").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("delivery-queued").WillReturnRows(sqlmock.NewRows(row).AddRow(
+		"delivery-queued", "artifact-queued", "job-queued", "build-1", "project-1", "producer-1", "dist/queued.tgz", "build-2", nil, "failed", now, now,
+	))
+	_, err = repo.ClaimFailedForRetry(context.Background(), "delivery-queued", now)
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+		t.Fatalf("expected queued delivery retry not claimable, got %v", err)
+	}
+
+	mock.ExpectQuery("UPDATE artifact_trigger_deliveries").WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("missing").WillReturnError(sql.ErrNoRows)
 	_, err = repo.ClaimFailedForRetry(context.Background(), "missing", now)
 	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {

--- a/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
+++ b/backend/internal/repository/postgres/artifact_trigger_delivery_repository_test.go
@@ -67,6 +67,17 @@ func TestArtifactTriggerDeliveryRepository_CreateGetAndUpdate(t *testing.T) {
 		t.Fatalf("expected error message %q, got %#v", errorMessage, got.ErrorMessage)
 	}
 
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("delivery-1").WillReturnRows(sqlmock.NewRows(row).AddRow(
+		"delivery-1", "artifact-1", "job-1", "build-1", "project-1", "producer-1", "dist/app.tgz", queuedBuildID, errorMessage, "failed", now, now,
+	))
+	byID, err := repo.GetByID(context.Background(), " delivery-1 ")
+	if err != nil {
+		t.Fatalf("get by id failed: %v", err)
+	}
+	if byID.ID != "delivery-1" {
+		t.Fatalf("expected delivery-1 from get by id, got %+v", byID)
+	}
+
 	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WillReturnError(sql.ErrNoRows)
 	_, err = repo.GetByArtifactIDAndConsumerJobID(context.Background(), "missing", "job-1")
 	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
@@ -107,6 +118,48 @@ func TestArtifactTriggerDeliveryRepository_CreateGetAndUpdate(t *testing.T) {
 	}
 	if deliveries[0].ID != "delivery-1" || deliveries[1].ID != "delivery-2" {
 		t.Fatalf("unexpected listed deliveries: %+v", deliveries)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestArtifactTriggerDeliveryRepository_ClaimFailedForRetry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+
+	repo := NewArtifactTriggerDeliveryRepository(db)
+	now := time.Now().UTC()
+	row := []string{"id", "artifact_id", "consumer_job_id", "producer_build_id", "producer_project_id", "producer_job_id", "artifact_path", "queued_build_id", "error_message", "status", "created_at", "updated_at"}
+
+	mock.ExpectQuery("UPDATE artifact_trigger_deliveries").WillReturnRows(sqlmock.NewRows(row).AddRow(
+		"delivery-1", "artifact-1", "job-1", "build-1", "project-1", "producer-1", "dist/app.tgz", nil, nil, "pending", now, now,
+	))
+	claimed, err := repo.ClaimFailedForRetry(context.Background(), "delivery-1", now)
+	if err != nil {
+		t.Fatalf("claim failed for retry: %v", err)
+	}
+	if claimed.Status != domain.ArtifactTriggerDeliveryStatusPending {
+		t.Fatalf("expected pending, got %q", claimed.Status)
+	}
+
+	mock.ExpectQuery("UPDATE artifact_trigger_deliveries").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("delivery-1").WillReturnRows(sqlmock.NewRows(row).AddRow(
+		"delivery-1", "artifact-1", "job-1", "build-1", "project-1", "producer-1", "dist/app.tgz", "build-2", nil, "queued", now, now,
+	))
+	_, err = repo.ClaimFailedForRetry(context.Background(), "delivery-1", now)
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+		t.Fatalf("expected retry not claimable, got %v", err)
+	}
+
+	mock.ExpectQuery("UPDATE artifact_trigger_deliveries").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT .*FROM artifact_trigger_deliveries").WithArgs("missing").WillReturnError(sql.ErrNoRows)
+	_, err = repo.ClaimFailedForRetry(context.Background(), "missing", now)
+	if !errors.Is(err, repository.ErrArtifactTriggerDeliveryNotFound) {
+		t.Fatalf("expected not found, got %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/backend/internal/service/job_service.go
+++ b/backend/internal/service/job_service.go
@@ -39,6 +39,9 @@ var ErrJobManagedImageWriteCredentialIDRequired = errors.New("job managed image 
 var ErrJobArtifactTriggerProducerJobIDRequired = errors.New("job artifact_triggers producer_job_id is required")
 var ErrJobArtifactTriggerPathRequired = errors.New("job artifact_triggers path is required")
 var ErrJobArtifactTriggerSelfReference = errors.New("job artifact_triggers cannot reference the same job")
+var ErrArtifactTriggerDeliveryQueuedBuildConflict = errors.New("artifact trigger delivery already references a downstream build")
+var ErrArtifactTriggerDeliveryPendingRetryDeferred = errors.New("artifact trigger delivery pending recovery is not retryable in v1.3")
+var ErrArtifactTriggerDeliveryRetryNotSupported = errors.New("artifact trigger delivery retry is not supported for this delivery state")
 
 type JobService struct {
 	jobRepo                   repository.JobRepository
@@ -654,15 +657,19 @@ func (s *JobService) dispatchArtifactTriggerToJob(ctx context.Context, producerB
 			if existing.Status != domain.ArtifactTriggerDeliveryStatusFailed {
 				return nil
 			}
-			existing.ProducerBuildID = producerBuild.ID
-			existing.ProducerProjectID = producerBuild.ProjectID
-			existing.ProducerJobID = producerJobID
-			existing.ArtifactPath = artifact.LogicalPath
-			existing.Status = domain.ArtifactTriggerDeliveryStatusPending
-			existing.QueuedBuildID = nil
-			existing.ErrorMessage = nil
-			existing.UpdatedAt = now
-			created, err = s.artifactTriggerDeliveries.Update(ctx, existing)
+			claimed, claimErr := s.artifactTriggerDeliveries.ClaimFailedForRetry(ctx, existing.ID, now)
+			if claimErr != nil {
+				if errors.Is(claimErr, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+					return nil
+				}
+				return claimErr
+			}
+			claimed.ProducerBuildID = producerBuild.ID
+			claimed.ProducerProjectID = producerBuild.ProjectID
+			claimed.ProducerJobID = producerJobID
+			claimed.ArtifactPath = artifact.LogicalPath
+			claimed.UpdatedAt = now
+			created, err = s.artifactTriggerDeliveries.Update(ctx, claimed)
 			if err != nil {
 				return err
 			}
@@ -670,12 +677,16 @@ func (s *JobService) dispatchArtifactTriggerToJob(ctx context.Context, producerB
 			return err
 		}
 	}
-	artifactSizeBytes := artifact.SizeBytes
+	_, err = s.queueArtifactTriggerDelivery(ctx, created, producerBuild, artifact, consumerJob)
+	return err
+}
 
+func (s *JobService) queueArtifactTriggerDelivery(ctx context.Context, delivery domain.ArtifactTriggerDelivery, producerBuild domain.Build, artifact domain.BuildArtifact, consumerJob domain.Job) (domain.ArtifactTriggerDelivery, error) {
+	artifactSizeBytes := artifact.SizeBytes
 	queuedBuild, queueErr := s.createBuildForJobWithTrigger(ctx, consumerJob, &buildsvc.CreateBuildTriggerInput{
 		Kind:                   string(domain.BuildTriggerKindArtifact),
 		ProducerProjectID:      producerBuild.ProjectID,
-		ProducerJobID:          producerJobID,
+		ProducerJobID:          strings.TrimSpace(readStringPtr(producerBuild.JobID)),
 		ProducerBuildID:        producerBuild.ID,
 		ArtifactID:             artifact.ID,
 		ArtifactPath:           artifact.LogicalPath,
@@ -685,15 +696,21 @@ func (s *JobService) dispatchArtifactTriggerToJob(ctx context.Context, producerB
 	})
 	if queueErr != nil {
 		message := queueErr.Error()
-		created.Status = domain.ArtifactTriggerDeliveryStatusFailed
-		created.ErrorMessage = &message
-		created.UpdatedAt = time.Now().UTC()
-		_, _ = s.artifactTriggerDeliveries.Update(ctx, created)
-		return queueErr
+		delivery.Status = domain.ArtifactTriggerDeliveryStatusFailed
+		delivery.ErrorMessage = &message
+		delivery.UpdatedAt = time.Now().UTC()
+		updated, updateErr := s.artifactTriggerDeliveries.Update(ctx, delivery)
+		if updateErr != nil {
+			return domain.ArtifactTriggerDelivery{}, updateErr
+		}
+		return updated, queueErr
 	}
-	created.Status = domain.ArtifactTriggerDeliveryStatusQueued
-	created.QueuedBuildID = &queuedBuild.ID
-	created.UpdatedAt = time.Now().UTC()
-	_, err = s.artifactTriggerDeliveries.Update(ctx, created)
-	return err
+	delivery.Status = domain.ArtifactTriggerDeliveryStatusQueued
+	delivery.QueuedBuildID = &queuedBuild.ID
+	delivery.UpdatedAt = time.Now().UTC()
+	updated, err := s.artifactTriggerDeliveries.Update(ctx, delivery)
+	if err != nil {
+		return domain.ArtifactTriggerDelivery{}, err
+	}
+	return updated, nil
 }

--- a/backend/internal/service/job_service_artifact_triggers.go
+++ b/backend/internal/service/job_service_artifact_triggers.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+	buildsvc "github.com/radiation/coyote-ci/backend/internal/service/build"
 )
 
 var ErrJobArtifactTriggerDeliveryRepositoryNotConfigured = errors.New("job artifact trigger delivery repository not configured")
@@ -13,6 +16,24 @@ var ErrJobArtifactTriggerDeliveryRepositoryNotConfigured = errors.New("job artif
 type ArtifactTriggerDeliveryView struct {
 	Delivery        domain.ArtifactTriggerDelivery
 	ConsumerJobName *string
+}
+
+type RetryArtifactTriggerDeliveryResult struct {
+	Result  string
+	Message string
+	View    ArtifactTriggerDeliveryView
+}
+
+func (s *JobService) GetArtifactTriggerDeliveryByID(ctx context.Context, deliveryID string) (ArtifactTriggerDeliveryView, error) {
+	if s.artifactTriggerDeliveries == nil {
+		return ArtifactTriggerDeliveryView{}, ErrJobArtifactTriggerDeliveryRepositoryNotConfigured
+	}
+
+	delivery, err := s.artifactTriggerDeliveries.GetByID(ctx, strings.TrimSpace(deliveryID))
+	if err != nil {
+		return ArtifactTriggerDeliveryView{}, err
+	}
+	return s.artifactTriggerDeliveryView(ctx, delivery)
 }
 
 func (s *JobService) ListArtifactTriggerDeliveriesByProducerBuildID(ctx context.Context, producerBuildID string) ([]ArtifactTriggerDeliveryView, error) {
@@ -50,10 +71,117 @@ func (s *JobService) ListArtifactTriggerDeliveriesByProducerBuildID(ctx context.
 
 	views := make([]ArtifactTriggerDeliveryView, 0, len(deliveries))
 	for _, delivery := range deliveries {
-		views = append(views, ArtifactTriggerDeliveryView{
-			Delivery:        delivery,
-			ConsumerJobName: jobNames[delivery.ConsumerJobID],
-		})
+		views = append(views, ArtifactTriggerDeliveryView{Delivery: delivery, ConsumerJobName: jobNames[delivery.ConsumerJobID]})
 	}
 	return views, nil
+}
+
+func (s *JobService) RetryArtifactTriggerDelivery(ctx context.Context, deliveryID string) (RetryArtifactTriggerDeliveryResult, error) {
+	if s.artifactTriggerDeliveries == nil {
+		return RetryArtifactTriggerDeliveryResult{}, ErrJobArtifactTriggerDeliveryRepositoryNotConfigured
+	}
+	if s.buildService == nil {
+		return RetryArtifactTriggerDeliveryResult{}, ErrJobBuildServiceNotConfigured
+	}
+	if s.jobRepo == nil {
+		return RetryArtifactTriggerDeliveryResult{}, ErrJobNotFound
+	}
+
+	trimmedDeliveryID := strings.TrimSpace(deliveryID)
+	claimed, err := s.artifactTriggerDeliveries.ClaimFailedForRetry(ctx, trimmedDeliveryID, time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, repository.ErrArtifactTriggerDeliveryRetryNotClaimable) {
+			current, getErr := s.GetArtifactTriggerDeliveryByID(ctx, trimmedDeliveryID)
+			if getErr != nil {
+				return RetryArtifactTriggerDeliveryResult{}, getErr
+			}
+			delivery := current.Delivery
+			if delivery.Status == domain.ArtifactTriggerDeliveryStatusQueued && delivery.QueuedBuildID != nil {
+				return RetryArtifactTriggerDeliveryResult{
+					Result:  "already_satisfied",
+					Message: "artifact trigger delivery already points at a downstream build",
+					View:    current,
+				}, nil
+			}
+			if delivery.QueuedBuildID != nil {
+				return RetryArtifactTriggerDeliveryResult{}, ErrArtifactTriggerDeliveryQueuedBuildConflict
+			}
+			if delivery.Status == domain.ArtifactTriggerDeliveryStatusPending {
+				return RetryArtifactTriggerDeliveryResult{}, ErrArtifactTriggerDeliveryPendingRetryDeferred
+			}
+			return RetryArtifactTriggerDeliveryResult{}, ErrArtifactTriggerDeliveryRetryNotSupported
+		}
+		return RetryArtifactTriggerDeliveryResult{}, err
+	}
+
+	consumerJob, err := s.jobRepo.GetByID(ctx, claimed.ConsumerJobID)
+	if err != nil {
+		s.failArtifactTriggerDeliveryRetry(ctx, claimed, err)
+		return RetryArtifactTriggerDeliveryResult{}, err
+	}
+	artifacts, err := s.buildService.GetBuildArtifacts(ctx, claimed.ProducerBuildID)
+	if err != nil {
+		s.failArtifactTriggerDeliveryRetry(ctx, claimed, err)
+		return RetryArtifactTriggerDeliveryResult{}, err
+	}
+	artifact, ok := artifactTriggerArtifactByID(artifacts, claimed.ArtifactID)
+	if !ok {
+		s.failArtifactTriggerDeliveryRetry(ctx, claimed, buildsvc.ErrArtifactNotFound)
+		return RetryArtifactTriggerDeliveryResult{}, buildsvc.ErrArtifactNotFound
+	}
+	producerJobID := strings.TrimSpace(claimed.ProducerJobID)
+	producerBuild := domain.Build{ID: claimed.ProducerBuildID, ProjectID: claimed.ProducerProjectID, JobID: &producerJobID}
+	updated, queueErr := s.queueArtifactTriggerDelivery(ctx, claimed, producerBuild, artifact, consumerJob)
+	if queueErr != nil {
+		return RetryArtifactTriggerDeliveryResult{}, queueErr
+	}
+	view, err := s.artifactTriggerDeliveryView(ctx, updated)
+	if err != nil {
+		return RetryArtifactTriggerDeliveryResult{}, err
+	}
+	return RetryArtifactTriggerDeliveryResult{Result: "retried", Message: "queued downstream build", View: view}, nil
+}
+
+func (s *JobService) failArtifactTriggerDeliveryRetry(ctx context.Context, delivery domain.ArtifactTriggerDelivery, retryErr error) {
+	if s.artifactTriggerDeliveries == nil || retryErr == nil {
+		return
+	}
+	message := strings.TrimSpace(retryErr.Error())
+	delivery.Status = domain.ArtifactTriggerDeliveryStatusFailed
+	delivery.QueuedBuildID = nil
+	delivery.UpdatedAt = time.Now().UTC()
+	if message == "" {
+		delivery.ErrorMessage = nil
+	} else {
+		delivery.ErrorMessage = &message
+	}
+	_, _ = s.artifactTriggerDeliveries.Update(ctx, delivery)
+}
+
+func (s *JobService) artifactTriggerDeliveryView(ctx context.Context, delivery domain.ArtifactTriggerDelivery) (ArtifactTriggerDeliveryView, error) {
+	view := ArtifactTriggerDeliveryView{Delivery: delivery}
+	if s.jobRepo == nil || strings.TrimSpace(delivery.ConsumerJobID) == "" {
+		return view, nil
+	}
+	job, err := s.jobRepo.GetByID(ctx, delivery.ConsumerJobID)
+	if err != nil {
+		if errors.Is(err, repository.ErrJobNotFound) {
+			return view, nil
+		}
+		return ArtifactTriggerDeliveryView{}, err
+	}
+	if name := strings.TrimSpace(job.Name); name != "" {
+		view.ConsumerJobName = &name
+	}
+	return view, nil
+}
+
+func artifactTriggerArtifactByID(artifacts []domain.BuildArtifact, artifactID string) (domain.BuildArtifact, bool) {
+	trimmedArtifactID := strings.TrimSpace(artifactID)
+	for _, artifact := range artifacts {
+		if artifact.ID == trimmedArtifactID {
+			return artifact, true
+		}
+	}
+	return domain.BuildArtifact{}, false
 }

--- a/backend/internal/service/job_service_test.go
+++ b/backend/internal/service/job_service_test.go
@@ -781,6 +781,148 @@ func TestJobService_RetryArtifactTriggerDelivery(t *testing.T) {
 	}
 }
 
+func TestJobService_RetryArtifactTriggerDelivery_ErrorPaths(t *testing.T) {
+	newFixture := func(t *testing.T) (*JobService, *memory.ArtifactTriggerDeliveryRepository, *fakeJobServiceArtifactRepo, domain.Job, domain.Job, domain.Build) {
+		t.Helper()
+		ctx := context.Background()
+		jobRepo := memory.NewJobRepository()
+		buildRepo := memory.NewBuildRepository()
+		deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+		artifactRepo := &fakeJobServiceArtifactRepo{}
+		buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+		buildService.SetArtifactPersistence(artifactRepo, nil, "")
+		jobService := NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+
+		now := time.Now().UTC()
+		producerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-upstream", ProjectID: "project-1", Name: "upstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: build\n    run: make build\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+		if err != nil {
+			t.Fatalf("create producer job failed: %v", err)
+		}
+		consumerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: consume\n    run: echo consume\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+		if err != nil {
+			t.Fatalf("create consumer job failed: %v", err)
+		}
+		producerBuild, err := buildRepo.CreateQueuedBuild(ctx, domain.Build{ID: "build-upstream", ProjectID: "project-1", JobID: &producerJob.ID, Status: domain.BuildStatusQueued, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}, nil)
+		if err != nil {
+			t.Fatalf("create producer build failed: %v", err)
+		}
+		if _, createArtifactErr := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); createArtifactErr != nil {
+			t.Fatalf("create artifact failed: %v", createArtifactErr)
+		}
+		return jobService, deliveryRepo, artifactRepo, producerJob, consumerJob, producerBuild
+	}
+
+	t.Run("requires delivery repository", func(t *testing.T) {
+		jobService := NewJobService(memory.NewJobRepository(), buildsvc.NewBuildService(memory.NewBuildRepository(), nil, nil))
+		_, err := jobService.RetryArtifactTriggerDelivery(context.Background(), "delivery-1")
+		if !errors.Is(err, ErrJobArtifactTriggerDeliveryRepositoryNotConfigured) {
+			t.Fatalf("expected missing delivery repository error, got %v", err)
+		}
+	})
+
+	t.Run("requires build service", func(t *testing.T) {
+		jobService := NewJobService(memory.NewJobRepository(), nil).WithArtifactTriggerDeliveryRepository(memory.NewArtifactTriggerDeliveryRepository())
+		_, err := jobService.RetryArtifactTriggerDelivery(context.Background(), "delivery-1")
+		if !errors.Is(err, ErrJobBuildServiceNotConfigured) {
+			t.Fatalf("expected missing build service error, got %v", err)
+		}
+	})
+
+	t.Run("requires job repository", func(t *testing.T) {
+		jobService := NewJobService(nil, buildsvc.NewBuildService(memory.NewBuildRepository(), nil, nil)).WithArtifactTriggerDeliveryRepository(memory.NewArtifactTriggerDeliveryRepository())
+		_, err := jobService.RetryArtifactTriggerDelivery(context.Background(), "delivery-1")
+		if !errors.Is(err, ErrJobNotFound) {
+			t.Fatalf("expected missing job repository error, got %v", err)
+		}
+	})
+
+	t.Run("queued build conflict when delivery already references downstream build", func(t *testing.T) {
+		ctx := context.Background()
+		jobService, deliveryRepo, _, producerJob, consumerJob, producerBuild := newFixture(t)
+		queuedBuildID := "build-existing"
+		if _, createDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-conflict", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", QueuedBuildID: &queuedBuildID, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); createDeliveryErr != nil {
+			t.Fatalf("create conflict delivery failed: %v", createDeliveryErr)
+		}
+		_, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-conflict")
+		if !errors.Is(err, ErrArtifactTriggerDeliveryQueuedBuildConflict) {
+			t.Fatalf("expected queued build conflict, got %v", err)
+		}
+	})
+
+	t.Run("retry not supported for unexpected status", func(t *testing.T) {
+		ctx := context.Background()
+		jobService, deliveryRepo, _, producerJob, consumerJob, producerBuild := newFixture(t)
+		if _, createDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-unsupported", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatus("mystery"), CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); createDeliveryErr != nil {
+			t.Fatalf("create unsupported delivery failed: %v", createDeliveryErr)
+		}
+		_, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-unsupported")
+		if !errors.Is(err, ErrArtifactTriggerDeliveryRetryNotSupported) {
+			t.Fatalf("expected retry not supported, got %v", err)
+		}
+	})
+
+	t.Run("artifact list failure restores failed status", func(t *testing.T) {
+		ctx := context.Background()
+		jobService, deliveryRepo, artifactRepo, producerJob, consumerJob, producerBuild := newFixture(t)
+		artifactRepo.listByBuildErr = errors.New("artifact lookup failed")
+		if _, createDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-artifact-error", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); createDeliveryErr != nil {
+			t.Fatalf("create artifact error delivery failed: %v", createDeliveryErr)
+		}
+		_, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-artifact-error")
+		if err == nil || err.Error() != "artifact lookup failed" {
+			t.Fatalf("expected artifact lookup failure, got %v", err)
+		}
+		restored, getErr := deliveryRepo.GetByID(ctx, "delivery-artifact-error")
+		if getErr != nil {
+			t.Fatalf("get restored artifact error delivery failed: %v", getErr)
+		}
+		if restored.Status != domain.ArtifactTriggerDeliveryStatusFailed || restored.QueuedBuildID != nil || restored.ErrorMessage == nil || *restored.ErrorMessage != "artifact lookup failed" {
+			t.Fatalf("unexpected restored artifact error delivery: %+v", restored)
+		}
+	})
+
+	t.Run("missing artifact restores failed status", func(t *testing.T) {
+		ctx := context.Background()
+		jobService, deliveryRepo, _, producerJob, consumerJob, producerBuild := newFixture(t)
+		if _, createDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-missing-artifact", ArtifactID: "artifact-missing", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); createDeliveryErr != nil {
+			t.Fatalf("create missing artifact delivery failed: %v", createDeliveryErr)
+		}
+		_, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-missing-artifact")
+		if !errors.Is(err, buildsvc.ErrArtifactNotFound) {
+			t.Fatalf("expected missing artifact error, got %v", err)
+		}
+		restored, getErr := deliveryRepo.GetByID(ctx, "delivery-missing-artifact")
+		if getErr != nil {
+			t.Fatalf("get restored missing artifact delivery failed: %v", getErr)
+		}
+		if restored.Status != domain.ArtifactTriggerDeliveryStatusFailed || restored.QueuedBuildID != nil || restored.ErrorMessage == nil || !strings.Contains(*restored.ErrorMessage, buildsvc.ErrArtifactNotFound.Error()) {
+			t.Fatalf("unexpected restored missing artifact delivery: %+v", restored)
+		}
+	})
+
+	t.Run("empty retry error clears persisted error message", func(t *testing.T) {
+		ctx := context.Background()
+		jobService, deliveryRepo, _, producerJob, consumerJob, producerBuild := newFixture(t)
+		oldMessage := "old failure"
+		created, createErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-empty-error", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &oldMessage, Status: domain.ArtifactTriggerDeliveryStatusPending, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()})
+		if createErr != nil {
+			t.Fatalf("create empty error delivery failed: %v", createErr)
+		}
+		jobService.failArtifactTriggerDeliveryRetry(ctx, created, emptyRetryError{})
+		updated, getErr := deliveryRepo.GetByID(ctx, created.ID)
+		if getErr != nil {
+			t.Fatalf("get empty error delivery failed: %v", getErr)
+		}
+		if updated.Status != domain.ArtifactTriggerDeliveryStatusFailed || updated.ErrorMessage != nil {
+			t.Fatalf("expected failed delivery with cleared error message, got %+v", updated)
+		}
+	})
+}
+
+type emptyRetryError struct{}
+
+func (emptyRetryError) Error() string { return "" }
+
 func TestJobService_ListArtifactTriggerDeliveriesByProducerBuildID(t *testing.T) {
 	ctx := context.Background()
 	jobRepo := memory.NewJobRepository()

--- a/backend/internal/service/job_service_test.go
+++ b/backend/internal/service/job_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,73 @@ type fakeServiceRepoFetcher struct {
 	commitSHA string
 	err       error
 	calls     int
+}
+
+type fakeJobServiceArtifactRepo struct {
+	artifactsByBuild map[string][]domain.BuildArtifact
+	listByBuildErr   error
+}
+
+func (r *fakeJobServiceArtifactRepo) Create(_ context.Context, artifact domain.BuildArtifact) (domain.BuildArtifact, error) {
+	if r.artifactsByBuild == nil {
+		r.artifactsByBuild = map[string][]domain.BuildArtifact{}
+	}
+	r.artifactsByBuild[artifact.BuildID] = append(r.artifactsByBuild[artifact.BuildID], artifact)
+	return artifact, nil
+}
+
+func (r *fakeJobServiceArtifactRepo) ListByBuildID(_ context.Context, buildID string) ([]domain.BuildArtifact, error) {
+	if r.listByBuildErr != nil {
+		return nil, r.listByBuildErr
+	}
+	items := append([]domain.BuildArtifact(nil), r.artifactsByBuild[buildID]...)
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+	return items, nil
+}
+
+func (r *fakeJobServiceArtifactRepo) Browse(_ context.Context, _ repository.BrowseArtifactsParams) ([]domain.ArtifactBrowseRecord, error) {
+	return nil, nil
+}
+
+func (r *fakeJobServiceArtifactRepo) ListCatalog(_ context.Context, _ repository.ArtifactCatalogParams) ([]domain.ArtifactRecord, error) {
+	return nil, nil
+}
+
+func (r *fakeJobServiceArtifactRepo) GetCatalogByID(_ context.Context, artifactID string) (domain.ArtifactRecord, error) {
+	for buildID, items := range r.artifactsByBuild {
+		for _, item := range items {
+			if item.ID == artifactID {
+				return domain.ArtifactRecord{Artifact: item, Build: domain.Build{ID: buildID}}, nil
+			}
+		}
+	}
+	return domain.ArtifactRecord{}, repository.ErrArtifactNotFound
+}
+
+func (r *fakeJobServiceArtifactRepo) GetByID(_ context.Context, buildID string, artifactID string) (domain.BuildArtifact, error) {
+	for _, item := range r.artifactsByBuild[buildID] {
+		if item.ID == artifactID {
+			return item, nil
+		}
+	}
+	return domain.BuildArtifact{}, repository.ErrArtifactNotFound
+}
+
+func (r *fakeJobServiceArtifactRepo) ListByStepID(_ context.Context, stepID string) ([]domain.BuildArtifact, error) {
+	var out []domain.BuildArtifact
+	for _, items := range r.artifactsByBuild {
+		for _, item := range items {
+			if item.StepID != nil && *item.StepID == stepID {
+				out = append(out, item)
+			}
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeServiceRepoFetcher) Fetch(_ context.Context, _ string, _ string) (string, string, error) {
@@ -618,6 +686,98 @@ func TestJobService_DispatchArtifactTriggers_RetriesFailedDelivery(t *testing.T)
 	}
 	if retriedDelivery.ErrorMessage != nil {
 		t.Fatalf("expected error message cleared after retry, got %#v", retriedDelivery.ErrorMessage)
+	}
+}
+
+func TestJobService_RetryArtifactTriggerDelivery(t *testing.T) {
+	ctx := context.Background()
+	jobRepo := memory.NewJobRepository()
+	buildRepo := memory.NewBuildRepository()
+	deliveryRepo := memory.NewArtifactTriggerDeliveryRepository()
+	artifactRepo := &fakeJobServiceArtifactRepo{}
+	buildService := buildsvc.NewBuildService(buildRepo, nil, nil)
+	buildService.SetArtifactPersistence(artifactRepo, nil, "")
+	jobService := NewJobService(jobRepo, buildService).WithArtifactTriggerDeliveryRepository(deliveryRepo)
+
+	now := time.Now().UTC()
+	producerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-upstream", ProjectID: "project-1", Name: "upstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: build\n    run: make build\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("create producer job failed: %v", err)
+	}
+	consumerJob, err := jobRepo.Create(ctx, domain.Job{ID: "job-downstream", ProjectID: "project-1", Name: "downstream", Priority: 5, RepositoryURL: "https://github.com/example/repo.git", DefaultRef: "main", PipelineYAML: "version: 1\nsteps:\n  - name: consume\n    run: echo consume\n", Enabled: true, CreatedAt: now, UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("create consumer job failed: %v", err)
+	}
+	producerBuild, err := buildRepo.CreateQueuedBuild(ctx, domain.Build{ID: "build-upstream", ProjectID: "project-1", JobID: &producerJob.ID, Status: domain.BuildStatusQueued, CreatedAt: now, Trigger: domain.BuildTrigger{Kind: domain.BuildTriggerKindManual}}, nil)
+	if err != nil {
+		t.Fatalf("create producer build failed: %v", err)
+	}
+	if _, createArtifactErr := artifactRepo.Create(ctx, domain.BuildArtifact{ID: "artifact-1", BuildID: producerBuild.ID, Name: "app.tgz", LogicalPath: "dist/app.tgz", SizeBytes: 42, CreatedAt: now}); createArtifactErr != nil {
+		t.Fatalf("create artifact failed: %v", createArtifactErr)
+	}
+	errorMessage := "queue failed"
+	if _, createFailedDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-1", ArtifactID: "artifact-1", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &errorMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); createFailedDeliveryErr != nil {
+		t.Fatalf("create failed delivery failed: %v", createFailedDeliveryErr)
+	}
+
+	result, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-1")
+	if err != nil {
+		t.Fatalf("retry artifact trigger delivery failed: %v", err)
+	}
+	if result.Result != "retried" || result.View.Delivery.Status != domain.ArtifactTriggerDeliveryStatusQueued {
+		t.Fatalf("unexpected retry result: %+v", result)
+	}
+	if result.View.Delivery.QueuedBuildID == nil {
+		t.Fatalf("expected queued build id after retry, got %+v", result.View.Delivery)
+	}
+	builds, err := buildService.ListBuildsByJobID(ctx, consumerJob.ID)
+	if err != nil {
+		t.Fatalf("list builds by consumer job failed: %v", err)
+	}
+	if len(builds) != 1 {
+		t.Fatalf("expected one downstream build after retry, got %d", len(builds))
+	}
+
+	if _, createPendingDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-pending", ArtifactID: "artifact-pending", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", Status: domain.ArtifactTriggerDeliveryStatusPending, CreatedAt: now, UpdatedAt: now}); createPendingDeliveryErr != nil {
+		t.Fatalf("create pending delivery failed: %v", createPendingDeliveryErr)
+	}
+	_, err = jobService.RetryArtifactTriggerDelivery(ctx, "delivery-pending")
+	if !errors.Is(err, ErrArtifactTriggerDeliveryPendingRetryDeferred) {
+		t.Fatalf("expected pending retry deferred error, got %v", err)
+	}
+
+	queuedBuildID := "build-downstream-existing"
+	if _, createQueuedDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-queued", ArtifactID: "artifact-queued", ConsumerJobID: consumerJob.ID, ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", QueuedBuildID: &queuedBuildID, Status: domain.ArtifactTriggerDeliveryStatusQueued, CreatedAt: now, UpdatedAt: now}); createQueuedDeliveryErr != nil {
+		t.Fatalf("create queued delivery failed: %v", createQueuedDeliveryErr)
+	}
+	alreadySatisfied, err := jobService.RetryArtifactTriggerDelivery(ctx, "delivery-queued")
+	if err != nil {
+		t.Fatalf("expected already satisfied retry to succeed, got %v", err)
+	}
+	if alreadySatisfied.Result != "already_satisfied" || alreadySatisfied.View.Delivery.QueuedBuildID == nil || *alreadySatisfied.View.Delivery.QueuedBuildID != queuedBuildID {
+		t.Fatalf("unexpected already satisfied result: %+v", alreadySatisfied)
+	}
+
+	strandedMessage := "old failure"
+	if _, createMissingJobDeliveryErr := deliveryRepo.Create(ctx, domain.ArtifactTriggerDelivery{ID: "delivery-missing-job", ArtifactID: "artifact-1", ConsumerJobID: "job-missing", ProducerBuildID: producerBuild.ID, ProducerProjectID: producerBuild.ProjectID, ProducerJobID: producerJob.ID, ArtifactPath: "dist/app.tgz", ErrorMessage: &strandedMessage, Status: domain.ArtifactTriggerDeliveryStatusFailed, CreatedAt: now, UpdatedAt: now}); createMissingJobDeliveryErr != nil {
+		t.Fatalf("create missing-job delivery failed: %v", createMissingJobDeliveryErr)
+	}
+	_, err = jobService.RetryArtifactTriggerDelivery(ctx, "delivery-missing-job")
+	if !errors.Is(err, repository.ErrJobNotFound) {
+		t.Fatalf("expected missing consumer job error, got %v", err)
+	}
+	restoredDelivery, err := deliveryRepo.GetByID(ctx, "delivery-missing-job")
+	if err != nil {
+		t.Fatalf("get restored delivery failed: %v", err)
+	}
+	if restoredDelivery.Status != domain.ArtifactTriggerDeliveryStatusFailed {
+		t.Fatalf("expected failed status after pre-enqueue retry error, got %q", restoredDelivery.Status)
+	}
+	if restoredDelivery.QueuedBuildID != nil {
+		t.Fatalf("expected nil queued build id after pre-enqueue retry error, got %#v", restoredDelivery.QueuedBuildID)
+	}
+	if restoredDelivery.ErrorMessage == nil || !strings.Contains(*restoredDelivery.ErrorMessage, repository.ErrJobNotFound.Error()) {
+		t.Fatalf("expected useful persisted error message, got %#v", restoredDelivery.ErrorMessage)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds manual retry support for artifact-trigger deliveries and finishes the V1.3 operational recovery loop.

## What Changed

- Added artifact-trigger delivery retry by delivery ID.
- Added backend retry handling for failed deliveries that have not already queued a downstream build.
- Preserved idempotent behavior for already-satisfied deliveries with an existing downstream build.
- Kept `pending` deliveries non-retryable for V1.3 to avoid duplicate downstream-build races.
- Protected retry with `build:run` rather than read-only build access.
- Added API client support for retrying artifact-trigger deliveries.
- Added CLI support:

  ```bash
  coyote build artifact-triggers retry <delivery-id>
  coyote build artifact-triggers retry <delivery-id> --json