### PR TITLE
Add artifact trigger context to slack notifications

### DIFF
--- a/backend/internal/service/build/notification_format.go
+++ b/backend/internal/service/build/notification_format.go
@@ -23,6 +23,7 @@ type buildNotificationDetails struct {
 	projectName   string
 	projectLabel  string
 	projectURL    string
+	trigger       *buildNotificationArtifactTrigger
 	jobID         string
 	jobName       string
 	jobLabel      string
@@ -53,6 +54,20 @@ type buildNotificationStep struct {
 	name  string
 	label string
 	url   string
+}
+
+type buildNotificationArtifactTrigger struct {
+	producerProjectID    string
+	producerProjectName  string
+	producerProjectURL   string
+	producerJobID        string
+	producerJobName      string
+	producerJobURL       string
+	producerBuildID      string
+	producerBuildURL     string
+	artifactPath         string
+	artifactName         string
+	artifactDisplayLabel string
 }
 
 type notificationArtifactLink struct {
@@ -135,7 +150,53 @@ func (s *BuildNotificationService) buildNotificationDetails(ctx context.Context,
 			details.commitURL = commitURL
 		}
 	}
+	details.trigger = s.buildNotificationArtifactTrigger(ctx, build)
 	return details
+}
+
+func (s *BuildNotificationService) buildNotificationArtifactTrigger(ctx context.Context, build domain.Build) *buildNotificationArtifactTrigger {
+	trigger := domain.NormalizeBuildTrigger(build.Trigger)
+	if trigger.Kind != domain.BuildTriggerKindArtifact {
+		return nil
+	}
+
+	producerProjectID := trimNotificationOptionalString(trigger.ProducerProjectID)
+	producerJobID := trimNotificationOptionalString(trigger.ProducerJobID)
+	producerBuildID := trimNotificationOptionalString(trigger.ProducerBuildID)
+	artifactPath := trimNotificationOptionalString(trigger.ArtifactPath)
+	artifactName := trimNotificationOptionalString(trigger.ArtifactName)
+	if producerProjectID == "" && producerJobID == "" && producerBuildID == "" && artifactPath == "" && artifactName == "" {
+		return nil
+	}
+
+	artifactTrigger := &buildNotificationArtifactTrigger{
+		producerProjectID:    producerProjectID,
+		producerProjectName:  producerProjectID,
+		producerJobID:        producerJobID,
+		producerJobName:      producerJobID,
+		producerBuildID:      producerBuildID,
+		artifactPath:         artifactPath,
+		artifactName:         artifactName,
+		artifactDisplayLabel: notificationTriggerArtifactDisplayLabel(artifactName, artifactPath),
+	}
+	if s.publicBaseURL != "" {
+		artifactTrigger.producerProjectURL = buildProjectDetailURL(s.publicBaseURL, producerProjectID)
+		artifactTrigger.producerJobURL = buildJobDetailURL(s.publicBaseURL, producerJobID)
+		artifactTrigger.producerBuildURL = buildBuildDetailURL(s.publicBaseURL, producerBuildID)
+	}
+	if s.projectRepo != nil && producerProjectID != "" {
+		project, err := s.projectRepo.GetByID(ctx, producerProjectID)
+		if err == nil && strings.TrimSpace(project.Name) != "" {
+			artifactTrigger.producerProjectName = strings.TrimSpace(project.Name)
+		}
+	}
+	if s.jobRepo != nil && producerJobID != "" {
+		job, err := s.jobRepo.GetByID(ctx, producerJobID)
+		if err == nil && strings.TrimSpace(job.Name) != "" {
+			artifactTrigger.producerJobName = strings.TrimSpace(job.Name)
+		}
+	}
+	return artifactTrigger
 }
 
 func (s *BuildNotificationService) enrichSlackNotificationDetails(ctx context.Context, build domain.Build, details buildNotificationDetails) (buildNotificationDetails, error) {
@@ -314,6 +375,7 @@ func formatBuildStatusSlackText(details buildNotificationDetails) string {
 			lines = append(lines, artifactLine)
 		}
 	}
+	lines = append(lines, notificationArtifactTriggerSlackLines(details)...)
 	lines = append(lines, notificationSlackCLIHintLines(details)...)
 	if details.buildURL != "" {
 		lines = append(lines, fmt.Sprintf("Build details: %s", slackMrkdwnLink(details.buildURL, "View build")))
@@ -379,6 +441,7 @@ func formatPersonalBuildStatusSlackText(details buildNotificationDetails) string
 			lines = append(lines, artifactLine)
 		}
 	}
+	lines = append(lines, notificationArtifactTriggerSlackLines(details)...)
 	lines = append(lines, notificationSlackCLIHintLines(details)...)
 	if details.buildURL != "" && (details.statusSummary != "failed" || details.buildURL != details.diagnosticURL) {
 		lines = append(lines, fmt.Sprintf("Build: %s", slackMrkdwnLink(details.buildURL, "View build")))
@@ -449,15 +512,108 @@ func notificationSlackCLIHintLines(details buildNotificationDetails) []string {
 	}
 
 	statusCommand := notificationSlackInlineCode(fmt.Sprintf("coyote build status %s", buildID))
+	artifactTriggerCommands := notificationArtifactTriggerCLIHintLines(details)
 	switch details.statusSummary {
 	case "failed":
 		logsCommand := notificationSlackInlineCode(notificationSlackFailedLogsCommand(buildID, details.failedStep))
 		retryCommand := notificationSlackInlineCode(fmt.Sprintf("coyote build retry %s --yes", buildID))
-		return []string{"CLI:", statusCommand, logsCommand, retryCommand}
+		lines := []string{"CLI:"}
+		if len(artifactTriggerCommands) > 0 {
+			lines = append(lines, artifactTriggerCommands...)
+		} else {
+			lines = append(lines, statusCommand)
+		}
+		return append(lines, logsCommand, retryCommand)
 	case "succeeded":
+		if len(artifactTriggerCommands) > 0 {
+			lines := []string{fmt.Sprintf("CLI: %s", artifactTriggerCommands[0])}
+			return append(lines, artifactTriggerCommands[1:]...)
+		}
 		return []string{fmt.Sprintf("CLI: %s", statusCommand)}
 	default:
 		return nil
+	}
+}
+
+func notificationArtifactTriggerSlackLines(details buildNotificationDetails) []string {
+	if details.trigger == nil {
+		return nil
+	}
+	lines := []string{}
+	triggeredBy := notificationArtifactTriggerProducerText(*details.trigger)
+	if triggeredBy != "" {
+		lines = append(lines, fmt.Sprintf("Triggered by: %s", triggeredBy))
+	}
+	if details.trigger.artifactDisplayLabel != "" {
+		lines = append(lines, fmt.Sprintf("Artifact: %s", slackEscapeMrkdwnLabel(details.trigger.artifactDisplayLabel)))
+	}
+	return lines
+}
+
+func notificationArtifactTriggerProducerText(trigger buildNotificationArtifactTrigger) string {
+	parts := make([]string, 0, 3)
+	if label := notificationArtifactTriggerEntityText(trigger.producerProjectName, trigger.producerProjectID, trigger.producerProjectURL); label != "" {
+		parts = append(parts, label)
+	}
+	if label := notificationArtifactTriggerEntityText(trigger.producerJobName, trigger.producerJobID, trigger.producerJobURL); label != "" {
+		parts = append(parts, label)
+	}
+	if label := notificationArtifactTriggerBuildText(trigger.producerBuildID, trigger.producerBuildURL); label != "" {
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func notificationArtifactTriggerEntityText(name string, fallbackID string, entityURL string) string {
+	label := strings.TrimSpace(name)
+	if label == "" {
+		label = strings.TrimSpace(fallbackID)
+	}
+	if label == "" {
+		return ""
+	}
+	if entityURL != "" {
+		return slackMrkdwnLink(entityURL, label)
+	}
+	return slackEscapeMrkdwnLabel(label)
+}
+
+func notificationArtifactTriggerBuildText(buildID string, buildURL string) string {
+	trimmedBuildID := strings.TrimSpace(buildID)
+	if trimmedBuildID == "" {
+		return ""
+	}
+	if buildURL != "" {
+		return slackMrkdwnLink(buildURL, trimmedBuildID)
+	}
+	return slackEscapeMrkdwnLabel(trimmedBuildID)
+}
+
+func notificationTriggerArtifactDisplayLabel(name string, logicalPath string) string {
+	trimmedName := strings.TrimSpace(name)
+	trimmedPath := strings.TrimSpace(logicalPath)
+	if trimmedName == "" {
+		return trimmedPath
+	}
+	if trimmedPath == "" || trimmedPath == trimmedName {
+		return trimmedName
+	}
+	return fmt.Sprintf("%s (%s)", trimmedName, trimmedPath)
+}
+
+func notificationArtifactTriggerCLIHintLines(details buildNotificationDetails) []string {
+	if details.trigger == nil {
+		return nil
+	}
+	buildID := strings.TrimSpace(details.buildID)
+	producerBuildID := strings.TrimSpace(details.trigger.producerBuildID)
+	if buildID == "" || producerBuildID == "" {
+		return nil
+	}
+	return []string{
+		notificationSlackInlineCode(fmt.Sprintf("coyote build watch %s", buildID)),
+		notificationSlackInlineCode(fmt.Sprintf("coyote build artifact-triggers %s", producerBuildID)),
+		notificationSlackInlineCode(fmt.Sprintf("coyote build status %s --json", buildID)),
 	}
 }
 

--- a/backend/internal/service/build/notification_format.go
+++ b/backend/internal/service/build/notification_format.go
@@ -150,7 +150,6 @@ func (s *BuildNotificationService) buildNotificationDetails(ctx context.Context,
 			details.commitURL = commitURL
 		}
 	}
-	details.trigger = s.buildNotificationArtifactTrigger(ctx, build)
 	return details
 }
 
@@ -201,6 +200,7 @@ func (s *BuildNotificationService) buildNotificationArtifactTrigger(ctx context.
 
 func (s *BuildNotificationService) enrichSlackNotificationDetails(ctx context.Context, build domain.Build, details buildNotificationDetails) (buildNotificationDetails, error) {
 	details = applyFallbackFailureContext(build, details)
+	details.trigger = s.buildNotificationArtifactTrigger(ctx, build)
 	if details.statusSummary == "failed" {
 		enriched, err := s.enrichFailedSlackNotificationDetails(ctx, build, details)
 		if err != nil {

--- a/backend/internal/service/build/notification_format_test.go
+++ b/backend/internal/service/build/notification_format_test.go
@@ -250,6 +250,155 @@ func TestBuildNotificationService_NotifyTerminalBuild_SlackSuccessArtifactsRemai
 	}
 }
 
+func TestBuildNotificationService_NotifyTerminalBuild_SlackFailureIncludesArtifactTriggerContext(t *testing.T) {
+	slackSender := &recordingSlackSender{}
+	deliveryRepo := memoryrepo.NewNotificationDeliveryRepository()
+	subscriptionRepo := memoryrepo.NewNotificationSubscriptionRepository()
+	jobRepo := memoryrepo.NewJobRepository()
+	projectRepo := memoryrepo.NewProjectRepository(jobRepo)
+	target := mustCreateSlackNotificationTarget(t, subscriptionRepo, "https://hooks.slack.example/services/T/B/X", true)
+	projectID := "project-1"
+	jobID := "job-downstream"
+	producerProjectID := "project-upstream"
+	producerJobID := "job-upstream"
+	producerBuildID := "build-upstream"
+	now := time.Now().UTC()
+	if _, err := projectRepo.Create(context.Background(), domain.Project{ID: projectID, Name: "Payments API", Slug: "payments-api", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream project failed: %v", err)
+	}
+	if _, err := projectRepo.Create(context.Background(), domain.Project{ID: producerProjectID, Name: "Artifact Producer", Slug: "artifact-producer", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create producer project failed: %v", err)
+	}
+	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: jobID, ProjectID: projectID, Name: "package-consumer", RepositoryURL: "https://github.com/example/payments.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream job failed: %v", err)
+	}
+	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: producerJobID, ProjectID: producerProjectID, Name: "package-producer", RepositoryURL: "https://github.com/example/payments.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create producer job failed: %v", err)
+	}
+	mustCreateNotificationSubscription(t, subscriptionRepo, target.ID, &projectID, nil, domain.NotificationEventTypeBuildFailed, true)
+	buildError := "artifact consumer failed"
+	notifier, err := NewBuildNotificationService(BuildNotificationConfig{Enabled: true, SlackSender: slackSender, JobRepo: jobRepo, ProjectRepo: projectRepo, DeliveryRepo: deliveryRepo, SubscriptionRepo: subscriptionRepo, PublicBaseURL: "https://ci.example.com/"})
+	if err != nil {
+		t.Fatalf("create notifier failed: %v", err)
+	}
+	build := domain.Build{
+		ID:        "build-downstream",
+		ProjectID: projectID,
+		JobID:     &jobID,
+		Status:    domain.BuildStatusFailed,
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: &producerProjectID,
+			ProducerJobID:     &producerJobID,
+			ProducerBuildID:   &producerBuildID,
+			ArtifactPath:      stringPtr("dist/service-client.jar"),
+			ArtifactName:      stringPtr("service-client.jar"),
+		},
+		ErrorMessage: &buildError,
+	}
+
+	if notifyErr := notifier.NotifyTerminalBuild(context.Background(), build); notifyErr != nil {
+		t.Fatalf("notify terminal build failed: %v", notifyErr)
+	}
+	message := slackSender.messages[0].Text
+	for _, want := range []string{
+		"Triggered by: <https://ci.example.com/projects/project-upstream|Artifact Producer> / <https://ci.example.com/jobs/job-upstream|package-producer> / <https://ci.example.com/builds/build-upstream|build-upstream>",
+		"Artifact: service-client.jar (dist/service-client.jar)",
+		"`coyote build watch build-downstream`",
+		"`coyote build artifact-triggers build-upstream`",
+		"`coyote build status build-downstream --json`",
+		"`coyote build retry build-downstream --yes`",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected artifact-trigger slack text to contain %q, got %q", want, message)
+		}
+	}
+	if strings.Contains(message, "`coyote build status build-downstream`") {
+		t.Fatalf("expected artifact-trigger message to prefer json status command, got %q", message)
+	}
+}
+
+func TestBuildNotificationService_NotifyTerminalBuild_SlackSuccessIncludesArtifactTriggerContext(t *testing.T) {
+	slackSender := &recordingSlackSender{}
+	deliveryRepo := memoryrepo.NewNotificationDeliveryRepository()
+	subscriptionRepo := memoryrepo.NewNotificationSubscriptionRepository()
+	jobRepo := memoryrepo.NewJobRepository()
+	projectRepo := memoryrepo.NewProjectRepository(jobRepo)
+	target := mustCreateSlackNotificationTarget(t, subscriptionRepo, "https://hooks.slack.example/services/T/B/X", true)
+	projectID := "project-1"
+	jobID := "job-downstream"
+	producerProjectID := "project-upstream"
+	producerJobID := "job-upstream"
+	producerBuildID := "build-upstream"
+	now := time.Now().UTC()
+	if _, err := projectRepo.Create(context.Background(), domain.Project{ID: projectID, Name: "Payments API", Slug: "payments-api", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream project failed: %v", err)
+	}
+	if _, err := jobRepo.Create(context.Background(), domain.Job{ID: jobID, ProjectID: projectID, Name: "package-consumer", RepositoryURL: "https://github.com/example/payments.git", DefaultRef: "main", PipelineYAML: "version: 1", Enabled: true, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create downstream job failed: %v", err)
+	}
+	mustCreateNotificationSubscription(t, subscriptionRepo, target.ID, &projectID, nil, domain.NotificationEventTypeBuildSucceeded, true)
+	notifier, err := NewBuildNotificationService(BuildNotificationConfig{Enabled: true, SlackSender: slackSender, JobRepo: jobRepo, ProjectRepo: projectRepo, DeliveryRepo: deliveryRepo, SubscriptionRepo: subscriptionRepo, PublicBaseURL: "https://ci.example.com/"})
+	if err != nil {
+		t.Fatalf("create notifier failed: %v", err)
+	}
+	build := domain.Build{
+		ID:        "build-downstream",
+		ProjectID: projectID,
+		JobID:     &jobID,
+		Status:    domain.BuildStatusSuccess,
+		Trigger: domain.BuildTrigger{
+			Kind:              domain.BuildTriggerKindArtifact,
+			ProducerProjectID: &producerProjectID,
+			ProducerJobID:     &producerJobID,
+			ProducerBuildID:   &producerBuildID,
+			ArtifactPath:      stringPtr("dist/service-client.jar"),
+		},
+	}
+
+	if notifyErr := notifier.NotifyTerminalBuild(context.Background(), build); notifyErr != nil {
+		t.Fatalf("notify terminal build failed: %v", notifyErr)
+	}
+	message := slackSender.messages[0].Text
+	for _, want := range []string{
+		"Triggered by: <https://ci.example.com/projects/project-upstream|project-upstream> / <https://ci.example.com/jobs/job-upstream|job-upstream> / <https://ci.example.com/builds/build-upstream|build-upstream>",
+		"Artifact: dist/service-client.jar",
+		"CLI: `coyote build watch build-downstream`",
+		"`coyote build artifact-triggers build-upstream`",
+		"`coyote build status build-downstream --json`",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected artifact-trigger success slack text to contain %q, got %q", want, message)
+		}
+	}
+	if strings.Contains(message, "`coyote build status build-downstream`") {
+		t.Fatalf("expected artifact-trigger success message to prefer json status command, got %q", message)
+	}
+}
+
+func TestBuildNotificationService_NotifyTerminalBuild_SlackOrdinaryBuildOmitsArtifactTriggerContext(t *testing.T) {
+	slackSender := &recordingSlackSender{}
+	deliveryRepo := memoryrepo.NewNotificationDeliveryRepository()
+	subscriptionRepo := memoryrepo.NewNotificationSubscriptionRepository()
+	target := mustCreateSlackNotificationTarget(t, subscriptionRepo, "https://hooks.slack.example/services/T/B/X", true)
+	projectID := "project-1"
+	mustCreateNotificationSubscription(t, subscriptionRepo, target.ID, &projectID, nil, domain.NotificationEventTypeBuildFailed, true)
+	notifier, err := NewBuildNotificationService(BuildNotificationConfig{Enabled: true, SlackSender: slackSender, DeliveryRepo: deliveryRepo, SubscriptionRepo: subscriptionRepo, PublicBaseURL: "https://ci.example.com/"})
+	if err != nil {
+		t.Fatalf("create notifier failed: %v", err)
+	}
+
+	if notifyErr := notifier.NotifyTerminalBuild(context.Background(), domain.Build{ID: "build-ordinary", ProjectID: projectID, Status: domain.BuildStatusFailed}); notifyErr != nil {
+		t.Fatalf("notify terminal build failed: %v", notifyErr)
+	}
+	message := slackSender.messages[0].Text
+	for _, unwanted := range []string{"Triggered by:", "Artifact:", "coyote build watch build-ordinary", "coyote build artifact-triggers"} {
+		if strings.Contains(message, unwanted) {
+			t.Fatalf("did not expect ordinary slack message to contain %q, got %q", unwanted, message)
+		}
+	}
+}
+
 func TestBuildNotificationService_NotifyTerminalBuild_SlackMessageOmitsMissingOptionalFields(t *testing.T) {
 	slackSender := &recordingSlackSender{}
 	subscriptionRepo := memoryrepo.NewNotificationSubscriptionRepository()


### PR DESCRIPTION
## Summary

Adds artifact-trigger context to Slack terminal build notifications.

## What Changed

- Enriched Slack success/failure notifications for artifact-triggered downstream builds.
- Added a conditional artifact-trigger section when build provenance indicates the build was triggered by an artifact.
- Included producer context in Slack messages:
  - producer project/job/build;
  - artifact path/name;
  - fallback IDs when names are not cheaply available.
- Added copyable CLI follow-ups for the artifact-trigger workflow:
  - `coyote build watch <downstream-build-id>`
  - `coyote build artifact-triggers <producer-build-id>`
  - `coyote build status <downstream-build-id> --json`
- Preserved ordinary Slack build notification structure for non-artifact-triggered builds.
- Left email, recipients, subscriptions, delivery-failure notifications, and artifact-trigger semantics unchanged.

## Tests

- Added formatter coverage for artifact-triggered failed Slack messages.
- Added formatter coverage for artifact-triggered successful Slack messages.
- Added regression coverage proving ordinary Slack build notifications omit artifact-trigger context.

## Validation

```bash
go test ./internal/service/build -run 'TestBuildNotificationService_NotifyTerminalBuild_|TestFormatBuildStatusSlackText_'