### PR TITLE
Add multi-connection SCM foundation

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -105,6 +105,8 @@ func main() {
 	projectMembershipRepo := repositorypostgres.NewProjectMembershipRepository(db)
 	jobManagedImageConfigRepo := repositorypostgres.NewJobManagedImageConfigRepository(db)
 	sourceCredentialRepo := repositorypostgres.NewSourceCredentialRepository(db)
+	scmConnectionRepo := repositorypostgres.NewSCMConnectionRepository(db)
+	scmRepositoryRegistrationRepo := repositorypostgres.NewSCMRepositoryRegistrationRepository(db)
 	managedImageCatalogRepo := repositorypostgres.NewManagedImageCatalogRepository(db)
 	versionTagRepo := repositorypostgres.NewVersionTagRepository(db)
 	artifactLabelRepo := repositorypostgres.NewArtifactLabelRepository(db)
@@ -211,6 +213,7 @@ func main() {
 		WithArtifactTriggerDeliveryRepository(artifactTriggerDeliveryRepo)
 	buildService.SetArtifactTriggerDispatcher(jobService)
 	sourceCredentialService := service.NewSourceCredentialService(sourceCredentialRepo)
+	scmAdminService := service.NewSCMAdminService(scmConnectionRepo, scmRepositoryRegistrationRepo)
 	notificationService := service.NewNotificationService(notificationSubscriptionRepo).
 		WithPreferenceRepository(notificationPreferenceRepo).
 		WithInstanceSettingsRepository(notificationInstanceSettingsRepo).
@@ -248,6 +251,8 @@ func main() {
 	versionTagHandler := handler.NewVersionTagHandler(versionTagService)
 	credentialHandler := handler.NewSourceCredentialHandler(sourceCredentialService)
 	credentialHandler.SetAuthorization(authMode)
+	scmHandler := handler.NewSCMHandler(scmAdminService)
+	scmHandler.SetAuthorization(authMode)
 	notificationHandler := handler.NewNotificationHandler(nil)
 	notificationHandler.SetAdminService(notificationService)
 	notificationHandler.SetSlackWorkspaceIntegrationService(slackWorkspaceIntegrationService)
@@ -337,6 +342,7 @@ func main() {
 		cfg.PushEventSecret,
 		apphttp.WithAuthHandler(authHandler),
 		apphttp.WithAuthMiddleware(authMiddleware),
+		apphttp.WithSCMHandler(scmHandler),
 		apphttp.WithNotificationHandler(notificationHandler),
 		apphttp.WithUserHandler(userHandler),
 		apphttp.WithServerInfoHandler(serverInfoHandler),

--- a/backend/db/migrations/00039_add_scm_connection_foundation.sql
+++ b/backend/db/migrations/00039_add_scm_connection_foundation.sql
@@ -1,0 +1,100 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS scm_connections (
+    id UUID PRIMARY KEY,
+    provider TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    deployment_kind TEXT NOT NULL,
+    api_base_url TEXT NOT NULL,
+    web_base_url TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    health_status TEXT NOT NULL DEFAULT 'unknown',
+    health_summary TEXT,
+    last_health_checked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT scm_connections_provider_check CHECK (provider IN ('github', 'gitlab', 'bitbucket')),
+    CONSTRAINT scm_connections_display_name_check CHECK (display_name <> ''),
+    CONSTRAINT scm_connections_deployment_kind_check CHECK (deployment_kind IN ('cloud', 'self_hosted')),
+    CONSTRAINT scm_connections_api_base_url_check CHECK (api_base_url <> ''),
+    CONSTRAINT scm_connections_web_base_url_check CHECK (web_base_url <> ''),
+    CONSTRAINT scm_connections_health_status_check CHECK (health_status IN ('unknown', 'healthy', 'degraded', 'unhealthy', 'revoked')),
+    CONSTRAINT scm_connections_health_summary_length_check CHECK (health_summary IS NULL OR length(health_summary) <= 512)
+);
+
+CREATE TABLE IF NOT EXISTS github_app_registrations (
+    id UUID PRIMARY KEY,
+    app_id TEXT NOT NULL,
+    display_name TEXT,
+    api_base_url TEXT NOT NULL,
+    web_base_url TEXT NOT NULL,
+    private_key_secret_ref TEXT NOT NULL,
+    webhook_secret_ref TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT github_app_registrations_app_id_check CHECK (app_id <> ''),
+    CONSTRAINT github_app_registrations_api_base_url_check CHECK (api_base_url <> ''),
+    CONSTRAINT github_app_registrations_web_base_url_check CHECK (web_base_url <> ''),
+    CONSTRAINT github_app_registrations_private_key_secret_ref_check CHECK (private_key_secret_ref <> ''),
+    CONSTRAINT github_app_registrations_webhook_secret_ref_check CHECK (webhook_secret_ref <> ''),
+    CONSTRAINT github_app_registrations_app_id_api_base_url_web_base_url_key UNIQUE (app_id, api_base_url, web_base_url)
+);
+
+CREATE TABLE IF NOT EXISTS github_app_installations (
+    connection_id UUID PRIMARY KEY REFERENCES scm_connections(id) ON DELETE CASCADE,
+    app_registration_id UUID NOT NULL REFERENCES github_app_registrations(id) ON DELETE RESTRICT,
+    installation_id TEXT NOT NULL,
+    account_login TEXT NOT NULL,
+    account_type TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT github_app_installations_installation_id_check CHECK (installation_id <> ''),
+    CONSTRAINT github_app_installations_account_login_check CHECK (account_login <> ''),
+    CONSTRAINT github_app_installations_account_type_check CHECK (account_type <> ''),
+    CONSTRAINT github_app_installations_account_id_check CHECK (account_id <> ''),
+    CONSTRAINT github_app_installations_app_registration_id_installation_id_key UNIQUE (app_registration_id, installation_id)
+);
+
+CREATE TABLE IF NOT EXISTS scm_registered_repositories (
+    id UUID PRIMARY KEY,
+    connection_id UUID NOT NULL REFERENCES scm_connections(id) ON DELETE RESTRICT,
+    provider_repository_id TEXT NOT NULL,
+    owner_name TEXT NOT NULL,
+    repository_name TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    clone_url TEXT NOT NULL,
+    web_url TEXT NOT NULL,
+    default_branch TEXT,
+    archived BOOLEAN NOT NULL DEFAULT FALSE,
+    disabled BOOLEAN NOT NULL DEFAULT FALSE,
+    metadata_refreshed_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT scm_registered_repositories_provider_repository_id_check CHECK (provider_repository_id <> ''),
+    CONSTRAINT scm_registered_repositories_owner_name_check CHECK (owner_name <> ''),
+    CONSTRAINT scm_registered_repositories_repository_name_check CHECK (repository_name <> ''),
+    CONSTRAINT scm_registered_repositories_full_name_check CHECK (full_name <> ''),
+    CONSTRAINT scm_registered_repositories_clone_url_check CHECK (clone_url <> ''),
+    CONSTRAINT scm_registered_repositories_web_url_check CHECK (web_url <> ''),
+    CONSTRAINT scm_registered_repositories_connection_id_provider_repository_id_key UNIQUE (connection_id, provider_repository_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scm_connections_provider_created_at
+    ON scm_connections (provider, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_github_app_installations_app_registration_id
+    ON github_app_installations (app_registration_id);
+
+CREATE INDEX IF NOT EXISTS idx_scm_registered_repositories_connection_id_created_at
+    ON scm_registered_repositories (connection_id, created_at DESC);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_scm_registered_repositories_connection_id_created_at;
+DROP INDEX IF EXISTS idx_github_app_installations_app_registration_id;
+DROP INDEX IF EXISTS idx_scm_connections_provider_created_at;
+DROP TABLE IF EXISTS scm_registered_repositories;
+DROP TABLE IF EXISTS github_app_installations;
+DROP TABLE IF EXISTS github_app_registrations;
+DROP TABLE IF EXISTS scm_connections;

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3588,6 +3588,140 @@ const docTemplate = `{
                 }
             }
         },
+        "/settings/scm/connections/github-app-installations": {
+            "post": {
+                "description": "Creates a GitHub App installation-backed SCM connection that references an existing GitHub App registration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Create installation-backed SCM connection",
+                "parameters": [
+                    {
+                        "description": "GitHub App installation connection request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateGitHubAppInstallationConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.SCMConnectionEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/settings/scm/github-apps": {
+            "post": {
+                "description": "Creates reusable GitHub App registration metadata and secret references without creating an installation-backed SCM connection.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Create GitHub App registration",
+                "parameters": [
+                    {
+                        "description": "GitHub App registration request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateGitHubAppRegistrationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "description": "Lists Coyote users.",
@@ -5049,6 +5183,55 @@ const docTemplate = `{
                 }
             }
         },
+        "api.CreateGitHubAppInstallationConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "account_login": {
+                    "type": "string"
+                },
+                "account_type": {
+                    "type": "string"
+                },
+                "app_registration_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "installation_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.CreateGitHubAppRegistrationRequest": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "private_key_secret_ref": {
+                    "type": "string"
+                },
+                "web_base_url": {
+                    "type": "string"
+                },
+                "webhook_secret_ref": {
+                    "type": "string"
+                }
+            }
+        },
         "api.CreateJobManagedImageConfigRequest": {
             "type": "object",
             "properties": {
@@ -5411,6 +5594,69 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "working_dir": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GitHubAppInstallationResponse": {
+            "type": "object",
+            "properties": {
+                "account_login": {
+                    "type": "string"
+                },
+                "account_type": {
+                    "type": "string"
+                },
+                "app_registration_id": {
+                    "type": "string"
+                },
+                "connection_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "installation_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationResponse": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "web_base_url": {
                     "type": "string"
                 }
             }
@@ -6144,6 +6390,61 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SCMConnectionEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.SCMConnectionResponse"
+                }
+            }
+        },
+        "api.SCMConnectionResponse": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "deployment_kind": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "github_app": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                },
+                "github_installation": {
+                    "$ref": "#/definitions/api.GitHubAppInstallationResponse"
+                },
+                "health_status": {
+                    "type": "string"
+                },
+                "health_summary": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_health_checked_at": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "web_base_url": {
                     "type": "string"
                 }
             }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3659,6 +3659,42 @@ const docTemplate = `{
             }
         },
         "/settings/scm/github-apps": {
+            "get": {
+                "description": "Returns safe GitHub App registration metadata for operator rediscovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "List GitHub App registrations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationListEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates reusable GitHub App registration metadata and secret references without creating an installation-backed SCM connection.",
                 "consumes": [
@@ -3709,6 +3745,50 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/settings/scm/github-apps/{registrationID}": {
+            "get": {
+                "description": "Returns safe GitHub App registration metadata by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Get GitHub App registration",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorResponse"
                         }
@@ -5635,6 +5715,25 @@ const docTemplate = `{
                 }
             }
         },
+        "api.GitHubAppRegistrationListEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationListResponse"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationListResponse": {
+            "type": "object",
+            "properties": {
+                "github_apps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                    }
+                }
+            }
+        },
         "api.GitHubAppRegistrationResponse": {
             "type": "object",
             "properties": {
@@ -5653,11 +5752,17 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "private_key_configured": {
+                    "type": "boolean"
+                },
                 "updated_at": {
                     "type": "string"
                 },
                 "web_base_url": {
                     "type": "string"
+                },
+                "webhook_configured": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3584,6 +3584,140 @@
                 }
             }
         },
+        "/settings/scm/connections/github-app-installations": {
+            "post": {
+                "description": "Creates a GitHub App installation-backed SCM connection that references an existing GitHub App registration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Create installation-backed SCM connection",
+                "parameters": [
+                    {
+                        "description": "GitHub App installation connection request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateGitHubAppInstallationConnectionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.SCMConnectionEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/settings/scm/github-apps": {
+            "post": {
+                "description": "Creates reusable GitHub App registration metadata and secret references without creating an installation-backed SCM connection.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Create GitHub App registration",
+                "parameters": [
+                    {
+                        "description": "GitHub App registration request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateGitHubAppRegistrationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "description": "Lists Coyote users.",
@@ -5045,6 +5179,55 @@
                 }
             }
         },
+        "api.CreateGitHubAppInstallationConnectionRequest": {
+            "type": "object",
+            "properties": {
+                "account_login": {
+                    "type": "string"
+                },
+                "account_type": {
+                    "type": "string"
+                },
+                "app_registration_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "installation_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.CreateGitHubAppRegistrationRequest": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "private_key_secret_ref": {
+                    "type": "string"
+                },
+                "web_base_url": {
+                    "type": "string"
+                },
+                "webhook_secret_ref": {
+                    "type": "string"
+                }
+            }
+        },
         "api.CreateJobManagedImageConfigRequest": {
             "type": "object",
             "properties": {
@@ -5407,6 +5590,69 @@
                     "type": "integer"
                 },
                 "working_dir": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GitHubAppInstallationResponse": {
+            "type": "object",
+            "properties": {
+                "account_login": {
+                    "type": "string"
+                },
+                "account_type": {
+                    "type": "string"
+                },
+                "app_registration_id": {
+                    "type": "string"
+                },
+                "connection_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "installation_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationResponse": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "web_base_url": {
                     "type": "string"
                 }
             }
@@ -6140,6 +6386,61 @@
             "type": "object",
             "properties": {
                 "ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SCMConnectionEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.SCMConnectionResponse"
+                }
+            }
+        },
+        "api.SCMConnectionResponse": {
+            "type": "object",
+            "properties": {
+                "api_base_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "deployment_kind": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "github_app": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                },
+                "github_installation": {
+                    "$ref": "#/definitions/api.GitHubAppInstallationResponse"
+                },
+                "health_status": {
+                    "type": "string"
+                },
+                "health_summary": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_health_checked_at": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "web_base_url": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3655,6 +3655,42 @@
             }
         },
         "/settings/scm/github-apps": {
+            "get": {
+                "description": "Returns safe GitHub App registration metadata for operator rediscovery.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "List GitHub App registrations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationListEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Creates reusable GitHub App registration metadata and secret references without creating an installation-backed SCM connection.",
                 "consumes": [
@@ -3705,6 +3741,50 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/settings/scm/github-apps/{registrationID}": {
+            "get": {
+                "description": "Returns safe GitHub App registration metadata by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Get GitHub App registration",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubAppRegistrationEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorResponse"
                         }
@@ -5631,6 +5711,25 @@
                 }
             }
         },
+        "api.GitHubAppRegistrationListEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.GitHubAppRegistrationListResponse"
+                }
+            }
+        },
+        "api.GitHubAppRegistrationListResponse": {
+            "type": "object",
+            "properties": {
+                "github_apps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GitHubAppRegistrationResponse"
+                    }
+                }
+            }
+        },
         "api.GitHubAppRegistrationResponse": {
             "type": "object",
             "properties": {
@@ -5649,11 +5748,17 @@
                 "id": {
                     "type": "string"
                 },
+                "private_key_configured": {
+                    "type": "boolean"
+                },
                 "updated_at": {
                     "type": "string"
                 },
                 "web_base_url": {
                     "type": "string"
+                },
+                "webhook_configured": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -762,6 +762,38 @@ definitions:
       working_dir:
         type: string
     type: object
+  api.CreateGitHubAppInstallationConnectionRequest:
+    properties:
+      account_login:
+        type: string
+      account_type:
+        type: string
+      app_registration_id:
+        type: string
+      display_name:
+        type: string
+      enabled:
+        type: boolean
+      installation_id:
+        type: string
+      target_id:
+        type: string
+    type: object
+  api.CreateGitHubAppRegistrationRequest:
+    properties:
+      api_base_url:
+        type: string
+      app_id:
+        type: string
+      display_name:
+        type: string
+      private_key_secret_ref:
+        type: string
+      web_base_url:
+        type: string
+      webhook_secret_ref:
+        type: string
+    type: object
   api.CreateJobManagedImageConfigRequest:
     properties:
       bot_branch_prefix:
@@ -1000,6 +1032,47 @@ definitions:
       timeout_seconds:
         type: integer
       working_dir:
+        type: string
+    type: object
+  api.GitHubAppInstallationResponse:
+    properties:
+      account_login:
+        type: string
+      account_type:
+        type: string
+      app_registration_id:
+        type: string
+      connection_id:
+        type: string
+      created_at:
+        type: string
+      installation_id:
+        type: string
+      target_id:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  api.GitHubAppRegistrationEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.GitHubAppRegistrationResponse'
+    type: object
+  api.GitHubAppRegistrationResponse:
+    properties:
+      api_base_url:
+        type: string
+      app_id:
+        type: string
+      created_at:
+        type: string
+      display_name:
+        type: string
+      id:
+        type: string
+      updated_at:
+        type: string
+      web_base_url:
         type: string
     type: object
   api.ImageExecutionResponse:
@@ -1473,6 +1546,42 @@ definitions:
   api.RunJobRequest:
     properties:
       ref:
+        type: string
+    type: object
+  api.SCMConnectionEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.SCMConnectionResponse'
+    type: object
+  api.SCMConnectionResponse:
+    properties:
+      api_base_url:
+        type: string
+      created_at:
+        type: string
+      deployment_kind:
+        type: string
+      display_name:
+        type: string
+      enabled:
+        type: boolean
+      github_app:
+        $ref: '#/definitions/api.GitHubAppRegistrationResponse'
+      github_installation:
+        $ref: '#/definitions/api.GitHubAppInstallationResponse'
+      health_status:
+        type: string
+      health_summary:
+        type: string
+      id:
+        type: string
+      last_health_checked_at:
+        type: string
+      provider:
+        type: string
+      updated_at:
+        type: string
+      web_base_url:
         type: string
     type: object
   api.ServerInfoEnvelope:
@@ -4164,6 +4273,96 @@ paths:
       summary: Update notification defaults
       tags:
       - notifications
+  /settings/scm/connections/github-app-installations:
+    post:
+      consumes:
+      - application/json
+      description: Creates a GitHub App installation-backed SCM connection that references
+        an existing GitHub App registration.
+      parameters:
+      - description: GitHub App installation connection request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateGitHubAppInstallationConnectionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.SCMConnectionEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Create installation-backed SCM connection
+      tags:
+      - scm
+  /settings/scm/github-apps:
+    post:
+      consumes:
+      - application/json
+      description: Creates reusable GitHub App registration metadata and secret references
+        without creating an installation-backed SCM connection.
+      parameters:
+      - description: GitHub App registration request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateGitHubAppRegistrationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.GitHubAppRegistrationEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Create GitHub App registration
+      tags:
+      - scm
   /users:
     get:
       description: Lists Coyote users.

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1058,6 +1058,18 @@ definitions:
       data:
         $ref: '#/definitions/api.GitHubAppRegistrationResponse'
     type: object
+  api.GitHubAppRegistrationListEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/api.GitHubAppRegistrationListResponse'
+    type: object
+  api.GitHubAppRegistrationListResponse:
+    properties:
+      github_apps:
+        items:
+          $ref: '#/definitions/api.GitHubAppRegistrationResponse'
+        type: array
+    type: object
   api.GitHubAppRegistrationResponse:
     properties:
       api_base_url:
@@ -1070,10 +1082,14 @@ definitions:
         type: string
       id:
         type: string
+      private_key_configured:
+        type: boolean
       updated_at:
         type: string
       web_base_url:
         type: string
+      webhook_configured:
+        type: boolean
     type: object
   api.ImageExecutionResponse:
     properties:
@@ -4321,6 +4337,30 @@ paths:
       tags:
       - scm
   /settings/scm/github-apps:
+    get:
+      description: Returns safe GitHub App registration metadata for operator rediscovery.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubAppRegistrationListEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: List GitHub App registrations
+      tags:
+      - scm
     post:
       consumes:
       - application/json
@@ -4361,6 +4401,35 @@ paths:
           schema:
             $ref: '#/definitions/api.ErrorResponse'
       summary: Create GitHub App registration
+      tags:
+      - scm
+  /settings/scm/github-apps/{registrationID}:
+    get:
+      description: Returns safe GitHub App registration metadata by ID.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubAppRegistrationEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Get GitHub App registration
       tags:
       - scm
   /users:

--- a/backend/internal/api/scm_dto.go
+++ b/backend/internal/api/scm_dto.go
@@ -1,18 +1,22 @@
 package api
 
-type CreateGitHubAppInstallationConnectionRequest struct {
-	DisplayName         string  `json:"display_name"`
-	DeploymentKind      string  `json:"deployment_kind"`
+type CreateGitHubAppRegistrationRequest struct {
+	AppID               string  `json:"app_id"`
+	DisplayName         *string `json:"display_name,omitempty"`
 	APIBaseURL          string  `json:"api_base_url,omitempty"`
 	WebBaseURL          string  `json:"web_base_url,omitempty"`
-	AppID               string  `json:"app_id"`
-	AppDisplayName      *string `json:"app_display_name,omitempty"`
 	PrivateKeySecretRef string  `json:"private_key_secret_ref"`
 	WebhookSecretRef    string  `json:"webhook_secret_ref"`
-	InstallationID      string  `json:"installation_id"`
-	AccountLogin        string  `json:"account_login"`
-	AccountType         string  `json:"account_type"`
-	AccountID           string  `json:"account_id"`
+}
+
+type CreateGitHubAppInstallationConnectionRequest struct {
+	AppRegistrationID string `json:"app_registration_id"`
+	DisplayName       string `json:"display_name"`
+	Enabled           *bool  `json:"enabled"`
+	InstallationID    string `json:"installation_id"`
+	AccountLogin      string `json:"account_login"`
+	AccountType       string `json:"account_type"`
+	TargetID          string `json:"target_id"`
 }
 
 type PatchSCMConnectionRequest struct {
@@ -37,15 +41,15 @@ type SCMConnectionResponse struct {
 }
 
 type GitHubAppRegistrationResponse struct {
-	ID                  string  `json:"id"`
-	AppID               string  `json:"app_id"`
-	DisplayName         *string `json:"display_name,omitempty"`
-	APIBaseURL          string  `json:"api_base_url"`
-	WebBaseURL          string  `json:"web_base_url"`
-	PrivateKeySecretRef string  `json:"private_key_secret_ref"`
-	WebhookSecretRef    string  `json:"webhook_secret_ref"`
-	CreatedAt           string  `json:"created_at"`
-	UpdatedAt           string  `json:"updated_at"`
+	ID                   string  `json:"id"`
+	AppID                string  `json:"app_id"`
+	DisplayName          *string `json:"display_name,omitempty"`
+	APIBaseURL           string  `json:"api_base_url"`
+	WebBaseURL           string  `json:"web_base_url"`
+	PrivateKeyConfigured bool    `json:"private_key_configured"`
+	WebhookConfigured    bool    `json:"webhook_configured"`
+	CreatedAt            string  `json:"created_at"`
+	UpdatedAt            string  `json:"updated_at"`
 }
 
 type GitHubAppInstallationResponse struct {
@@ -54,9 +58,21 @@ type GitHubAppInstallationResponse struct {
 	InstallationID    string `json:"installation_id"`
 	AccountLogin      string `json:"account_login"`
 	AccountType       string `json:"account_type"`
-	AccountID         string `json:"account_id"`
+	TargetID          string `json:"target_id"`
 	CreatedAt         string `json:"created_at"`
 	UpdatedAt         string `json:"updated_at"`
+}
+
+type GitHubAppRegistrationEnvelope struct {
+	Data GitHubAppRegistrationResponse `json:"data"`
+}
+
+type GitHubAppRegistrationListResponse struct {
+	GitHubApps []GitHubAppRegistrationResponse `json:"github_apps"`
+}
+
+type GitHubAppRegistrationListEnvelope struct {
+	Data GitHubAppRegistrationListResponse `json:"data"`
 }
 
 type SCMConnectionListResponse struct {

--- a/backend/internal/api/scm_dto.go
+++ b/backend/internal/api/scm_dto.go
@@ -1,0 +1,114 @@
+package api
+
+type CreateGitHubAppInstallationConnectionRequest struct {
+	DisplayName         string  `json:"display_name"`
+	DeploymentKind      string  `json:"deployment_kind"`
+	APIBaseURL          string  `json:"api_base_url,omitempty"`
+	WebBaseURL          string  `json:"web_base_url,omitempty"`
+	AppID               string  `json:"app_id"`
+	AppDisplayName      *string `json:"app_display_name,omitempty"`
+	PrivateKeySecretRef string  `json:"private_key_secret_ref"`
+	WebhookSecretRef    string  `json:"webhook_secret_ref"`
+	InstallationID      string  `json:"installation_id"`
+	AccountLogin        string  `json:"account_login"`
+	AccountType         string  `json:"account_type"`
+	AccountID           string  `json:"account_id"`
+}
+
+type PatchSCMConnectionRequest struct {
+	Enabled *bool `json:"enabled"`
+}
+
+type SCMConnectionResponse struct {
+	ID                  string                         `json:"id"`
+	Provider            string                         `json:"provider"`
+	DisplayName         string                         `json:"display_name"`
+	DeploymentKind      string                         `json:"deployment_kind"`
+	APIBaseURL          string                         `json:"api_base_url"`
+	WebBaseURL          string                         `json:"web_base_url"`
+	Enabled             bool                           `json:"enabled"`
+	HealthStatus        string                         `json:"health_status"`
+	HealthSummary       *string                        `json:"health_summary,omitempty"`
+	LastHealthCheckedAt *string                        `json:"last_health_checked_at,omitempty"`
+	GitHubApp           *GitHubAppRegistrationResponse `json:"github_app,omitempty"`
+	GitHubInstallation  *GitHubAppInstallationResponse `json:"github_installation,omitempty"`
+	CreatedAt           string                         `json:"created_at"`
+	UpdatedAt           string                         `json:"updated_at"`
+}
+
+type GitHubAppRegistrationResponse struct {
+	ID                  string  `json:"id"`
+	AppID               string  `json:"app_id"`
+	DisplayName         *string `json:"display_name,omitempty"`
+	APIBaseURL          string  `json:"api_base_url"`
+	WebBaseURL          string  `json:"web_base_url"`
+	PrivateKeySecretRef string  `json:"private_key_secret_ref"`
+	WebhookSecretRef    string  `json:"webhook_secret_ref"`
+	CreatedAt           string  `json:"created_at"`
+	UpdatedAt           string  `json:"updated_at"`
+}
+
+type GitHubAppInstallationResponse struct {
+	ConnectionID      string `json:"connection_id"`
+	AppRegistrationID string `json:"app_registration_id"`
+	InstallationID    string `json:"installation_id"`
+	AccountLogin      string `json:"account_login"`
+	AccountType       string `json:"account_type"`
+	AccountID         string `json:"account_id"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
+type SCMConnectionListResponse struct {
+	Connections []SCMConnectionResponse `json:"connections"`
+}
+
+type SCMConnectionEnvelope struct {
+	Data SCMConnectionResponse `json:"data"`
+}
+
+type SCMConnectionListEnvelope struct {
+	Data SCMConnectionListResponse `json:"data"`
+}
+
+type CreateSCMRepositoryRegistrationRequest struct {
+	ConnectionID         string  `json:"connection_id"`
+	ProviderRepositoryID string  `json:"provider_repository_id"`
+	Owner                string  `json:"owner"`
+	Name                 string  `json:"name"`
+	FullName             string  `json:"full_name"`
+	CloneURL             string  `json:"clone_url"`
+	WebURL               string  `json:"web_url"`
+	DefaultBranch        *string `json:"default_branch,omitempty"`
+	Archived             *bool   `json:"archived,omitempty"`
+	Disabled             *bool   `json:"disabled,omitempty"`
+}
+
+type SCMRepositoryRegistrationResponse struct {
+	ID                   string  `json:"id"`
+	ConnectionID         string  `json:"connection_id"`
+	ProviderRepositoryID string  `json:"provider_repository_id"`
+	Owner                string  `json:"owner"`
+	Name                 string  `json:"name"`
+	FullName             string  `json:"full_name"`
+	CloneURL             string  `json:"clone_url"`
+	WebURL               string  `json:"web_url"`
+	DefaultBranch        *string `json:"default_branch,omitempty"`
+	Archived             bool    `json:"archived"`
+	Disabled             bool    `json:"disabled"`
+	MetadataRefreshedAt  string  `json:"metadata_refreshed_at"`
+	CreatedAt            string  `json:"created_at"`
+	UpdatedAt            string  `json:"updated_at"`
+}
+
+type SCMRepositoryRegistrationListResponse struct {
+	Repositories []SCMRepositoryRegistrationResponse `json:"repositories"`
+}
+
+type SCMRepositoryRegistrationEnvelope struct {
+	Data SCMRepositoryRegistrationResponse `json:"data"`
+}
+
+type SCMRepositoryRegistrationListEnvelope struct {
+	Data SCMRepositoryRegistrationListResponse `json:"data"`
+}

--- a/backend/internal/domain/scm_connection.go
+++ b/backend/internal/domain/scm_connection.go
@@ -1,0 +1,346 @@
+package domain
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type SCMProvider string
+
+const (
+	SCMProviderGitHub    SCMProvider = "github"
+	SCMProviderGitLab    SCMProvider = "gitlab"
+	SCMProviderBitbucket SCMProvider = "bitbucket"
+)
+
+type SCMDeploymentKind string
+
+const (
+	SCMDeploymentKindCloud      SCMDeploymentKind = "cloud"
+	SCMDeploymentKindSelfHosted SCMDeploymentKind = "self_hosted"
+)
+
+type SCMConnectionHealthStatus string
+
+const (
+	SCMConnectionHealthStatusUnknown   SCMConnectionHealthStatus = "unknown"
+	SCMConnectionHealthStatusHealthy   SCMConnectionHealthStatus = "healthy"
+	SCMConnectionHealthStatusDegraded  SCMConnectionHealthStatus = "degraded"
+	SCMConnectionHealthStatusUnhealthy SCMConnectionHealthStatus = "unhealthy"
+	SCMConnectionHealthStatusRevoked   SCMConnectionHealthStatus = "revoked"
+)
+
+const (
+	defaultGitHubAPIBaseURL          = "https://api.github.com"
+	defaultGitHubWebBaseURL          = "https://github.com"
+	maxSCMConnectionHealthSummaryLen = 512
+	maxSCMConnectionDisplayNameLen   = 200
+	maxGitHubAppDisplayNameLen       = 200
+	maxGitHubAccountLoginLen         = 200
+	maxGitHubAccountTypeLen          = 50
+)
+
+type SCMConnection struct {
+	ID                  string
+	Provider            SCMProvider
+	DisplayName         string
+	DeploymentKind      SCMDeploymentKind
+	APIBaseURL          string
+	WebBaseURL          string
+	Enabled             bool
+	HealthStatus        SCMConnectionHealthStatus
+	HealthSummary       *string
+	LastHealthCheckedAt *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type GitHubAppRegistration struct {
+	ID                  string
+	AppID               string
+	DisplayName         *string
+	APIBaseURL          string
+	WebBaseURL          string
+	PrivateKeySecretRef string
+	WebhookSecretRef    string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type GitHubAppInstallation struct {
+	ConnectionID      string
+	AppRegistrationID string
+	InstallationID    string
+	AccountLogin      string
+	AccountType       string
+	AccountID         string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type SCMConnectionDetail struct {
+	Connection            SCMConnection
+	GitHubAppRegistration *GitHubAppRegistration
+	GitHubAppInstallation *GitHubAppInstallation
+}
+
+func (p SCMProvider) IsValid() bool {
+	switch p {
+	case SCMProviderGitHub, SCMProviderGitLab, SCMProviderBitbucket:
+		return true
+	default:
+		return false
+	}
+}
+
+func (k SCMDeploymentKind) IsValid() bool {
+	switch k {
+	case SCMDeploymentKindCloud, SCMDeploymentKindSelfHosted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s SCMConnectionHealthStatus) IsValid() bool {
+	switch s {
+	case SCMConnectionHealthStatusUnknown,
+		SCMConnectionHealthStatusHealthy,
+		SCMConnectionHealthStatusDegraded,
+		SCMConnectionHealthStatusUnhealthy,
+		SCMConnectionHealthStatusRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c SCMConnection) Normalize() SCMConnection {
+	c.ID = strings.TrimSpace(c.ID)
+	c.Provider = SCMProvider(strings.ToLower(strings.TrimSpace(string(c.Provider))))
+	c.DisplayName = truncateDomainText(strings.TrimSpace(c.DisplayName), maxSCMConnectionDisplayNameLen)
+	c.DeploymentKind = SCMDeploymentKind(strings.ToLower(strings.TrimSpace(string(c.DeploymentKind))))
+	c.APIBaseURL = normalizeSCMBaseURL(c.Provider, c.DeploymentKind, c.APIBaseURL, true)
+	c.WebBaseURL = normalizeSCMBaseURL(c.Provider, c.DeploymentKind, c.WebBaseURL, false)
+	c.HealthStatus = SCMConnectionHealthStatus(strings.ToLower(strings.TrimSpace(string(c.HealthStatus))))
+	c.HealthSummary = trimAndTruncateOptionalString(c.HealthSummary, maxSCMConnectionHealthSummaryLen)
+	c.LastHealthCheckedAt = normalizeSCMTimePointer(c.LastHealthCheckedAt)
+	c.CreatedAt = c.CreatedAt.UTC()
+	c.UpdatedAt = c.UpdatedAt.UTC()
+	if c.HealthStatus == "" {
+		c.HealthStatus = SCMConnectionHealthStatusUnknown
+	}
+	return c
+}
+
+func (c SCMConnection) Validate() error {
+	c = c.Normalize()
+	if c.ID == "" {
+		return fmt.Errorf("scm connection id is required")
+	}
+	if !c.Provider.IsValid() {
+		return fmt.Errorf("unsupported scm provider %q", c.Provider)
+	}
+	if c.DisplayName == "" {
+		return fmt.Errorf("scm connection display name is required")
+	}
+	if !c.DeploymentKind.IsValid() {
+		return fmt.Errorf("unsupported scm deployment kind %q", c.DeploymentKind)
+	}
+	if c.APIBaseURL == "" || !isAbsoluteURL(c.APIBaseURL) {
+		return fmt.Errorf("scm connection api base url is required")
+	}
+	if c.WebBaseURL == "" || !isAbsoluteURL(c.WebBaseURL) {
+		return fmt.Errorf("scm connection web base url is required")
+	}
+	if !c.HealthStatus.IsValid() {
+		return fmt.Errorf("unsupported scm connection health status %q", c.HealthStatus)
+	}
+	if c.CreatedAt.IsZero() || c.UpdatedAt.IsZero() {
+		return fmt.Errorf("scm connection timestamps are required")
+	}
+	return nil
+}
+
+func (r GitHubAppRegistration) Normalize() GitHubAppRegistration {
+	r.ID = strings.TrimSpace(r.ID)
+	r.AppID = strings.TrimSpace(r.AppID)
+	r.DisplayName = trimAndTruncateOptionalString(r.DisplayName, maxGitHubAppDisplayNameLen)
+	r.APIBaseURL = normalizeSCMBaseURL(SCMProviderGitHub, "", r.APIBaseURL, true)
+	r.WebBaseURL = normalizeSCMBaseURL(SCMProviderGitHub, "", r.WebBaseURL, false)
+	r.PrivateKeySecretRef = strings.TrimSpace(r.PrivateKeySecretRef)
+	r.WebhookSecretRef = strings.TrimSpace(r.WebhookSecretRef)
+	r.CreatedAt = r.CreatedAt.UTC()
+	r.UpdatedAt = r.UpdatedAt.UTC()
+	return r
+}
+
+func (r GitHubAppRegistration) Validate() error {
+	r = r.Normalize()
+	if r.ID == "" {
+		return fmt.Errorf("github app registration id is required")
+	}
+	if r.AppID == "" {
+		return fmt.Errorf("github app registration app id is required")
+	}
+	if r.APIBaseURL == "" || !isAbsoluteURL(r.APIBaseURL) {
+		return fmt.Errorf("github app registration api base url is required")
+	}
+	if r.WebBaseURL == "" || !isAbsoluteURL(r.WebBaseURL) {
+		return fmt.Errorf("github app registration web base url is required")
+	}
+	if r.PrivateKeySecretRef == "" {
+		return fmt.Errorf("github app registration private key secret ref is required")
+	}
+	if r.WebhookSecretRef == "" {
+		return fmt.Errorf("github app registration webhook secret ref is required")
+	}
+	if r.CreatedAt.IsZero() || r.UpdatedAt.IsZero() {
+		return fmt.Errorf("github app registration timestamps are required")
+	}
+	return nil
+}
+
+func (i GitHubAppInstallation) Normalize() GitHubAppInstallation {
+	i.ConnectionID = strings.TrimSpace(i.ConnectionID)
+	i.AppRegistrationID = strings.TrimSpace(i.AppRegistrationID)
+	i.InstallationID = strings.TrimSpace(i.InstallationID)
+	i.AccountLogin = truncateDomainText(strings.TrimSpace(i.AccountLogin), maxGitHubAccountLoginLen)
+	i.AccountType = truncateDomainText(strings.ToLower(strings.TrimSpace(i.AccountType)), maxGitHubAccountTypeLen)
+	i.AccountID = strings.TrimSpace(i.AccountID)
+	i.CreatedAt = i.CreatedAt.UTC()
+	i.UpdatedAt = i.UpdatedAt.UTC()
+	return i
+}
+
+func (i GitHubAppInstallation) Validate() error {
+	i = i.Normalize()
+	if i.ConnectionID == "" {
+		return fmt.Errorf("github app installation connection id is required")
+	}
+	if i.AppRegistrationID == "" {
+		return fmt.Errorf("github app installation app registration id is required")
+	}
+	if i.InstallationID == "" {
+		return fmt.Errorf("github app installation installation id is required")
+	}
+	if i.AccountLogin == "" {
+		return fmt.Errorf("github app installation account login is required")
+	}
+	if i.AccountType == "" {
+		return fmt.Errorf("github app installation account type is required")
+	}
+	if i.AccountID == "" {
+		return fmt.Errorf("github app installation account id is required")
+	}
+	if i.CreatedAt.IsZero() || i.UpdatedAt.IsZero() {
+		return fmt.Errorf("github app installation timestamps are required")
+	}
+	return nil
+}
+
+func (d SCMConnectionDetail) Normalize() SCMConnectionDetail {
+	d.Connection = d.Connection.Normalize()
+	if d.GitHubAppRegistration != nil {
+		registration := d.GitHubAppRegistration.Normalize()
+		d.GitHubAppRegistration = &registration
+	}
+	if d.GitHubAppInstallation != nil {
+		installation := d.GitHubAppInstallation.Normalize()
+		d.GitHubAppInstallation = &installation
+	}
+	return d
+}
+
+func (d SCMConnectionDetail) Validate() error {
+	d = d.Normalize()
+	if err := d.Connection.Validate(); err != nil {
+		return err
+	}
+	if d.Connection.Provider == SCMProviderGitHub {
+		if d.GitHubAppRegistration == nil {
+			return fmt.Errorf("github app registration is required for github connections")
+		}
+		if d.GitHubAppInstallation == nil {
+			return fmt.Errorf("github app installation is required for github connections")
+		}
+		if err := d.GitHubAppRegistration.Validate(); err != nil {
+			return err
+		}
+		if err := d.GitHubAppInstallation.Validate(); err != nil {
+			return err
+		}
+		if d.GitHubAppInstallation.ConnectionID != d.Connection.ID {
+			return fmt.Errorf("github app installation connection id must match scm connection id")
+		}
+		if d.GitHubAppInstallation.AppRegistrationID != d.GitHubAppRegistration.ID {
+			return fmt.Errorf("github app installation app registration id must match github app registration id")
+		}
+		if d.Connection.APIBaseURL != d.GitHubAppRegistration.APIBaseURL {
+			return fmt.Errorf("github connection api base url must match github app registration api base url")
+		}
+		if d.Connection.WebBaseURL != d.GitHubAppRegistration.WebBaseURL {
+			return fmt.Errorf("github connection web base url must match github app registration web base url")
+		}
+	}
+	return nil
+}
+
+func normalizeSCMBaseURL(provider SCMProvider, deploymentKind SCMDeploymentKind, raw string, api bool) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" && provider == SCMProviderGitHub {
+		if api {
+			trimmed = defaultGitHubAPIBaseURL
+		} else {
+			trimmed = defaultGitHubWebBaseURL
+		}
+	}
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func trimAndTruncateOptionalString(value *string, maxLen int) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := truncateDomainText(strings.TrimSpace(*value), maxLen)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func truncateDomainText(value string, maxLen int) string {
+	if maxLen <= 0 || len([]rune(value)) <= maxLen {
+		return value
+	}
+	runes := []rune(value)
+	return string(runes[:maxLen])
+}
+
+func normalizeSCMTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	converted := value.UTC()
+	return &converted
+}
+
+func isAbsoluteURL(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed == nil {
+		return false
+	}
+	return parsed.Scheme != "" && parsed.Host != ""
+}

--- a/backend/internal/domain/scm_connection_test.go
+++ b/backend/internal/domain/scm_connection_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -79,5 +80,140 @@ func TestSCMConnectionDetailValidateRejectsMismatchedRelationship(t *testing.T) 
 
 	if err := detail.Validate(); err == nil {
 		t.Fatal("expected mismatched connection id validation error")
+	}
+}
+
+func TestSCMConnectionValidationHelpersAndErrors(t *testing.T) {
+	if !SCMProviderGitHub.IsValid() || SCMProvider("svn").IsValid() {
+		t.Fatal("expected provider validity checks to discriminate known and unknown providers")
+	}
+	if !SCMDeploymentKindCloud.IsValid() || SCMDeploymentKind("other").IsValid() {
+		t.Fatal("expected deployment kind validity checks to discriminate known and unknown kinds")
+	}
+	if !SCMConnectionHealthStatusHealthy.IsValid() || SCMConnectionHealthStatus("bad").IsValid() {
+		t.Fatal("expected health status validity checks to discriminate known and unknown statuses")
+	}
+	if normalizeSCMBaseURL(SCMProviderGitHub, "", "", true) != defaultGitHubAPIBaseURL {
+		t.Fatalf("expected github api default")
+	}
+	if normalizeSCMBaseURL(SCMProvider("custom"), "", "", false) != "" {
+		t.Fatalf("expected empty default for non-github provider")
+	}
+	if got := normalizeSCMBaseURL("", "", "https://example.com/path/?q=1#frag", false); got != "https://example.com/path" {
+		t.Fatalf("expected normalized url, got %q", got)
+	}
+	if got := normalizeSCMBaseURL("", "", "not-a-url", false); got != "" {
+		t.Fatalf("expected invalid url to normalize to empty, got %q", got)
+	}
+	blank := "   "
+	if trimAndTruncateOptionalString(&blank, 10) != nil {
+		t.Fatal("expected blank optional string to normalize to nil")
+	}
+	longValue := strings.Repeat("x", maxSCMConnectionDisplayNameLen+5)
+	if got := truncateDomainText(longValue, maxSCMConnectionDisplayNameLen); len([]rune(got)) != maxSCMConnectionDisplayNameLen {
+		t.Fatalf("expected truncated text length %d, got %d", maxSCMConnectionDisplayNameLen, len([]rune(got)))
+	}
+	now := time.Now()
+	converted := normalizeSCMTimePointer(&now)
+	if converted == nil || converted.Location() != time.UTC {
+		t.Fatal("expected normalized time pointer to be converted to UTC")
+	}
+	if normalizeSCMTimePointer(nil) != nil {
+		t.Fatal("expected nil time pointer to stay nil")
+	}
+	if !isAbsoluteURL("https://example.com") || isAbsoluteURL("/relative") {
+		t.Fatal("expected absolute url helper to discriminate absolute and relative urls")
+	}
+
+	now = time.Now().UTC()
+	connectionCases := []struct {
+		name  string
+		value SCMConnection
+	}{
+		{name: "missing id", value: SCMConnection{Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad provider", value: SCMConnection{ID: "id", Provider: SCMProvider("other"), DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing display", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad deployment", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKind("other"), APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad api url", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: "bad", WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad web url", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: "bad", HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad health", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatus("other"), CreatedAt: now, UpdatedAt: now}},
+		{name: "missing timestamps", value: SCMConnection{ID: "id", Provider: SCMProviderGitHub, DisplayName: "name", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown}},
+	}
+	for _, test := range connectionCases {
+		if err := test.value.Validate(); err == nil {
+			t.Fatalf("expected validation error for %s", test.name)
+		}
+	}
+
+	registrationCases := []struct {
+		name  string
+		value GitHubAppRegistration
+	}{
+		{name: "missing id", value: GitHubAppRegistration{AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing app id", value: GitHubAppRegistration{ID: "id", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now}},
+		{name: "bad api url", value: GitHubAppRegistration{ID: "id", AppID: "1", APIBaseURL: "bad", WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now}},
+		{name: "bad web url", value: GitHubAppRegistration{ID: "id", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: "bad", PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing private key", value: GitHubAppRegistration{ID: "id", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing webhook", value: GitHubAppRegistration{ID: "id", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing timestamps", value: GitHubAppRegistration{ID: "id", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b"}},
+	}
+	for _, test := range registrationCases {
+		if err := test.value.Validate(); err == nil {
+			t.Fatalf("expected github app registration validation error for %s", test.name)
+		}
+	}
+
+	installationCases := []struct {
+		name  string
+		value GitHubAppInstallation
+	}{
+		{name: "missing connection id", value: GitHubAppInstallation{AppRegistrationID: "reg", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing registration id", value: GitHubAppInstallation{ConnectionID: "conn", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing installation id", value: GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing login", value: GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", InstallationID: "inst", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing type", value: GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", InstallationID: "inst", AccountLogin: "octo", AccountID: "42", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing account id", value: GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing timestamps", value: GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", AccountID: "42"}},
+	}
+	for _, test := range installationCases {
+		if err := test.value.Validate(); err == nil {
+			t.Fatalf("expected github app installation validation error for %s", test.name)
+		}
+	}
+
+	nonGitHubDetail := SCMConnectionDetail{Connection: SCMConnection{ID: "conn", Provider: SCMProviderGitLab, DisplayName: "GitLab", DeploymentKind: SCMDeploymentKindSelfHosted, APIBaseURL: "https://gitlab.example/api/v4", WebBaseURL: "https://gitlab.example", HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now}}
+	if err := nonGitHubDetail.Validate(); err != nil {
+		t.Fatalf("expected non-github detail without github substructures to validate, got %v", err)
+	}
+
+	baseDetail := SCMConnectionDetail{
+		Connection:            SCMConnection{ID: "conn", Provider: SCMProviderGitHub, DisplayName: "GitHub", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &GitHubAppRegistration{ID: "reg", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now},
+		GitHubAppInstallation: &GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "reg", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now},
+	}
+	missingRegistration := baseDetail
+	missingRegistration.GitHubAppRegistration = nil
+	if err := missingRegistration.Validate(); err == nil {
+		t.Fatal("expected missing github app registration to fail validation")
+	}
+	missingInstallation := baseDetail
+	missingInstallation.GitHubAppInstallation = nil
+	if err := missingInstallation.Validate(); err == nil {
+		t.Fatal("expected missing github app installation to fail validation")
+	}
+	mismatchedRegistrationID := baseDetail
+	mismatchedRegistrationID.GitHubAppInstallation = &GitHubAppInstallation{ConnectionID: "conn", AppRegistrationID: "other", InstallationID: "inst", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}
+	if err := mismatchedRegistrationID.Validate(); err == nil {
+		t.Fatal("expected mismatched registration id to fail validation")
+	}
+	mismatchedAPIBaseURL := baseDetail
+	mismatchedAPIBaseURL.Connection.APIBaseURL = "https://ghe.example/api/v3"
+	if err := mismatchedAPIBaseURL.Validate(); err == nil {
+		t.Fatal("expected mismatched api base url to fail validation")
+	}
+	mismatchedWebBaseURL := baseDetail
+	mismatchedWebBaseURL.Connection.WebBaseURL = "https://ghe.example"
+	if err := mismatchedWebBaseURL.Validate(); err == nil {
+		t.Fatal("expected mismatched web base url to fail validation")
 	}
 }

--- a/backend/internal/domain/scm_connection_test.go
+++ b/backend/internal/domain/scm_connection_test.go
@@ -1,0 +1,83 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSCMConnectionDetailNormalizeAndValidate(t *testing.T) {
+	now := time.Now().UTC()
+	summary := "  healthy enough  "
+	displayName := " GitHub App "
+	detail := SCMConnectionDetail{
+		Connection: SCMConnection{
+			ID:             " connection-1 ",
+			Provider:       SCMProvider(" GITHUB "),
+			DisplayName:    " Example Connection ",
+			DeploymentKind: SCMDeploymentKind(" cloud "),
+			Enabled:        true,
+			HealthStatus:   SCMConnectionHealthStatus(" healthy "),
+			HealthSummary:  &summary,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		GitHubAppRegistration: &GitHubAppRegistration{
+			ID:                  " registration-1 ",
+			AppID:               " 12345 ",
+			DisplayName:         &displayName,
+			PrivateKeySecretRef: " secrets/github/private-key ",
+			WebhookSecretRef:    " secrets/github/webhook ",
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		},
+		GitHubAppInstallation: &GitHubAppInstallation{
+			ConnectionID:      " connection-1 ",
+			AppRegistrationID: " registration-1 ",
+			InstallationID:    " 98765 ",
+			AccountLogin:      " octo-org ",
+			AccountType:       " Organization ",
+			AccountID:         " 42 ",
+			CreatedAt:         now,
+			UpdatedAt:         now,
+		},
+	}
+
+	normalized := detail.Normalize()
+	if normalized.Connection.Provider != SCMProviderGitHub {
+		t.Fatalf("expected normalized provider github, got %q", normalized.Connection.Provider)
+	}
+	if normalized.Connection.APIBaseURL != defaultGitHubAPIBaseURL {
+		t.Fatalf("expected default api base url, got %q", normalized.Connection.APIBaseURL)
+	}
+	if normalized.Connection.WebBaseURL != defaultGitHubWebBaseURL {
+		t.Fatalf("expected default web base url, got %q", normalized.Connection.WebBaseURL)
+	}
+	if normalized.GitHubAppRegistration == nil || normalized.GitHubAppRegistration.APIBaseURL != defaultGitHubAPIBaseURL {
+		t.Fatalf("expected github app registration default api base url, got %+v", normalized.GitHubAppRegistration)
+	}
+	if normalized.GitHubAppInstallation == nil || normalized.GitHubAppInstallation.AccountType != "organization" {
+		t.Fatalf("expected normalized account type organization, got %+v", normalized.GitHubAppInstallation)
+	}
+	if normalized.Connection.HealthSummary == nil || *normalized.Connection.HealthSummary != "healthy enough" {
+		t.Fatalf("expected trimmed health summary, got %+v", normalized.Connection.HealthSummary)
+	}
+	if normalized.GitHubAppRegistration.DisplayName == nil || *normalized.GitHubAppRegistration.DisplayName != "GitHub App" {
+		t.Fatalf("expected trimmed github app display name, got %+v", normalized.GitHubAppRegistration.DisplayName)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("expected valid connection detail, got %v", err)
+	}
+}
+
+func TestSCMConnectionDetailValidateRejectsMismatchedRelationship(t *testing.T) {
+	now := time.Now().UTC()
+	detail := SCMConnectionDetail{
+		Connection:            SCMConnection{ID: "connection-1", Provider: SCMProviderGitHub, DisplayName: "GitHub", DeploymentKind: SCMDeploymentKindCloud, APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, Enabled: true, HealthStatus: SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &GitHubAppRegistration{ID: "registration-1", AppID: "1", APIBaseURL: defaultGitHubAPIBaseURL, WebBaseURL: defaultGitHubWebBaseURL, PrivateKeySecretRef: "secret/a", WebhookSecretRef: "secret/b", CreatedAt: now, UpdatedAt: now},
+		GitHubAppInstallation: &GitHubAppInstallation{ConnectionID: "connection-2", AppRegistrationID: "registration-1", InstallationID: "9", AccountLogin: "octo", AccountType: "organization", AccountID: "2", CreatedAt: now, UpdatedAt: now},
+	}
+
+	if err := detail.Validate(); err == nil {
+		t.Fatal("expected mismatched connection id validation error")
+	}
+}

--- a/backend/internal/domain/scm_repository_registration.go
+++ b/backend/internal/domain/scm_repository_registration.go
@@ -1,0 +1,77 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const maxSCMRepositoryTextLen = 300
+
+type SCMRepositoryRegistration struct {
+	ID                   string
+	ConnectionID         string
+	ProviderRepositoryID string
+	Owner                string
+	Name                 string
+	FullName             string
+	CloneURL             string
+	WebURL               string
+	DefaultBranch        *string
+	Archived             bool
+	Disabled             bool
+	MetadataRefreshedAt  time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+func (r SCMRepositoryRegistration) Normalize() SCMRepositoryRegistration {
+	r.ID = strings.TrimSpace(r.ID)
+	r.ConnectionID = strings.TrimSpace(r.ConnectionID)
+	r.ProviderRepositoryID = strings.TrimSpace(r.ProviderRepositoryID)
+	r.Owner = truncateDomainText(strings.TrimSpace(r.Owner), maxSCMRepositoryTextLen)
+	r.Name = truncateDomainText(strings.TrimSpace(r.Name), maxSCMRepositoryTextLen)
+	r.FullName = truncateDomainText(strings.TrimSpace(r.FullName), maxSCMRepositoryTextLen)
+	r.CloneURL = normalizeSCMBaseURL("", "", r.CloneURL, false)
+	r.WebURL = normalizeSCMBaseURL("", "", r.WebURL, false)
+	r.DefaultBranch = trimAndTruncateOptionalString(r.DefaultBranch, maxSCMRepositoryTextLen)
+	r.MetadataRefreshedAt = r.MetadataRefreshedAt.UTC()
+	r.CreatedAt = r.CreatedAt.UTC()
+	r.UpdatedAt = r.UpdatedAt.UTC()
+	return r
+}
+
+func (r SCMRepositoryRegistration) Validate() error {
+	r = r.Normalize()
+	if r.ID == "" {
+		return fmt.Errorf("scm registered repository id is required")
+	}
+	if r.ConnectionID == "" {
+		return fmt.Errorf("scm registered repository connection id is required")
+	}
+	if r.ProviderRepositoryID == "" {
+		return fmt.Errorf("scm registered repository provider repository id is required")
+	}
+	if r.Owner == "" {
+		return fmt.Errorf("scm registered repository owner is required")
+	}
+	if r.Name == "" {
+		return fmt.Errorf("scm registered repository name is required")
+	}
+	if r.FullName == "" {
+		return fmt.Errorf("scm registered repository full name is required")
+	}
+	if r.CloneURL == "" || !isAbsoluteURL(r.CloneURL) {
+		return fmt.Errorf("scm registered repository clone url is required")
+	}
+	if r.WebURL == "" || !isAbsoluteURL(r.WebURL) {
+		return fmt.Errorf("scm registered repository web url is required")
+	}
+	if r.MetadataRefreshedAt.IsZero() {
+		return fmt.Errorf("scm registered repository metadata refreshed at is required")
+	}
+	if r.CreatedAt.IsZero() || r.UpdatedAt.IsZero() {
+		return fmt.Errorf("scm registered repository timestamps are required")
+	}
+	return nil
+}

--- a/backend/internal/domain/scm_repository_registration_test.go
+++ b/backend/internal/domain/scm_repository_registration_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,5 +41,47 @@ func TestSCMRepositoryRegistrationValidateRequiresConnectionScopedIdentity(t *te
 	repo := SCMRepositoryRegistration{ID: "repo-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
 	if err := repo.Validate(); err == nil {
 		t.Fatal("expected missing connection id validation error")
+	}
+}
+
+func TestSCMRepositoryRegistrationValidationBranches(t *testing.T) {
+	now := time.Now().UTC()
+	longBranch := strings.Repeat("a", maxSCMRepositoryTextLen+20)
+	normalized := SCMRepositoryRegistration{
+		ID:                   " repo-1 ",
+		ConnectionID:         " connection-1 ",
+		ProviderRepositoryID: " 1001 ",
+		Owner:                " owner ",
+		Name:                 " repo ",
+		FullName:             " owner/repo ",
+		CloneURL:             " https://github.com/owner/repo.git ",
+		WebURL:               " https://github.com/owner/repo ",
+		DefaultBranch:        &longBranch,
+		MetadataRefreshedAt:  now,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}.Normalize()
+	if normalized.DefaultBranch == nil || len([]rune(*normalized.DefaultBranch)) != maxSCMRepositoryTextLen {
+		t.Fatalf("expected normalized default branch to be truncated to %d", maxSCMRepositoryTextLen)
+	}
+
+	cases := []struct {
+		name  string
+		value SCMRepositoryRegistration
+	}{
+		{name: "missing id", value: SCMRepositoryRegistration{ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing provider repo id", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing owner", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing name", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing full name", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad clone url", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "bad", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "bad web url", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "bad", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}},
+		{name: "missing metadata refreshed at", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", CreatedAt: now, UpdatedAt: now}},
+		{name: "missing timestamps", value: SCMRepositoryRegistration{ID: "id", ConnectionID: "conn", ProviderRepositoryID: "1001", Owner: "owner", Name: "repo", FullName: "owner/repo", CloneURL: "https://github.com/owner/repo.git", WebURL: "https://github.com/owner/repo", MetadataRefreshedAt: now}},
+	}
+	for _, test := range cases {
+		if err := test.value.Validate(); err == nil {
+			t.Fatalf("expected validation error for %s", test.name)
+		}
 	}
 }

--- a/backend/internal/domain/scm_repository_registration_test.go
+++ b/backend/internal/domain/scm_repository_registration_test.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSCMRepositoryRegistrationNormalizeAndValidate(t *testing.T) {
+	now := time.Now().UTC()
+	branch := " main "
+	repo := SCMRepositoryRegistration{
+		ID:                   " repo-1 ",
+		ConnectionID:         " connection-1 ",
+		ProviderRepositoryID: " 1001 ",
+		Owner:                " octo ",
+		Name:                 " widgets ",
+		FullName:             " octo/widgets ",
+		CloneURL:             " https://github.com/octo/widgets.git ",
+		WebURL:               " https://github.com/octo/widgets ",
+		DefaultBranch:        &branch,
+		MetadataRefreshedAt:  now,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+
+	normalized := repo.Normalize()
+	if normalized.CloneURL != "https://github.com/octo/widgets.git" {
+		t.Fatalf("expected normalized clone url, got %q", normalized.CloneURL)
+	}
+	if normalized.DefaultBranch == nil || *normalized.DefaultBranch != "main" {
+		t.Fatalf("expected normalized default branch, got %+v", normalized.DefaultBranch)
+	}
+	if err := normalized.Validate(); err != nil {
+		t.Fatalf("expected valid repository registration, got %v", err)
+	}
+}
+
+func TestSCMRepositoryRegistrationValidateRequiresConnectionScopedIdentity(t *testing.T) {
+	now := time.Now().UTC()
+	repo := SCMRepositoryRegistration{ID: "repo-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	if err := repo.Validate(); err == nil {
+		t.Fatal("expected missing connection id validation error")
+	}
+}

--- a/backend/internal/http/handler/scm_handler.go
+++ b/backend/internal/http/handler/scm_handler.go
@@ -1,0 +1,279 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/radiation/coyote-ci/backend/internal/api"
+	"github.com/radiation/coyote-ci/backend/internal/auth"
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+	"github.com/radiation/coyote-ci/backend/internal/service"
+)
+
+type scmAdminService interface {
+	ListConnections(ctx context.Context) ([]domain.SCMConnectionDetail, error)
+	GetConnection(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
+	CreateGitHubAppInstallationConnection(ctx context.Context, input service.CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error)
+	SetConnectionEnabled(ctx context.Context, id string, enabled *bool) (domain.SCMConnectionDetail, error)
+	ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error)
+	GetRegisteredRepository(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error)
+	CreateRegisteredRepository(ctx context.Context, input service.CreateSCMRepositoryRegistrationInput) (domain.SCMRepositoryRegistration, error)
+}
+
+type SCMHandler struct {
+	admin    scmAdminService
+	authMode auth.Mode
+}
+
+func NewSCMHandler(admin scmAdminService) *SCMHandler {
+	return &SCMHandler{admin: admin}
+}
+
+func (h *SCMHandler) SetAuthorization(mode auth.Mode) {
+	h.authMode = mode
+}
+
+func (h *SCMHandler) ListConnections(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	connections, err := h.admin.ListConnections(r.Context())
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	responses := make([]api.SCMConnectionResponse, 0, len(connections))
+	for _, item := range connections {
+		responses = append(responses, toSCMConnectionResponse(item))
+	}
+	writeDataJSON(w, http.StatusOK, api.SCMConnectionListResponse{Connections: responses})
+}
+
+func (h *SCMHandler) CreateGitHubAppInstallationConnection(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	var req api.CreateGitHubAppInstallationConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	connection, err := h.admin.CreateGitHubAppInstallationConnection(r.Context(), service.CreateGitHubAppInstallationConnectionInput{
+		DisplayName:         req.DisplayName,
+		DeploymentKind:      req.DeploymentKind,
+		APIBaseURL:          req.APIBaseURL,
+		WebBaseURL:          req.WebBaseURL,
+		AppID:               req.AppID,
+		AppDisplayName:      req.AppDisplayName,
+		PrivateKeySecretRef: req.PrivateKeySecretRef,
+		WebhookSecretRef:    req.WebhookSecretRef,
+		InstallationID:      req.InstallationID,
+		AccountLogin:        req.AccountLogin,
+		AccountType:         req.AccountType,
+		AccountID:           req.AccountID,
+	})
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusCreated, toSCMConnectionResponse(connection))
+}
+
+func (h *SCMHandler) GetConnection(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	connection, err := h.admin.GetConnection(r.Context(), strings.TrimSpace(chi.URLParam(r, "connectionID")))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, toSCMConnectionResponse(connection))
+}
+
+func (h *SCMHandler) PatchConnection(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	var req api.PatchSCMConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	connection, err := h.admin.SetConnectionEnabled(r.Context(), strings.TrimSpace(chi.URLParam(r, "connectionID")), req.Enabled)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, toSCMConnectionResponse(connection))
+}
+
+func (h *SCMHandler) ListRegisteredRepositories(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	repositories, err := h.admin.ListRegisteredRepositories(r.Context())
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	responses := make([]api.SCMRepositoryRegistrationResponse, 0, len(repositories))
+	for _, item := range repositories {
+		responses = append(responses, toSCMRepositoryRegistrationResponse(item))
+	}
+	writeDataJSON(w, http.StatusOK, api.SCMRepositoryRegistrationListResponse{Repositories: responses})
+}
+
+func (h *SCMHandler) CreateRegisteredRepository(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	var req api.CreateSCMRepositoryRegistrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	archived := req.Archived != nil && *req.Archived
+	disabled := req.Disabled != nil && *req.Disabled
+	repositoryRegistration, err := h.admin.CreateRegisteredRepository(r.Context(), service.CreateSCMRepositoryRegistrationInput{
+		ConnectionID:         req.ConnectionID,
+		ProviderRepositoryID: req.ProviderRepositoryID,
+		Owner:                req.Owner,
+		Name:                 req.Name,
+		FullName:             req.FullName,
+		CloneURL:             req.CloneURL,
+		WebURL:               req.WebURL,
+		DefaultBranch:        req.DefaultBranch,
+		Archived:             archived,
+		Disabled:             disabled,
+	})
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusCreated, toSCMRepositoryRegistrationResponse(repositoryRegistration))
+}
+
+func (h *SCMHandler) GetRegisteredRepository(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	repositoryRegistration, err := h.admin.GetRegisteredRepository(r.Context(), strings.TrimSpace(chi.URLParam(r, "repositoryID")))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, toSCMRepositoryRegistrationResponse(repositoryRegistration))
+}
+
+func (h *SCMHandler) authorizeAdmin(w http.ResponseWriter, r *http.Request) bool {
+	if h == nil || h.admin == nil {
+		writeErrorJSON(w, http.StatusNotFound, "not_found", "scm endpoint is not available")
+		return false
+	}
+	return authorizeGlobalAdmin(w, r, h.authMode, "global admin is required")
+}
+
+func (h *SCMHandler) writeError(w http.ResponseWriter, err error) {
+	if errors.Is(err, repository.ErrSCMConnectionNotFound) || errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
+		writeErrorJSON(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	if errors.Is(err, repository.ErrSCMConnectionConflict) || errors.Is(err, repository.ErrSCMGitHubAppRegistrationConflict) || errors.Is(err, repository.ErrSCMGitHubAppInstallationConflict) || errors.Is(err, repository.ErrSCMRepositoryRegistrationDuplicate) {
+		writeErrorJSON(w, http.StatusConflict, "conflict", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMConnectionDisplayNameRequired) ||
+		errors.Is(err, service.ErrSCMConnectionDeploymentKindInvalid) ||
+		errors.Is(err, service.ErrSCMGitHubAppIDRequired) ||
+		errors.Is(err, service.ErrSCMGitHubPrivateKeySecretRefRequired) ||
+		errors.Is(err, service.ErrSCMGitHubWebhookSecretRefRequired) ||
+		errors.Is(err, service.ErrSCMGitHubInstallationIDRequired) ||
+		errors.Is(err, service.ErrSCMGitHubAccountLoginRequired) ||
+		errors.Is(err, service.ErrSCMGitHubAccountTypeRequired) ||
+		errors.Is(err, service.ErrSCMGitHubAccountIDRequired) ||
+		errors.Is(err, service.ErrSCMConnectionEnabledRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryConnectionIDRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryProviderRepositoryIDRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryOwnerRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryNameRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryFullNameRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryCloneURLRequired) ||
+		errors.Is(err, service.ErrSCMRegisteredRepositoryWebURLRequired) {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
+}
+
+func toSCMConnectionResponse(detail domain.SCMConnectionDetail) api.SCMConnectionResponse {
+	response := api.SCMConnectionResponse{
+		ID:             detail.Connection.ID,
+		Provider:       string(detail.Connection.Provider),
+		DisplayName:    detail.Connection.DisplayName,
+		DeploymentKind: string(detail.Connection.DeploymentKind),
+		APIBaseURL:     detail.Connection.APIBaseURL,
+		WebBaseURL:     detail.Connection.WebBaseURL,
+		Enabled:        detail.Connection.Enabled,
+		HealthStatus:   string(detail.Connection.HealthStatus),
+		HealthSummary:  detail.Connection.HealthSummary,
+		CreatedAt:      detail.Connection.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:      detail.Connection.UpdatedAt.Format(time.RFC3339),
+	}
+	if detail.Connection.LastHealthCheckedAt != nil {
+		formatted := detail.Connection.LastHealthCheckedAt.Format(time.RFC3339)
+		response.LastHealthCheckedAt = &formatted
+	}
+	if detail.GitHubAppRegistration != nil {
+		response.GitHubApp = &api.GitHubAppRegistrationResponse{
+			ID:                  detail.GitHubAppRegistration.ID,
+			AppID:               detail.GitHubAppRegistration.AppID,
+			DisplayName:         detail.GitHubAppRegistration.DisplayName,
+			APIBaseURL:          detail.GitHubAppRegistration.APIBaseURL,
+			WebBaseURL:          detail.GitHubAppRegistration.WebBaseURL,
+			PrivateKeySecretRef: detail.GitHubAppRegistration.PrivateKeySecretRef,
+			WebhookSecretRef:    detail.GitHubAppRegistration.WebhookSecretRef,
+			CreatedAt:           detail.GitHubAppRegistration.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:           detail.GitHubAppRegistration.UpdatedAt.Format(time.RFC3339),
+		}
+	}
+	if detail.GitHubAppInstallation != nil {
+		response.GitHubInstallation = &api.GitHubAppInstallationResponse{
+			ConnectionID:      detail.GitHubAppInstallation.ConnectionID,
+			AppRegistrationID: detail.GitHubAppInstallation.AppRegistrationID,
+			InstallationID:    detail.GitHubAppInstallation.InstallationID,
+			AccountLogin:      detail.GitHubAppInstallation.AccountLogin,
+			AccountType:       detail.GitHubAppInstallation.AccountType,
+			AccountID:         detail.GitHubAppInstallation.AccountID,
+			CreatedAt:         detail.GitHubAppInstallation.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:         detail.GitHubAppInstallation.UpdatedAt.Format(time.RFC3339),
+		}
+	}
+	return response
+}
+
+func toSCMRepositoryRegistrationResponse(registration domain.SCMRepositoryRegistration) api.SCMRepositoryRegistrationResponse {
+	return api.SCMRepositoryRegistrationResponse{
+		ID:                   registration.ID,
+		ConnectionID:         registration.ConnectionID,
+		ProviderRepositoryID: registration.ProviderRepositoryID,
+		Owner:                registration.Owner,
+		Name:                 registration.Name,
+		FullName:             registration.FullName,
+		CloneURL:             registration.CloneURL,
+		WebURL:               registration.WebURL,
+		DefaultBranch:        registration.DefaultBranch,
+		Archived:             registration.Archived,
+		Disabled:             registration.Disabled,
+		MetadataRefreshedAt:  registration.MetadataRefreshedAt.Format(time.RFC3339),
+		CreatedAt:            registration.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:            registration.UpdatedAt.Format(time.RFC3339),
+	}
+}

--- a/backend/internal/http/handler/scm_handler.go
+++ b/backend/internal/http/handler/scm_handler.go
@@ -20,6 +20,9 @@ import (
 type scmAdminService interface {
 	ListConnections(ctx context.Context) ([]domain.SCMConnectionDetail, error)
 	GetConnection(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
+	ListGitHubAppRegistrations(ctx context.Context) ([]domain.GitHubAppRegistration, error)
+	GetGitHubAppRegistration(ctx context.Context, id string) (domain.GitHubAppRegistration, error)
+	CreateGitHubAppRegistration(ctx context.Context, input service.CreateGitHubAppRegistrationInput) (domain.GitHubAppRegistration, error)
 	CreateGitHubAppInstallationConnection(ctx context.Context, input service.CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error)
 	SetConnectionEnabled(ctx context.Context, id string, enabled *bool) (domain.SCMConnectionDetail, error)
 	ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error)
@@ -40,6 +43,93 @@ func (h *SCMHandler) SetAuthorization(mode auth.Mode) {
 	h.authMode = mode
 }
 
+// ListGitHubAppRegistrations godoc
+// @Summary List GitHub App registrations
+// @Description Returns safe GitHub App registration metadata for operator rediscovery.
+// @Tags scm
+// @Produce json
+// @Success 200 {object} api.GitHubAppRegistrationListEnvelope
+// @Failure 401 {object} api.ErrorResponse
+// @Failure 403 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /settings/scm/github-apps [get]
+func (h *SCMHandler) ListGitHubAppRegistrations(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	registrations, err := h.admin.ListGitHubAppRegistrations(r.Context())
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	responses := make([]api.GitHubAppRegistrationResponse, 0, len(registrations))
+	for _, item := range registrations {
+		responses = append(responses, toGitHubAppRegistrationResponse(item))
+	}
+	writeDataJSON(w, http.StatusOK, api.GitHubAppRegistrationListResponse{GitHubApps: responses})
+}
+
+// GetGitHubAppRegistration godoc
+// @Summary Get GitHub App registration
+// @Description Returns safe GitHub App registration metadata by ID.
+// @Tags scm
+// @Produce json
+// @Success 200 {object} api.GitHubAppRegistrationEnvelope
+// @Failure 401 {object} api.ErrorResponse
+// @Failure 403 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /settings/scm/github-apps/{registrationID} [get]
+func (h *SCMHandler) GetGitHubAppRegistration(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	registration, err := h.admin.GetGitHubAppRegistration(r.Context(), strings.TrimSpace(chi.URLParam(r, "registrationID")))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, toGitHubAppRegistrationResponse(registration))
+}
+
+// CreateGitHubAppRegistration godoc
+// @Summary Create GitHub App registration
+// @Description Creates reusable GitHub App registration metadata and secret references without creating an installation-backed SCM connection.
+// @Tags scm
+// @Accept json
+// @Produce json
+// @Param request body api.CreateGitHubAppRegistrationRequest true "GitHub App registration request"
+// @Success 201 {object} api.GitHubAppRegistrationEnvelope
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 401 {object} api.ErrorResponse
+// @Failure 403 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /settings/scm/github-apps [post]
+func (h *SCMHandler) CreateGitHubAppRegistration(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	var req api.CreateGitHubAppRegistrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+	registration, err := h.admin.CreateGitHubAppRegistration(r.Context(), service.CreateGitHubAppRegistrationInput{
+		AppID:               req.AppID,
+		DisplayName:         req.DisplayName,
+		APIBaseURL:          req.APIBaseURL,
+		WebBaseURL:          req.WebBaseURL,
+		PrivateKeySecretRef: req.PrivateKeySecretRef,
+		WebhookSecretRef:    req.WebhookSecretRef,
+	})
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusCreated, toGitHubAppRegistrationResponse(registration))
+}
+
 func (h *SCMHandler) ListConnections(w http.ResponseWriter, r *http.Request) {
 	if !h.authorizeAdmin(w, r) {
 		return
@@ -56,6 +146,21 @@ func (h *SCMHandler) ListConnections(w http.ResponseWriter, r *http.Request) {
 	writeDataJSON(w, http.StatusOK, api.SCMConnectionListResponse{Connections: responses})
 }
 
+// CreateGitHubAppInstallationConnection godoc
+// @Summary Create installation-backed SCM connection
+// @Description Creates a GitHub App installation-backed SCM connection that references an existing GitHub App registration.
+// @Tags scm
+// @Accept json
+// @Produce json
+// @Param request body api.CreateGitHubAppInstallationConnectionRequest true "GitHub App installation connection request"
+// @Success 201 {object} api.SCMConnectionEnvelope
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 401 {object} api.ErrorResponse
+// @Failure 403 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /settings/scm/connections/github-app-installations [post]
 func (h *SCMHandler) CreateGitHubAppInstallationConnection(w http.ResponseWriter, r *http.Request) {
 	if !h.authorizeAdmin(w, r) {
 		return
@@ -66,18 +171,13 @@ func (h *SCMHandler) CreateGitHubAppInstallationConnection(w http.ResponseWriter
 		return
 	}
 	connection, err := h.admin.CreateGitHubAppInstallationConnection(r.Context(), service.CreateGitHubAppInstallationConnectionInput{
-		DisplayName:         req.DisplayName,
-		DeploymentKind:      req.DeploymentKind,
-		APIBaseURL:          req.APIBaseURL,
-		WebBaseURL:          req.WebBaseURL,
-		AppID:               req.AppID,
-		AppDisplayName:      req.AppDisplayName,
-		PrivateKeySecretRef: req.PrivateKeySecretRef,
-		WebhookSecretRef:    req.WebhookSecretRef,
-		InstallationID:      req.InstallationID,
-		AccountLogin:        req.AccountLogin,
-		AccountType:         req.AccountType,
-		AccountID:           req.AccountID,
+		AppRegistrationID: req.AppRegistrationID,
+		DisplayName:       req.DisplayName,
+		Enabled:           req.Enabled,
+		InstallationID:    req.InstallationID,
+		AccountLogin:      req.AccountLogin,
+		AccountType:       req.AccountType,
+		TargetID:          req.TargetID,
 	})
 	if err != nil {
 		h.writeError(w, err)
@@ -182,7 +282,7 @@ func (h *SCMHandler) authorizeAdmin(w http.ResponseWriter, r *http.Request) bool
 }
 
 func (h *SCMHandler) writeError(w http.ResponseWriter, err error) {
-	if errors.Is(err, repository.ErrSCMConnectionNotFound) || errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
+	if errors.Is(err, repository.ErrSCMConnectionNotFound) || errors.Is(err, repository.ErrSCMGitHubAppRegistrationNotFound) || errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
 		writeErrorJSON(w, http.StatusNotFound, "not_found", err.Error())
 		return
 	}
@@ -191,14 +291,14 @@ func (h *SCMHandler) writeError(w http.ResponseWriter, err error) {
 		return
 	}
 	if errors.Is(err, service.ErrSCMConnectionDisplayNameRequired) ||
-		errors.Is(err, service.ErrSCMConnectionDeploymentKindInvalid) ||
+		errors.Is(err, service.ErrSCMGitHubAppRegistrationIDRequired) ||
 		errors.Is(err, service.ErrSCMGitHubAppIDRequired) ||
 		errors.Is(err, service.ErrSCMGitHubPrivateKeySecretRefRequired) ||
 		errors.Is(err, service.ErrSCMGitHubWebhookSecretRefRequired) ||
 		errors.Is(err, service.ErrSCMGitHubInstallationIDRequired) ||
 		errors.Is(err, service.ErrSCMGitHubAccountLoginRequired) ||
 		errors.Is(err, service.ErrSCMGitHubAccountTypeRequired) ||
-		errors.Is(err, service.ErrSCMGitHubAccountIDRequired) ||
+		errors.Is(err, service.ErrSCMGitHubTargetIDRequired) ||
 		errors.Is(err, service.ErrSCMConnectionEnabledRequired) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryConnectionIDRequired) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryProviderRepositoryIDRequired) ||
@@ -232,17 +332,8 @@ func toSCMConnectionResponse(detail domain.SCMConnectionDetail) api.SCMConnectio
 		response.LastHealthCheckedAt = &formatted
 	}
 	if detail.GitHubAppRegistration != nil {
-		response.GitHubApp = &api.GitHubAppRegistrationResponse{
-			ID:                  detail.GitHubAppRegistration.ID,
-			AppID:               detail.GitHubAppRegistration.AppID,
-			DisplayName:         detail.GitHubAppRegistration.DisplayName,
-			APIBaseURL:          detail.GitHubAppRegistration.APIBaseURL,
-			WebBaseURL:          detail.GitHubAppRegistration.WebBaseURL,
-			PrivateKeySecretRef: detail.GitHubAppRegistration.PrivateKeySecretRef,
-			WebhookSecretRef:    detail.GitHubAppRegistration.WebhookSecretRef,
-			CreatedAt:           detail.GitHubAppRegistration.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:           detail.GitHubAppRegistration.UpdatedAt.Format(time.RFC3339),
-		}
+		githubApp := toGitHubAppRegistrationResponse(*detail.GitHubAppRegistration)
+		response.GitHubApp = &githubApp
 	}
 	if detail.GitHubAppInstallation != nil {
 		response.GitHubInstallation = &api.GitHubAppInstallationResponse{
@@ -251,12 +342,26 @@ func toSCMConnectionResponse(detail domain.SCMConnectionDetail) api.SCMConnectio
 			InstallationID:    detail.GitHubAppInstallation.InstallationID,
 			AccountLogin:      detail.GitHubAppInstallation.AccountLogin,
 			AccountType:       detail.GitHubAppInstallation.AccountType,
-			AccountID:         detail.GitHubAppInstallation.AccountID,
+			TargetID:          detail.GitHubAppInstallation.AccountID,
 			CreatedAt:         detail.GitHubAppInstallation.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:         detail.GitHubAppInstallation.UpdatedAt.Format(time.RFC3339),
 		}
 	}
 	return response
+}
+
+func toGitHubAppRegistrationResponse(registration domain.GitHubAppRegistration) api.GitHubAppRegistrationResponse {
+	return api.GitHubAppRegistrationResponse{
+		ID:                   registration.ID,
+		AppID:                registration.AppID,
+		DisplayName:          registration.DisplayName,
+		APIBaseURL:           registration.APIBaseURL,
+		WebBaseURL:           registration.WebBaseURL,
+		PrivateKeyConfigured: strings.TrimSpace(registration.PrivateKeySecretRef) != "",
+		WebhookConfigured:    strings.TrimSpace(registration.WebhookSecretRef) != "",
+		CreatedAt:            registration.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:            registration.UpdatedAt.Format(time.RFC3339),
+	}
 }
 
 func toSCMRepositoryRegistrationResponse(registration domain.SCMRepositoryRegistration) api.SCMRepositoryRegistrationResponse {

--- a/backend/internal/http/handler/scm_handler_test.go
+++ b/backend/internal/http/handler/scm_handler_test.go
@@ -227,3 +227,59 @@ func TestToGitHubAppRegistrationResponse_ConfiguredBooleans(t *testing.T) {
 		t.Fatal("expected webhook configured to be false")
 	}
 }
+
+func TestSCMHandler_ErrorPaths(t *testing.T) {
+	unavailable := &SCMHandler{}
+	unavailableReq := httptest.NewRequest(http.MethodGet, "/settings/scm/github-apps", nil)
+	unavailableRes := httptest.NewRecorder()
+	unavailable.ListGitHubAppRegistrations(unavailableRes, unavailableReq)
+	if unavailableRes.Code != http.StatusNotFound {
+		t.Fatalf("expected unavailable handler status %d, got %d body=%s", http.StatusNotFound, unavailableRes.Code, unavailableRes.Body.String())
+	}
+
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	h := NewSCMHandler(service.NewSCMAdminService(connectionRepo, repositoryRepo))
+
+	badCreateRegistrationReq := httptest.NewRequest(http.MethodPost, "/settings/scm/github-apps", bytes.NewBufferString(`{"app_id":`))
+	badCreateRegistrationRes := httptest.NewRecorder()
+	h.CreateGitHubAppRegistration(badCreateRegistrationRes, badCreateRegistrationReq)
+	if badCreateRegistrationRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad registration request status %d, got %d body=%s", http.StatusBadRequest, badCreateRegistrationRes.Code, badCreateRegistrationRes.Body.String())
+	}
+
+	badCreateConnectionReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"app_registration_id":`))
+	badCreateConnectionRes := httptest.NewRecorder()
+	h.CreateGitHubAppInstallationConnection(badCreateConnectionRes, badCreateConnectionReq)
+	if badCreateConnectionRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad connection request status %d, got %d body=%s", http.StatusBadRequest, badCreateConnectionRes.Code, badCreateConnectionRes.Body.String())
+	}
+
+	badPatchReq := addURLParam(httptest.NewRequest(http.MethodPatch, "/settings/scm/connections/connection-1", bytes.NewBufferString(`{"enabled":`)), "connectionID", "connection-1")
+	badPatchRes := httptest.NewRecorder()
+	h.PatchConnection(badPatchRes, badPatchReq)
+	if badPatchRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad patch request status %d, got %d body=%s", http.StatusBadRequest, badPatchRes.Code, badPatchRes.Body.String())
+	}
+
+	badCreateRepositoryReq := httptest.NewRequest(http.MethodPost, "/settings/scm/repositories", bytes.NewBufferString(`{"connection_id":`))
+	badCreateRepositoryRes := httptest.NewRecorder()
+	h.CreateRegisteredRepository(badCreateRepositoryRes, badCreateRepositoryReq)
+	if badCreateRepositoryRes.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad repository request status %d, got %d body=%s", http.StatusBadRequest, badCreateRepositoryRes.Code, badCreateRepositoryRes.Body.String())
+	}
+
+	missingConnectionReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/connections/missing", nil), "connectionID", "missing")
+	missingConnectionRes := httptest.NewRecorder()
+	h.GetConnection(missingConnectionRes, missingConnectionReq)
+	if missingConnectionRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing connection status %d, got %d body=%s", http.StatusNotFound, missingConnectionRes.Code, missingConnectionRes.Body.String())
+	}
+
+	missingRepositoryReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/repositories/missing", nil), "repositoryID", "missing")
+	missingRepositoryRes := httptest.NewRecorder()
+	h.GetRegisteredRepository(missingRepositoryRes, missingRepositoryReq)
+	if missingRepositoryRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing repository status %d, got %d body=%s", http.StatusNotFound, missingRepositoryRes.Code, missingRepositoryRes.Body.String())
+	}
+}

--- a/backend/internal/http/handler/scm_handler_test.go
+++ b/backend/internal/http/handler/scm_handler_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/radiation/coyote-ci/backend/internal/domain"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
 	"github.com/radiation/coyote-ci/backend/internal/service"
 )
@@ -15,23 +17,107 @@ func TestSCMHandler_CRUDFoundationRoutes(t *testing.T) {
 	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
 	h := NewSCMHandler(service.NewSCMAdminService(connectionRepo, repositoryRepo))
 
-	createConnectionReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"display_name":"octo cloud","deployment_kind":"cloud","app_id":"12345","private_key_secret_ref":"secret/github/private-key","webhook_secret_ref":"secret/github/webhook","installation_id":"999","account_login":"octo","account_type":"organization","account_id":"42"}`))
+	listEmptyRegistrationsReq := httptest.NewRequest(http.MethodGet, "/settings/scm/github-apps", nil)
+	listEmptyRegistrationsRes := httptest.NewRecorder()
+	h.ListGitHubAppRegistrations(listEmptyRegistrationsRes, listEmptyRegistrationsReq)
+	if listEmptyRegistrationsRes.Code != http.StatusOK {
+		t.Fatalf("expected empty registration list status %d, got %d body=%s", http.StatusOK, listEmptyRegistrationsRes.Code, listEmptyRegistrationsRes.Body.String())
+	}
+	if body := listEmptyRegistrationsRes.Body.String(); !bytes.Contains([]byte(body), []byte(`"github_apps":[]`)) {
+		t.Fatalf("expected empty github app list, got %s", body)
+	}
+
+	createRegistrationReq := httptest.NewRequest(http.MethodPost, "/settings/scm/github-apps", bytes.NewBufferString(`{"app_id":"12345","private_key_secret_ref":"secret/github/private-key","webhook_secret_ref":"secret/github/webhook"}`))
+	createRegistrationRes := httptest.NewRecorder()
+	h.CreateGitHubAppRegistration(createRegistrationRes, createRegistrationReq)
+	if createRegistrationRes.Code != http.StatusCreated {
+		t.Fatalf("expected create registration status %d, got %d body=%s", http.StatusCreated, createRegistrationRes.Code, createRegistrationRes.Body.String())
+	}
+	createdRegistration := decodeDataMap(t, createRegistrationRes)
+	registrationID, hasRegistrationID := createdRegistration["id"].(string)
+	if !hasRegistrationID || registrationID == "" {
+		t.Fatalf("expected registration id, got %v", createdRegistration["id"])
+	}
+	if _, hasPrivateKeySecretRef := createdRegistration["private_key_secret_ref"]; hasPrivateKeySecretRef {
+		t.Fatalf("expected registration response to omit secret refs, got %v", createdRegistration)
+	}
+	if _, hasWebhookSecretRef := createdRegistration["webhook_secret_ref"]; hasWebhookSecretRef {
+		t.Fatalf("expected registration response to omit secret refs, got %v", createdRegistration)
+	}
+	privateKeyConfigured, hasPrivateKeyConfigured := createdRegistration["private_key_configured"].(bool)
+	if !hasPrivateKeyConfigured || !privateKeyConfigured {
+		t.Fatalf("expected private_key_configured to be true, got %v", createdRegistration["private_key_configured"])
+	}
+	webhookConfigured, hasWebhookConfigured := createdRegistration["webhook_configured"].(bool)
+	if !hasWebhookConfigured || !webhookConfigured {
+		t.Fatalf("expected webhook_configured to be true, got %v", createdRegistration["webhook_configured"])
+	}
+
+	createSecondRegistrationReq := httptest.NewRequest(http.MethodPost, "/settings/scm/github-apps", bytes.NewBufferString(`{"app_id":"54321","api_base_url":"https://ghe.example/api/v3","web_base_url":"https://ghe.example","private_key_secret_ref":"secret/github/private-key-2","webhook_secret_ref":"secret/github/webhook-2"}`))
+	createSecondRegistrationRes := httptest.NewRecorder()
+	h.CreateGitHubAppRegistration(createSecondRegistrationRes, createSecondRegistrationReq)
+	if createSecondRegistrationRes.Code != http.StatusCreated {
+		t.Fatalf("expected second registration status %d, got %d body=%s", http.StatusCreated, createSecondRegistrationRes.Code, createSecondRegistrationRes.Body.String())
+	}
+	createdSecondRegistration := decodeDataMap(t, createSecondRegistrationRes)
+	secondRegistrationID, hasSecondRegistrationID := createdSecondRegistration["id"].(string)
+	if !hasSecondRegistrationID || secondRegistrationID == "" {
+		t.Fatalf("expected second registration id, got %v", createdSecondRegistration["id"])
+	}
+
+	listRegistrationsReq := httptest.NewRequest(http.MethodGet, "/settings/scm/github-apps", nil)
+	listRegistrationsRes := httptest.NewRecorder()
+	h.ListGitHubAppRegistrations(listRegistrationsRes, listRegistrationsReq)
+	if listRegistrationsRes.Code != http.StatusOK {
+		t.Fatalf("expected list registration status %d, got %d body=%s", http.StatusOK, listRegistrationsRes.Code, listRegistrationsRes.Body.String())
+	}
+	listRegistrations := decodeDataMap(t, listRegistrationsRes)
+	items, hasRegistrations := listRegistrations["github_apps"].([]any)
+	if !hasRegistrations || len(items) != 2 {
+		t.Fatalf("expected two github app registrations, got %v", listRegistrations["github_apps"])
+	}
+
+	getRegistrationReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/github-apps/"+registrationID, nil), "registrationID", registrationID)
+	getRegistrationRes := httptest.NewRecorder()
+	h.GetGitHubAppRegistration(getRegistrationRes, getRegistrationReq)
+	if getRegistrationRes.Code != http.StatusOK {
+		t.Fatalf("expected get registration status %d, got %d body=%s", http.StatusOK, getRegistrationRes.Code, getRegistrationRes.Body.String())
+	}
+	gotRegistration := decodeDataMap(t, getRegistrationRes)
+	if _, hasPrivateKeySecretRef := gotRegistration["private_key_secret_ref"]; hasPrivateKeySecretRef {
+		t.Fatalf("expected get registration response to omit private key secret ref, got %v", gotRegistration)
+	}
+	if _, hasWebhookSecretRef := gotRegistration["webhook_secret_ref"]; hasWebhookSecretRef {
+		t.Fatalf("expected get registration response to omit webhook secret ref, got %v", gotRegistration)
+	}
+
+	getMissingRegistrationReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/github-apps/missing", nil), "registrationID", "missing")
+	getMissingRegistrationRes := httptest.NewRecorder()
+	h.GetGitHubAppRegistration(getMissingRegistrationRes, getMissingRegistrationReq)
+	if getMissingRegistrationRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing registration status %d, got %d body=%s", http.StatusNotFound, getMissingRegistrationRes.Code, getMissingRegistrationRes.Body.String())
+	}
+
+	createConnectionReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"app_registration_id":"`+registrationID+`","display_name":"octo cloud","enabled":true,"installation_id":"999","account_login":"octo","account_type":"organization","target_id":"42"}`))
 	createConnectionRes := httptest.NewRecorder()
 	h.CreateGitHubAppInstallationConnection(createConnectionRes, createConnectionReq)
 	if createConnectionRes.Code != http.StatusCreated {
 		t.Fatalf("expected create connection status %d, got %d body=%s", http.StatusCreated, createConnectionRes.Code, createConnectionRes.Body.String())
 	}
 	createdConnection := decodeDataMap(t, createConnectionRes)
-	connectionID, ok := createdConnection["id"].(string)
-	if !ok || connectionID == "" {
+	connectionID, hasConnectionID := createdConnection["id"].(string)
+	if !hasConnectionID || connectionID == "" {
 		t.Fatalf("expected connection id, got %v", createdConnection["id"])
 	}
-	githubApp, ok := createdConnection["github_app"].(map[string]any)
-	if !ok || githubApp["private_key_secret_ref"] != "secret/github/private-key" {
-		t.Fatalf("expected github app secret refs in response, got %v", createdConnection["github_app"])
+	githubApp, hasGitHubApp := createdConnection["github_app"].(map[string]any)
+	if !hasGitHubApp {
+		t.Fatalf("expected github app metadata in response, got %v", createdConnection["github_app"])
 	}
-	if _, ok := githubApp["private_key"]; ok {
-		t.Fatal("did not expect raw private key field in response")
+	if _, hasPrivateKeySecretRef := githubApp["private_key_secret_ref"]; hasPrivateKeySecretRef {
+		t.Fatalf("expected connection response to omit private key secret ref, got %v", githubApp)
+	}
+	if _, hasWebhookSecretRef := githubApp["webhook_secret_ref"]; hasWebhookSecretRef {
+		t.Fatalf("expected connection response to omit webhook secret ref, got %v", githubApp)
 	}
 
 	listConnectionsReq := httptest.NewRequest(http.MethodGet, "/settings/scm/connections", nil)
@@ -55,8 +141,44 @@ func TestSCMHandler_CRUDFoundationRoutes(t *testing.T) {
 		t.Fatalf("expected patch connection status %d, got %d", http.StatusOK, patchConnectionRes.Code)
 	}
 	patchedConnection := decodeDataMap(t, patchConnectionRes)
-	if enabled, ok := patchedConnection["enabled"].(bool); !ok || enabled {
+	if enabled, hasEnabledFlag := patchedConnection["enabled"].(bool); !hasEnabledFlag || enabled {
 		t.Fatalf("expected connection to be disabled, got %v", patchedConnection["enabled"])
+	}
+
+	createSiblingReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"app_registration_id":"`+registrationID+`","display_name":"octo sibling","enabled":true,"installation_id":"1000","account_login":"octo-two","account_type":"organization","target_id":"84"}`))
+	createSiblingRes := httptest.NewRecorder()
+	h.CreateGitHubAppInstallationConnection(createSiblingRes, createSiblingReq)
+	if createSiblingRes.Code != http.StatusCreated {
+		t.Fatalf("expected create sibling connection status %d, got %d body=%s", http.StatusCreated, createSiblingRes.Code, createSiblingRes.Body.String())
+	}
+	createdSibling := decodeDataMap(t, createSiblingRes)
+	siblingID, hasSiblingID := createdSibling["id"].(string)
+	if !hasSiblingID || siblingID == "" {
+		t.Fatalf("expected sibling connection id, got %v", createdSibling["id"])
+	}
+	getSiblingReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/connections/"+siblingID, nil), "connectionID", siblingID)
+	getSiblingRes := httptest.NewRecorder()
+	h.GetConnection(getSiblingRes, getSiblingReq)
+	if getSiblingRes.Code != http.StatusOK {
+		t.Fatalf("expected get sibling connection status %d, got %d body=%s", http.StatusOK, getSiblingRes.Code, getSiblingRes.Body.String())
+	}
+	siblingConnection := decodeDataMap(t, getSiblingRes)
+	if enabled, hasEnabledFlag := siblingConnection["enabled"].(bool); !hasEnabledFlag || !enabled {
+		t.Fatalf("expected sibling connection to remain enabled, got %v", siblingConnection["enabled"])
+	}
+
+	duplicateConnectionReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"app_registration_id":"`+registrationID+`","display_name":"duplicate","enabled":true,"installation_id":"999","account_login":"octo-dup","account_type":"organization","target_id":"126"}`))
+	duplicateConnectionRes := httptest.NewRecorder()
+	h.CreateGitHubAppInstallationConnection(duplicateConnectionRes, duplicateConnectionReq)
+	if duplicateConnectionRes.Code != http.StatusConflict {
+		t.Fatalf("expected duplicate connection status %d, got %d body=%s", http.StatusConflict, duplicateConnectionRes.Code, duplicateConnectionRes.Body.String())
+	}
+
+	missingRegistrationReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"app_registration_id":"missing","display_name":"missing","enabled":true,"installation_id":"1001","account_login":"octo-missing","account_type":"organization","target_id":"168"}`))
+	missingRegistrationRes := httptest.NewRecorder()
+	h.CreateGitHubAppInstallationConnection(missingRegistrationRes, missingRegistrationReq)
+	if missingRegistrationRes.Code != http.StatusNotFound {
+		t.Fatalf("expected missing registration status %d, got %d body=%s", http.StatusNotFound, missingRegistrationRes.Code, missingRegistrationRes.Body.String())
 	}
 
 	createRepositoryReq := httptest.NewRequest(http.MethodPost, "/settings/scm/repositories", bytes.NewBufferString(`{"connection_id":"`+connectionID+`","provider_repository_id":"1001","owner":"octo","name":"widgets","full_name":"octo/widgets","clone_url":"https://github.com/octo/widgets.git","web_url":"https://github.com/octo/widgets","default_branch":"main"}`))
@@ -66,8 +188,8 @@ func TestSCMHandler_CRUDFoundationRoutes(t *testing.T) {
 		t.Fatalf("expected create repository status %d, got %d body=%s", http.StatusCreated, createRepositoryRes.Code, createRepositoryRes.Body.String())
 	}
 	createdRepository := decodeDataMap(t, createRepositoryRes)
-	repositoryID, ok := createdRepository["id"].(string)
-	if !ok || repositoryID == "" {
+	repositoryID, hasRepositoryID := createdRepository["id"].(string)
+	if !hasRepositoryID || repositoryID == "" {
 		t.Fatalf("expected repository id, got %v", createdRepository["id"])
 	}
 
@@ -83,5 +205,25 @@ func TestSCMHandler_CRUDFoundationRoutes(t *testing.T) {
 	h.GetRegisteredRepository(getRepositoryRes, getRepositoryReq)
 	if getRepositoryRes.Code != http.StatusOK {
 		t.Fatalf("expected get repository status %d, got %d", http.StatusOK, getRepositoryRes.Code)
+	}
+}
+
+func TestToGitHubAppRegistrationResponse_ConfiguredBooleans(t *testing.T) {
+	now := time.Now().UTC()
+	response := toGitHubAppRegistrationResponse(domain.GitHubAppRegistration{
+		ID:                  "registration-1",
+		AppID:               "12345",
+		APIBaseURL:          "https://api.github.com",
+		WebBaseURL:          "https://github.com",
+		PrivateKeySecretRef: "",
+		WebhookSecretRef:    "",
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if response.PrivateKeyConfigured {
+		t.Fatal("expected private key configured to be false")
+	}
+	if response.WebhookConfigured {
+		t.Fatal("expected webhook configured to be false")
 	}
 }

--- a/backend/internal/http/handler/scm_handler_test.go
+++ b/backend/internal/http/handler/scm_handler_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
+	"github.com/radiation/coyote-ci/backend/internal/service"
+)
+
+func TestSCMHandler_CRUDFoundationRoutes(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	h := NewSCMHandler(service.NewSCMAdminService(connectionRepo, repositoryRepo))
+
+	createConnectionReq := httptest.NewRequest(http.MethodPost, "/settings/scm/connections/github-app-installations", bytes.NewBufferString(`{"display_name":"octo cloud","deployment_kind":"cloud","app_id":"12345","private_key_secret_ref":"secret/github/private-key","webhook_secret_ref":"secret/github/webhook","installation_id":"999","account_login":"octo","account_type":"organization","account_id":"42"}`))
+	createConnectionRes := httptest.NewRecorder()
+	h.CreateGitHubAppInstallationConnection(createConnectionRes, createConnectionReq)
+	if createConnectionRes.Code != http.StatusCreated {
+		t.Fatalf("expected create connection status %d, got %d body=%s", http.StatusCreated, createConnectionRes.Code, createConnectionRes.Body.String())
+	}
+	createdConnection := decodeDataMap(t, createConnectionRes)
+	connectionID, ok := createdConnection["id"].(string)
+	if !ok || connectionID == "" {
+		t.Fatalf("expected connection id, got %v", createdConnection["id"])
+	}
+	githubApp, ok := createdConnection["github_app"].(map[string]any)
+	if !ok || githubApp["private_key_secret_ref"] != "secret/github/private-key" {
+		t.Fatalf("expected github app secret refs in response, got %v", createdConnection["github_app"])
+	}
+	if _, ok := githubApp["private_key"]; ok {
+		t.Fatal("did not expect raw private key field in response")
+	}
+
+	listConnectionsReq := httptest.NewRequest(http.MethodGet, "/settings/scm/connections", nil)
+	listConnectionsRes := httptest.NewRecorder()
+	h.ListConnections(listConnectionsRes, listConnectionsReq)
+	if listConnectionsRes.Code != http.StatusOK {
+		t.Fatalf("expected list connections status %d, got %d", http.StatusOK, listConnectionsRes.Code)
+	}
+
+	getConnectionReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/connections/"+connectionID, nil), "connectionID", connectionID)
+	getConnectionRes := httptest.NewRecorder()
+	h.GetConnection(getConnectionRes, getConnectionReq)
+	if getConnectionRes.Code != http.StatusOK {
+		t.Fatalf("expected get connection status %d, got %d", http.StatusOK, getConnectionRes.Code)
+	}
+
+	patchConnectionReq := addURLParam(httptest.NewRequest(http.MethodPatch, "/settings/scm/connections/"+connectionID, bytes.NewBufferString(`{"enabled":false}`)), "connectionID", connectionID)
+	patchConnectionRes := httptest.NewRecorder()
+	h.PatchConnection(patchConnectionRes, patchConnectionReq)
+	if patchConnectionRes.Code != http.StatusOK {
+		t.Fatalf("expected patch connection status %d, got %d", http.StatusOK, patchConnectionRes.Code)
+	}
+	patchedConnection := decodeDataMap(t, patchConnectionRes)
+	if enabled, ok := patchedConnection["enabled"].(bool); !ok || enabled {
+		t.Fatalf("expected connection to be disabled, got %v", patchedConnection["enabled"])
+	}
+
+	createRepositoryReq := httptest.NewRequest(http.MethodPost, "/settings/scm/repositories", bytes.NewBufferString(`{"connection_id":"`+connectionID+`","provider_repository_id":"1001","owner":"octo","name":"widgets","full_name":"octo/widgets","clone_url":"https://github.com/octo/widgets.git","web_url":"https://github.com/octo/widgets","default_branch":"main"}`))
+	createRepositoryRes := httptest.NewRecorder()
+	h.CreateRegisteredRepository(createRepositoryRes, createRepositoryReq)
+	if createRepositoryRes.Code != http.StatusCreated {
+		t.Fatalf("expected create repository status %d, got %d body=%s", http.StatusCreated, createRepositoryRes.Code, createRepositoryRes.Body.String())
+	}
+	createdRepository := decodeDataMap(t, createRepositoryRes)
+	repositoryID, ok := createdRepository["id"].(string)
+	if !ok || repositoryID == "" {
+		t.Fatalf("expected repository id, got %v", createdRepository["id"])
+	}
+
+	listRepositoriesReq := httptest.NewRequest(http.MethodGet, "/settings/scm/repositories", nil)
+	listRepositoriesRes := httptest.NewRecorder()
+	h.ListRegisteredRepositories(listRepositoriesRes, listRepositoriesReq)
+	if listRepositoriesRes.Code != http.StatusOK {
+		t.Fatalf("expected list repositories status %d, got %d", http.StatusOK, listRepositoriesRes.Code)
+	}
+
+	getRepositoryReq := addURLParam(httptest.NewRequest(http.MethodGet, "/settings/scm/repositories/"+repositoryID, nil), "repositoryID", repositoryID)
+	getRepositoryRes := httptest.NewRecorder()
+	h.GetRegisteredRepository(getRepositoryRes, getRepositoryReq)
+	if getRepositoryRes.Code != http.StatusOK {
+		t.Fatalf("expected get repository status %d, got %d", http.StatusOK, getRepositoryRes.Code)
+	}
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -25,6 +25,7 @@ type routerConfig struct {
 	apiTokenHandler          *handler.APITokenHandler
 	projectMembershipHandler *handler.ProjectMembershipHandler
 	workerHandler            *handler.WorkerHandler
+	scmHandler               *handler.SCMHandler
 }
 
 type RouterOption func(*routerConfig)
@@ -74,6 +75,12 @@ func WithProjectMembershipHandler(projectMembershipHandler *handler.ProjectMembe
 func WithWorkerHandler(workerHandler *handler.WorkerHandler) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.workerHandler = workerHandler
+	}
+}
+
+func WithSCMHandler(scmHandler *handler.SCMHandler) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.scmHandler = scmHandler
 	}
 }
 
@@ -188,6 +195,22 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 					r.Post("/", cfg.notificationHandler.CreateSubscription)
 					r.Patch("/{subscriptionID}", cfg.notificationHandler.UpdateSubscription)
 					r.Delete("/{subscriptionID}", cfg.notificationHandler.DeleteSubscription)
+				})
+			}
+
+			if cfg.scmHandler != nil {
+				r.Route("/settings/scm", func(r chi.Router) {
+					r.Route("/connections", func(r chi.Router) {
+						r.Get("/", cfg.scmHandler.ListConnections)
+						r.Post("/github-app-installations", cfg.scmHandler.CreateGitHubAppInstallationConnection)
+						r.Get("/{connectionID}", cfg.scmHandler.GetConnection)
+						r.Patch("/{connectionID}", cfg.scmHandler.PatchConnection)
+					})
+					r.Route("/repositories", func(r chi.Router) {
+						r.Get("/", cfg.scmHandler.ListRegisteredRepositories)
+						r.Post("/", cfg.scmHandler.CreateRegisteredRepository)
+						r.Get("/{repositoryID}", cfg.scmHandler.GetRegisteredRepository)
+					})
 				})
 			}
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -200,6 +200,11 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 
 			if cfg.scmHandler != nil {
 				r.Route("/settings/scm", func(r chi.Router) {
+					r.Route("/github-apps", func(r chi.Router) {
+						r.Get("/", cfg.scmHandler.ListGitHubAppRegistrations)
+						r.Post("/", cfg.scmHandler.CreateGitHubAppRegistration)
+						r.Get("/{registrationID}", cfg.scmHandler.GetGitHubAppRegistration)
+					})
 					r.Route("/connections", func(r chi.Router) {
 						r.Get("/", cfg.scmHandler.ListConnections)
 						r.Post("/github-app-installations", cfg.scmHandler.CreateGitHubAppInstallationConnection)

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -245,6 +245,16 @@ func TestNewRouter_SCMRoutes(t *testing.T) {
 
 	router := NewRouter(buildHandler, nil, jobHandler, nil, nil, nil, eventHandler, "", WithSCMHandler(scmHandler))
 
+	githubAppsReq := httptest.NewRequest(http.MethodGet, "/api/settings/scm/github-apps", nil)
+	githubAppsRes := httptest.NewRecorder()
+	router.ServeHTTP(githubAppsRes, githubAppsReq)
+	if githubAppsRes.Code != http.StatusOK {
+		t.Fatalf("expected github app registrations status %d, got %d body=%s", http.StatusOK, githubAppsRes.Code, githubAppsRes.Body.String())
+	}
+	if !strings.Contains(githubAppsRes.Body.String(), `"github_apps":[]`) {
+		t.Fatalf("expected empty github app registration list, got %s", githubAppsRes.Body.String())
+	}
+
 	connectionsReq := httptest.NewRequest(http.MethodGet, "/api/settings/scm/connections", nil)
 	connectionsRes := httptest.NewRecorder()
 	router.ServeHTTP(connectionsRes, connectionsReq)
@@ -263,6 +273,13 @@ func TestNewRouter_SCMRoutes(t *testing.T) {
 	}
 	if !strings.Contains(repositoriesRes.Body.String(), `"repositories":[]`) {
 		t.Fatalf("expected empty scm repositories list, got %s", repositoriesRes.Body.String())
+	}
+
+	createGitHubAppReq := httptest.NewRequest(http.MethodPost, "/api/settings/scm/github-apps", strings.NewReader(`{"app_id":"12345","private_key_secret_ref":"secret/github/private-key","webhook_secret_ref":"secret/github/webhook"}`))
+	createGitHubAppRes := httptest.NewRecorder()
+	router.ServeHTTP(createGitHubAppRes, createGitHubAppReq)
+	if createGitHubAppRes.Code != http.StatusCreated {
+		t.Fatalf("expected github app registration status %d, got %d body=%s", http.StatusCreated, createGitHubAppRes.Code, createGitHubAppRes.Body.String())
 	}
 }
 

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -233,6 +233,39 @@ func TestNewRouter_ServerInfoAndWorkerRoutes(t *testing.T) {
 	}
 }
 
+func TestNewRouter_SCMRoutes(t *testing.T) {
+	buildRepo := repositorymemory.NewBuildRepository()
+	jobRepo := repositorymemory.NewJobRepository()
+	buildSvc := buildsvc.NewBuildService(buildRepo, nil, nil)
+	buildHandler := handler.NewBuildHandler(buildSvc)
+	jobSvc := service.NewJobService(jobRepo, buildSvc)
+	jobHandler := handler.NewJobHandler(jobSvc)
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	scmHandler := handler.NewSCMHandler(service.NewSCMAdminService(repositorymemory.NewSCMConnectionRepository(), repositorymemory.NewSCMRepositoryRegistrationRepository()))
+
+	router := NewRouter(buildHandler, nil, jobHandler, nil, nil, nil, eventHandler, "", WithSCMHandler(scmHandler))
+
+	connectionsReq := httptest.NewRequest(http.MethodGet, "/api/settings/scm/connections", nil)
+	connectionsRes := httptest.NewRecorder()
+	router.ServeHTTP(connectionsRes, connectionsReq)
+	if connectionsRes.Code != http.StatusOK {
+		t.Fatalf("expected scm connections status %d, got %d body=%s", http.StatusOK, connectionsRes.Code, connectionsRes.Body.String())
+	}
+	if !strings.Contains(connectionsRes.Body.String(), `"connections":[]`) {
+		t.Fatalf("expected empty scm connections list, got %s", connectionsRes.Body.String())
+	}
+
+	repositoriesReq := httptest.NewRequest(http.MethodGet, "/api/settings/scm/repositories", nil)
+	repositoriesRes := httptest.NewRecorder()
+	router.ServeHTTP(repositoriesRes, repositoriesReq)
+	if repositoriesRes.Code != http.StatusOK {
+		t.Fatalf("expected scm repositories status %d, got %d body=%s", http.StatusOK, repositoriesRes.Code, repositoriesRes.Body.String())
+	}
+	if !strings.Contains(repositoriesRes.Body.String(), `"repositories":[]`) {
+		t.Fatalf("expected empty scm repositories list, got %s", repositoriesRes.Body.String())
+	}
+}
+
 func TestNewRouter_ServerInfoRouteUsesAuthMiddlewareWhenConfigured(t *testing.T) {
 	headerRouter := newIdentityTestRouter(auth.ModeHeader, "push-secret", "github-secret", WithServerInfoHandler(handler.NewServerInfoHandler()))
 

--- a/backend/internal/platform/db/schema_test.go
+++ b/backend/internal/platform/db/schema_test.go
@@ -26,6 +26,7 @@ func TestInitSchemaIncludesBuildLifecycleAndSteps(t *testing.T) {
 		"../../../db/migrations/00032_refactor_notification_delivery_identity.sql",
 		"../../../db/migrations/00033_add_claimable_notification_delivery_ledger.sql",
 		"../../../db/migrations/00034_add_notification_recovery_scan_indexes.sql",
+		"../../../db/migrations/00039_add_scm_connection_foundation.sql",
 	}
 
 	var builder strings.Builder
@@ -87,6 +88,11 @@ func TestInitSchemaIncludesBuildLifecycleAndSteps(t *testing.T) {
 		"idx_notification_deliveries_retry_waiting_next_attempt_at_id",
 		"idx_notification_deliveries_sending_claim_expires_at_id",
 		"idx_notification_deliveries_build_id",
+		"CREATE TABLE IF NOT EXISTS scm_connections",
+		"CREATE TABLE IF NOT EXISTS github_app_registrations",
+		"CREATE TABLE IF NOT EXISTS github_app_installations",
+		"CREATE TABLE IF NOT EXISTS scm_registered_repositories",
+		"scm_registered_repositories_connection_id_provider_repository_id_key",
 		"CREATE TABLE IF NOT EXISTS notification_targets",
 		"origin TEXT",
 		"notification_targets_origin_semantics_check",

--- a/backend/internal/repository/memory/scm_connection_repository.go
+++ b/backend/internal/repository/memory/scm_connection_repository.go
@@ -1,0 +1,134 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+type SCMConnectionRepository struct {
+	mu                         sync.RWMutex
+	connections                map[string]domain.SCMConnection
+	githubAppRegistrations     map[string]domain.GitHubAppRegistration
+	githubAppInstallations     map[string]domain.GitHubAppInstallation
+	registrationIndexByAppHost map[string]string
+	installationIndex          map[string]string
+}
+
+func NewSCMConnectionRepository() *SCMConnectionRepository {
+	return &SCMConnectionRepository{
+		connections:                map[string]domain.SCMConnection{},
+		githubAppRegistrations:     map[string]domain.GitHubAppRegistration{},
+		githubAppInstallations:     map[string]domain.GitHubAppInstallation{},
+		registrationIndexByAppHost: map[string]string{},
+		installationIndex:          map[string]string{},
+	}
+}
+
+func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(_ context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error) {
+	detail = detail.Normalize()
+	if err := detail.Validate(); err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.connections[detail.Connection.ID]; exists {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionConflict
+	}
+
+	registration := *detail.GitHubAppRegistration
+	registrationID, err := r.resolveGitHubAppRegistrationLocked(registration)
+	if err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+	registration = r.githubAppRegistrations[registrationID]
+
+	installation := *detail.GitHubAppInstallation
+	installation.AppRegistrationID = registration.ID
+	installationKey := installationIndexKey(registration.ID, installation.InstallationID)
+	if _, exists := r.installationIndex[installationKey]; exists {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMGitHubAppInstallationConflict
+	}
+
+	connection := detail.Connection
+	r.connections[connection.ID] = connection
+	r.githubAppInstallations[connection.ID] = installation
+	r.installationIndex[installationKey] = connection.ID
+
+	return domain.SCMConnectionDetail{Connection: connection, GitHubAppRegistration: &registration, GitHubAppInstallation: &installation}, nil
+}
+
+func (r *SCMConnectionRepository) List(_ context.Context) ([]domain.SCMConnectionDetail, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := make([]domain.SCMConnectionDetail, 0, len(r.connections))
+	for _, connection := range r.connections {
+		items = append(items, r.detailLocked(connection.ID))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Connection.CreatedAt.Equal(items[j].Connection.CreatedAt) {
+			return items[i].Connection.ID < items[j].Connection.ID
+		}
+		return items[i].Connection.CreatedAt.After(items[j].Connection.CreatedAt)
+	})
+	return items, nil
+}
+
+func (r *SCMConnectionRepository) GetByID(_ context.Context, id string) (domain.SCMConnectionDetail, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if _, ok := r.connections[id]; !ok {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+	}
+	return r.detailLocked(id), nil
+}
+
+func (r *SCMConnectionRepository) SetEnabled(_ context.Context, id string, enabled bool, updatedAt time.Time) (domain.SCMConnectionDetail, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	connection, ok := r.connections[id]
+	if !ok {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+	}
+	connection.Enabled = enabled
+	connection.UpdatedAt = updatedAt.UTC()
+	r.connections[id] = connection
+	return r.detailLocked(id), nil
+}
+
+func (r *SCMConnectionRepository) resolveGitHubAppRegistrationLocked(registration domain.GitHubAppRegistration) (string, error) {
+	key := githubAppRegistrationIndexKey(registration.AppID, registration.APIBaseURL, registration.WebBaseURL)
+	if existingID, ok := r.registrationIndexByAppHost[key]; ok {
+		existing := r.githubAppRegistrations[existingID]
+		if existing.PrivateKeySecretRef != registration.PrivateKeySecretRef || existing.WebhookSecretRef != registration.WebhookSecretRef {
+			return "", repository.ErrSCMGitHubAppRegistrationConflict
+		}
+		return existingID, nil
+	}
+	r.githubAppRegistrations[registration.ID] = registration
+	r.registrationIndexByAppHost[key] = registration.ID
+	return registration.ID, nil
+}
+
+func (r *SCMConnectionRepository) detailLocked(connectionID string) domain.SCMConnectionDetail {
+	connection := r.connections[connectionID]
+	installation, ok := r.githubAppInstallations[connectionID]
+	if !ok {
+		return domain.SCMConnectionDetail{Connection: connection}
+	}
+	registration := r.githubAppRegistrations[installation.AppRegistrationID]
+	return domain.SCMConnectionDetail{Connection: connection, GitHubAppRegistration: &registration, GitHubAppInstallation: &installation}
+}
+
+func githubAppRegistrationIndexKey(appID string, apiBaseURL string, webBaseURL string) string {
+	return appID + "|" + apiBaseURL + "|" + webBaseURL
+}
+
+func installationIndexKey(appRegistrationID string, installationID string) string {
+	return appRegistrationID + "|" + installationID
+}

--- a/backend/internal/repository/memory/scm_connection_repository.go
+++ b/backend/internal/repository/memory/scm_connection_repository.go
@@ -29,6 +29,52 @@ func NewSCMConnectionRepository() *SCMConnectionRepository {
 	}
 }
 
+func (r *SCMConnectionRepository) CreateGitHubAppRegistration(_ context.Context, registration domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error) {
+	registration = registration.Normalize()
+	if err := registration.Validate(); err != nil {
+		return domain.GitHubAppRegistration{}, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.githubAppRegistrations[registration.ID]; exists {
+		return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+	}
+	key := githubAppRegistrationIndexKey(registration.AppID, registration.APIBaseURL, registration.WebBaseURL)
+	if _, exists := r.registrationIndexByAppHost[key]; exists {
+		return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+	}
+	r.githubAppRegistrations[registration.ID] = registration
+	r.registrationIndexByAppHost[key] = registration.ID
+	return registration, nil
+}
+
+func (r *SCMConnectionRepository) ListGitHubAppRegistrations(_ context.Context) ([]domain.GitHubAppRegistration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := make([]domain.GitHubAppRegistration, 0, len(r.githubAppRegistrations))
+	for _, registration := range r.githubAppRegistrations {
+		items = append(items, registration)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	return items, nil
+}
+
+func (r *SCMConnectionRepository) GetGitHubAppRegistrationByID(_ context.Context, id string) (domain.GitHubAppRegistration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	registration, ok := r.githubAppRegistrations[id]
+	if !ok {
+		return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationNotFound
+	}
+	return registration, nil
+}
+
 func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(_ context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error) {
 	detail = detail.Normalize()
 	if err := detail.Validate(); err != nil {
@@ -42,14 +88,13 @@ func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(_ contex
 	}
 
 	registration := *detail.GitHubAppRegistration
-	registrationID, err := r.resolveGitHubAppRegistrationLocked(registration)
-	if err != nil {
-		return domain.SCMConnectionDetail{}, err
+	storedRegistration, ok := r.githubAppRegistrations[registration.ID]
+	if !ok {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMGitHubAppRegistrationNotFound
 	}
-	registration = r.githubAppRegistrations[registrationID]
+	registration = storedRegistration
 
 	installation := *detail.GitHubAppInstallation
-	installation.AppRegistrationID = registration.ID
 	installationKey := installationIndexKey(registration.ID, installation.InstallationID)
 	if _, exists := r.installationIndex[installationKey]; exists {
 		return domain.SCMConnectionDetail{}, repository.ErrSCMGitHubAppInstallationConflict
@@ -99,20 +144,6 @@ func (r *SCMConnectionRepository) SetEnabled(_ context.Context, id string, enabl
 	connection.UpdatedAt = updatedAt.UTC()
 	r.connections[id] = connection
 	return r.detailLocked(id), nil
-}
-
-func (r *SCMConnectionRepository) resolveGitHubAppRegistrationLocked(registration domain.GitHubAppRegistration) (string, error) {
-	key := githubAppRegistrationIndexKey(registration.AppID, registration.APIBaseURL, registration.WebBaseURL)
-	if existingID, ok := r.registrationIndexByAppHost[key]; ok {
-		existing := r.githubAppRegistrations[existingID]
-		if existing.PrivateKeySecretRef != registration.PrivateKeySecretRef || existing.WebhookSecretRef != registration.WebhookSecretRef {
-			return "", repository.ErrSCMGitHubAppRegistrationConflict
-		}
-		return existingID, nil
-	}
-	r.githubAppRegistrations[registration.ID] = registration
-	r.registrationIndexByAppHost[key] = registration.ID
-	return registration.ID, nil
 }
 
 func (r *SCMConnectionRepository) detailLocked(connectionID string) domain.SCMConnectionDetail {

--- a/backend/internal/repository/memory/scm_connection_repository_test.go
+++ b/backend/internal/repository/memory/scm_connection_repository_test.go
@@ -13,7 +13,11 @@ import (
 func TestSCMConnectionRepository_CreateListGetAndSetEnabled(t *testing.T) {
 	repo := NewSCMConnectionRepository()
 	now := time.Now().UTC()
-	detail := testGitHubConnectionDetail(now, "connection-1", "registration-1", "installation-1", "octo")
+	registration := testGitHubAppRegistration(now, "registration-1")
+	if _, err := repo.CreateGitHubAppRegistration(context.Background(), registration); err != nil {
+		t.Fatalf("create registration failed: %v", err)
+	}
+	detail := testGitHubConnectionDetail(now, "connection-1", registration, "installation-1", "octo")
 
 	created, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
 	if createErr != nil {
@@ -48,18 +52,61 @@ func TestSCMConnectionRepository_CreateListGetAndSetEnabled(t *testing.T) {
 	}
 }
 
+func TestSCMConnectionRepository_ListAndGetGitHubAppRegistrations(t *testing.T) {
+	repo := NewSCMConnectionRepository()
+	emptyList, emptyListErr := repo.ListGitHubAppRegistrations(context.Background())
+	if emptyListErr != nil {
+		t.Fatalf("list empty registrations failed: %v", emptyListErr)
+	}
+	if len(emptyList) != 0 {
+		t.Fatalf("expected zero registrations, got %d", len(emptyList))
+	}
+
+	now := time.Now().UTC()
+	older := testGitHubAppRegistration(now.Add(-time.Minute), "registration-1")
+	newer := testGitHubAppRegistration(now, "registration-2")
+	newer.AppID = "54321"
+	newer.APIBaseURL = "https://ghe.example/api/v3"
+	newer.WebBaseURL = "https://ghe.example"
+	if _, err := repo.CreateGitHubAppRegistration(context.Background(), older); err != nil {
+		t.Fatalf("create older registration failed: %v", err)
+	}
+	if _, err := repo.CreateGitHubAppRegistration(context.Background(), newer); err != nil {
+		t.Fatalf("create newer registration failed: %v", err)
+	}
+
+	list, listErr := repo.ListGitHubAppRegistrations(context.Background())
+	if listErr != nil {
+		t.Fatalf("list registrations failed: %v", listErr)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected two registrations, got %d", len(list))
+	}
+	if list[0].ID != "registration-2" || list[1].ID != "registration-1" {
+		t.Fatalf("expected registrations sorted newest first, got %+v", list)
+	}
+	fetched, getErr := repo.GetGitHubAppRegistrationByID(context.Background(), "registration-1")
+	if getErr != nil {
+		t.Fatalf("get registration failed: %v", getErr)
+	}
+	if fetched.ID != "registration-1" {
+		t.Fatalf("expected registration-1, got %q", fetched.ID)
+	}
+	_, missingErr := repo.GetGitHubAppRegistrationByID(context.Background(), "missing")
+	if !errors.Is(missingErr, repository.ErrSCMGitHubAppRegistrationNotFound) {
+		t.Fatalf("expected not found error, got %v", missingErr)
+	}
+}
+
 func TestSCMConnectionRepository_ReusesMatchingGitHubAppRegistrationAndScopesInstallationUniqueness(t *testing.T) {
 	repo := NewSCMConnectionRepository()
 	now := time.Now().UTC()
-	first := testGitHubConnectionDetail(now, "connection-1", "registration-1", "installation-1", "octo")
-	second := testGitHubConnectionDetail(now.Add(time.Minute), "connection-2", "registration-2", "installation-2", "octo-two")
-	second.GitHubAppRegistration.ID = "registration-2"
-	second.GitHubAppRegistration.AppID = first.GitHubAppRegistration.AppID
-	second.GitHubAppRegistration.APIBaseURL = first.GitHubAppRegistration.APIBaseURL
-	second.GitHubAppRegistration.WebBaseURL = first.GitHubAppRegistration.WebBaseURL
-	second.GitHubAppRegistration.PrivateKeySecretRef = first.GitHubAppRegistration.PrivateKeySecretRef
-	second.GitHubAppRegistration.WebhookSecretRef = first.GitHubAppRegistration.WebhookSecretRef
-	second.GitHubAppInstallation.AppRegistrationID = "registration-2"
+	registration := testGitHubAppRegistration(now, "registration-1")
+	if _, err := repo.CreateGitHubAppRegistration(context.Background(), registration); err != nil {
+		t.Fatalf("create registration failed: %v", err)
+	}
+	first := testGitHubConnectionDetail(now, "connection-1", registration, "installation-1", "octo")
+	second := testGitHubConnectionDetail(now.Add(time.Minute), "connection-2", registration, "installation-2", "octo-two")
 
 	if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), first); err != nil {
 		t.Fatalf("create first failed: %v", err)
@@ -68,25 +115,49 @@ func TestSCMConnectionRepository_ReusesMatchingGitHubAppRegistrationAndScopesIns
 	if secondErr != nil {
 		t.Fatalf("create second failed: %v", secondErr)
 	}
-	if createdSecond.GitHubAppRegistration == nil || createdSecond.GitHubAppRegistration.ID != "registration-1" {
+	if createdSecond.GitHubAppRegistration == nil || createdSecond.GitHubAppRegistration.ID != registration.ID {
 		t.Fatalf("expected existing registration to be reused, got %+v", createdSecond.GitHubAppRegistration)
 	}
+	updatedFirst, updateErr := repo.SetEnabled(context.Background(), first.Connection.ID, false, now.Add(2*time.Minute))
+	if updateErr != nil {
+		t.Fatalf("disable first failed: %v", updateErr)
+	}
+	if updatedFirst.Connection.Enabled {
+		t.Fatal("expected first connection to be disabled")
+	}
+	storedRegistration, registrationErr := repo.GetGitHubAppRegistrationByID(context.Background(), registration.ID)
+	if registrationErr != nil {
+		t.Fatalf("get registration failed: %v", registrationErr)
+	}
+	if storedRegistration.UpdatedAt != registration.UpdatedAt {
+		t.Fatalf("expected registration to remain unchanged, got %s want %s", storedRegistration.UpdatedAt, registration.UpdatedAt)
+	}
+	fetchedSecond, getErr := repo.GetByID(context.Background(), second.Connection.ID)
+	if getErr != nil {
+		t.Fatalf("get second failed: %v", getErr)
+	}
+	if !fetchedSecond.Connection.Enabled {
+		t.Fatal("expected sibling connection to remain enabled")
+	}
 
-	duplicateInstallation := testGitHubConnectionDetail(now.Add(2*time.Minute), "connection-3", "registration-3", "installation-1", "octo-three")
-	duplicateInstallation.GitHubAppRegistration.AppID = first.GitHubAppRegistration.AppID
-	duplicateInstallation.GitHubAppRegistration.APIBaseURL = first.GitHubAppRegistration.APIBaseURL
-	duplicateInstallation.GitHubAppRegistration.WebBaseURL = first.GitHubAppRegistration.WebBaseURL
-	duplicateInstallation.GitHubAppRegistration.PrivateKeySecretRef = first.GitHubAppRegistration.PrivateKeySecretRef
-	duplicateInstallation.GitHubAppRegistration.WebhookSecretRef = first.GitHubAppRegistration.WebhookSecretRef
+	duplicateInstallation := testGitHubConnectionDetail(now.Add(3*time.Minute), "connection-3", registration, "installation-1", "octo-three")
 	if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), duplicateInstallation); !errors.Is(err, repository.ErrSCMGitHubAppInstallationConflict) {
 		t.Fatalf("expected installation conflict, got %v", err)
 	}
+	missingRegistration := testGitHubConnectionDetail(now.Add(4*time.Minute), "connection-4", testGitHubAppRegistration(now, "missing-registration"), "installation-4", "octo-four")
+	if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), missingRegistration); !errors.Is(err, repository.ErrSCMGitHubAppRegistrationNotFound) {
+		t.Fatalf("expected missing registration error, got %v", err)
+	}
 }
 
-func testGitHubConnectionDetail(now time.Time, connectionID string, registrationID string, installationID string, accountLogin string) domain.SCMConnectionDetail {
+func testGitHubAppRegistration(now time.Time, registrationID string) domain.GitHubAppRegistration {
+	return domain.GitHubAppRegistration{ID: registrationID, AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now}
+}
+
+func testGitHubConnectionDetail(now time.Time, connectionID string, registration domain.GitHubAppRegistration, installationID string, accountLogin string) domain.SCMConnectionDetail {
 	return domain.SCMConnectionDetail{
 		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: accountLogin + " connection", DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
-		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: registrationID, AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now},
-		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registrationID, InstallationID: installationID, AccountLogin: accountLogin, AccountType: "organization", AccountID: installationID + "-account", CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &registration,
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registration.ID, InstallationID: installationID, AccountLogin: accountLogin, AccountType: "organization", AccountID: installationID + "-account", CreatedAt: now, UpdatedAt: now},
 	}
 }

--- a/backend/internal/repository/memory/scm_connection_repository_test.go
+++ b/backend/internal/repository/memory/scm_connection_repository_test.go
@@ -1,0 +1,92 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+func TestSCMConnectionRepository_CreateListGetAndSetEnabled(t *testing.T) {
+	repo := NewSCMConnectionRepository()
+	now := time.Now().UTC()
+	detail := testGitHubConnectionDetail(now, "connection-1", "registration-1", "installation-1", "octo")
+
+	created, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
+	if createErr != nil {
+		t.Fatalf("create connection failed: %v", createErr)
+	}
+	if created.GitHubAppRegistration == nil || created.GitHubAppInstallation == nil {
+		t.Fatalf("expected github detail to be persisted, got %+v", created)
+	}
+
+	fetched, getErr := repo.GetByID(context.Background(), "connection-1")
+	if getErr != nil {
+		t.Fatalf("get connection failed: %v", getErr)
+	}
+	if fetched.Connection.DisplayName != "octo connection" {
+		t.Fatalf("expected display name to round-trip, got %q", fetched.Connection.DisplayName)
+	}
+
+	list, listErr := repo.List(context.Background())
+	if listErr != nil {
+		t.Fatalf("list connections failed: %v", listErr)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one connection, got %d", len(list))
+	}
+
+	updated, updateErr := repo.SetEnabled(context.Background(), "connection-1", false, now.Add(time.Minute))
+	if updateErr != nil {
+		t.Fatalf("set enabled failed: %v", updateErr)
+	}
+	if updated.Connection.Enabled {
+		t.Fatal("expected connection to be disabled")
+	}
+}
+
+func TestSCMConnectionRepository_ReusesMatchingGitHubAppRegistrationAndScopesInstallationUniqueness(t *testing.T) {
+	repo := NewSCMConnectionRepository()
+	now := time.Now().UTC()
+	first := testGitHubConnectionDetail(now, "connection-1", "registration-1", "installation-1", "octo")
+	second := testGitHubConnectionDetail(now.Add(time.Minute), "connection-2", "registration-2", "installation-2", "octo-two")
+	second.GitHubAppRegistration.ID = "registration-2"
+	second.GitHubAppRegistration.AppID = first.GitHubAppRegistration.AppID
+	second.GitHubAppRegistration.APIBaseURL = first.GitHubAppRegistration.APIBaseURL
+	second.GitHubAppRegistration.WebBaseURL = first.GitHubAppRegistration.WebBaseURL
+	second.GitHubAppRegistration.PrivateKeySecretRef = first.GitHubAppRegistration.PrivateKeySecretRef
+	second.GitHubAppRegistration.WebhookSecretRef = first.GitHubAppRegistration.WebhookSecretRef
+	second.GitHubAppInstallation.AppRegistrationID = "registration-2"
+
+	if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), first); err != nil {
+		t.Fatalf("create first failed: %v", err)
+	}
+	createdSecond, secondErr := repo.CreateGitHubAppInstallationConnection(context.Background(), second)
+	if secondErr != nil {
+		t.Fatalf("create second failed: %v", secondErr)
+	}
+	if createdSecond.GitHubAppRegistration == nil || createdSecond.GitHubAppRegistration.ID != "registration-1" {
+		t.Fatalf("expected existing registration to be reused, got %+v", createdSecond.GitHubAppRegistration)
+	}
+
+	duplicateInstallation := testGitHubConnectionDetail(now.Add(2*time.Minute), "connection-3", "registration-3", "installation-1", "octo-three")
+	duplicateInstallation.GitHubAppRegistration.AppID = first.GitHubAppRegistration.AppID
+	duplicateInstallation.GitHubAppRegistration.APIBaseURL = first.GitHubAppRegistration.APIBaseURL
+	duplicateInstallation.GitHubAppRegistration.WebBaseURL = first.GitHubAppRegistration.WebBaseURL
+	duplicateInstallation.GitHubAppRegistration.PrivateKeySecretRef = first.GitHubAppRegistration.PrivateKeySecretRef
+	duplicateInstallation.GitHubAppRegistration.WebhookSecretRef = first.GitHubAppRegistration.WebhookSecretRef
+	if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), duplicateInstallation); !errors.Is(err, repository.ErrSCMGitHubAppInstallationConflict) {
+		t.Fatalf("expected installation conflict, got %v", err)
+	}
+}
+
+func testGitHubConnectionDetail(now time.Time, connectionID string, registrationID string, installationID string, accountLogin string) domain.SCMConnectionDetail {
+	return domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: accountLogin + " connection", DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: registrationID, AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now},
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registrationID, InstallationID: installationID, AccountLogin: accountLogin, AccountType: "organization", AccountID: installationID + "-account", CreatedAt: now, UpdatedAt: now},
+	}
+}

--- a/backend/internal/repository/memory/scm_repository_registration_repository.go
+++ b/backend/internal/repository/memory/scm_repository_registration_repository.go
@@ -1,0 +1,91 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+type SCMRepositoryRegistrationRepository struct {
+	mu             sync.RWMutex
+	repositories   map[string]domain.SCMRepositoryRegistration
+	identityLookup map[string]string
+}
+
+func NewSCMRepositoryRegistrationRepository() *SCMRepositoryRegistrationRepository {
+	return &SCMRepositoryRegistrationRepository{
+		repositories:   map[string]domain.SCMRepositoryRegistration{},
+		identityLookup: map[string]string{},
+	}
+}
+
+func (r *SCMRepositoryRegistrationRepository) Create(_ context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
+	registration = registration.Normalize()
+	if err := registration.Validate(); err != nil {
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	identityKey := scmRegisteredRepositoryIdentityKey(registration.ConnectionID, registration.ProviderRepositoryID)
+	if _, exists := r.identityLookup[identityKey]; exists {
+		return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationDuplicate
+	}
+	r.repositories[registration.ID] = registration
+	r.identityLookup[identityKey] = registration.ID
+	return registration, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) List(_ context.Context) ([]domain.SCMRepositoryRegistration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := make([]domain.SCMRepositoryRegistration, 0, len(r.repositories))
+	for _, item := range r.repositories {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	return items, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) GetByID(_ context.Context, id string) (domain.SCMRepositoryRegistration, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	registration, ok := r.repositories[id]
+	if !ok {
+		return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationNotFound
+	}
+	return registration, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) Update(_ context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
+	registration = registration.Normalize()
+	if err := registration.Validate(); err != nil {
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current, ok := r.repositories[registration.ID]
+	if !ok {
+		return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationNotFound
+	}
+	oldIdentityKey := scmRegisteredRepositoryIdentityKey(current.ConnectionID, current.ProviderRepositoryID)
+	newIdentityKey := scmRegisteredRepositoryIdentityKey(registration.ConnectionID, registration.ProviderRepositoryID)
+	if ownerID, exists := r.identityLookup[newIdentityKey]; exists && ownerID != registration.ID {
+		return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationDuplicate
+	}
+	delete(r.identityLookup, oldIdentityKey)
+	r.identityLookup[newIdentityKey] = registration.ID
+	r.repositories[registration.ID] = registration
+	return registration, nil
+}
+
+func scmRegisteredRepositoryIdentityKey(connectionID string, providerRepositoryID string) string {
+	return connectionID + "|" + providerRepositoryID
+}

--- a/backend/internal/repository/memory/scm_repository_registration_repository_test.go
+++ b/backend/internal/repository/memory/scm_repository_registration_repository_test.go
@@ -1,0 +1,53 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+func TestSCMRepositoryRegistrationRepository_UniquenessAndMetadataUpdates(t *testing.T) {
+	repo := NewSCMRepositoryRegistrationRepository()
+	now := time.Now().UTC()
+	left := domain.SCMRepositoryRegistration{ID: "repo-1", ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	right := domain.SCMRepositoryRegistration{ID: "repo-2", ConnectionID: "connection-2", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://ghe.example/octo/widgets.git", WebURL: "https://ghe.example/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+
+	if _, err := repo.Create(context.Background(), left); err != nil {
+		t.Fatalf("create left failed: %v", err)
+	}
+	if _, err := repo.Create(context.Background(), right); err != nil {
+		t.Fatalf("create right failed: %v", err)
+	}
+
+	duplicate := left
+	duplicate.ID = "repo-3"
+	if _, err := repo.Create(context.Background(), duplicate); !errors.Is(err, repository.ErrSCMRepositoryRegistrationDuplicate) {
+		t.Fatalf("expected duplicate identity error, got %v", err)
+	}
+
+	left.Owner = "acme"
+	left.Name = "platform"
+	left.FullName = "acme/platform"
+	left.WebURL = "https://github.com/acme/platform"
+	left.CloneURL = "https://github.com/acme/platform.git"
+	left.UpdatedAt = now.Add(time.Minute)
+	updated, updateErr := repo.Update(context.Background(), left)
+	if updateErr != nil {
+		t.Fatalf("update failed: %v", updateErr)
+	}
+	if updated.ProviderRepositoryID != "1001" || updated.FullName != "acme/platform" {
+		t.Fatalf("expected metadata update without identity change, got %+v", updated)
+	}
+
+	list, listErr := repo.List(context.Background())
+	if listErr != nil {
+		t.Fatalf("list failed: %v", listErr)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected two repositories, got %d", len(list))
+	}
+}

--- a/backend/internal/repository/memory/scm_repository_registration_repository_test.go
+++ b/backend/internal/repository/memory/scm_repository_registration_repository_test.go
@@ -51,3 +51,29 @@ func TestSCMRepositoryRegistrationRepository_UniquenessAndMetadataUpdates(t *tes
 		t.Fatalf("expected two repositories, got %d", len(list))
 	}
 }
+
+func TestSCMRepositoryRegistrationRepository_NotFoundAndUpdateConflict(t *testing.T) {
+	repo := NewSCMRepositoryRegistrationRepository()
+	now := time.Now().UTC()
+	left := domain.SCMRepositoryRegistration{ID: "repo-1", ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	right := domain.SCMRepositoryRegistration{ID: "repo-2", ConnectionID: "connection-2", ProviderRepositoryID: "2002", Owner: "acme", Name: "platform", FullName: "acme/platform", CloneURL: "https://github.com/acme/platform.git", WebURL: "https://github.com/acme/platform", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	if _, err := repo.Create(context.Background(), left); err != nil {
+		t.Fatalf("create left failed: %v", err)
+	}
+	if _, err := repo.Create(context.Background(), right); err != nil {
+		t.Fatalf("create right failed: %v", err)
+	}
+	if _, err := repo.GetByID(context.Background(), "missing"); !errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
+		t.Fatalf("expected missing repository error, got %v", err)
+	}
+	missing := left
+	missing.ID = "missing"
+	if _, err := repo.Update(context.Background(), missing); !errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
+		t.Fatalf("expected update missing repository error, got %v", err)
+	}
+	left.ConnectionID = right.ConnectionID
+	left.ProviderRepositoryID = right.ProviderRepositoryID
+	if _, err := repo.Update(context.Background(), left); !errors.Is(err, repository.ErrSCMRepositoryRegistrationDuplicate) {
+		t.Fatalf("expected duplicate identity on update, got %v", err)
+	}
+}

--- a/backend/internal/repository/postgres/scm_connection_repository.go
+++ b/backend/internal/repository/postgres/scm_connection_repository.go
@@ -1,0 +1,350 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+type SCMConnectionRepository struct {
+	db *sql.DB
+}
+
+func NewSCMConnectionRepository(db *sql.DB) *SCMConnectionRepository {
+	return &SCMConnectionRepository{db: db}
+}
+
+const scmConnectionColumns = `c.id, c.provider, c.display_name, c.deployment_kind, c.api_base_url, c.web_base_url, c.enabled, c.health_status, c.health_summary, c.last_health_checked_at, c.created_at, c.updated_at,
+	ga.id, ga.app_id, ga.display_name, ga.api_base_url, ga.web_base_url, ga.private_key_secret_ref, ga.webhook_secret_ref, ga.created_at, ga.updated_at,
+	gi.connection_id, gi.app_registration_id, gi.installation_id, gi.account_login, gi.account_type, gi.account_id, gi.created_at, gi.updated_at`
+
+func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(ctx context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error) {
+	detail = detail.Normalize()
+	if err := detail.Validate(); err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	registration := *detail.GitHubAppRegistration
+	registration, err = resolveOrCreateGitHubAppRegistration(ctx, tx, registration)
+	if err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+
+	const insertConnectionQuery = `
+		INSERT INTO scm_connections (
+			id, provider, display_name, deployment_kind, api_base_url, web_base_url, enabled, health_status, health_summary, last_health_checked_at, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+	`
+	_, err = tx.ExecContext(ctx, insertConnectionQuery,
+		detail.Connection.ID,
+		string(detail.Connection.Provider),
+		detail.Connection.DisplayName,
+		string(detail.Connection.DeploymentKind),
+		detail.Connection.APIBaseURL,
+		detail.Connection.WebBaseURL,
+		detail.Connection.Enabled,
+		string(detail.Connection.HealthStatus),
+		detail.Connection.HealthSummary,
+		detail.Connection.LastHealthCheckedAt,
+		detail.Connection.CreatedAt,
+		detail.Connection.UpdatedAt,
+	)
+	if err != nil {
+		if isSCMConnectionUniqueViolation(err, "scm_connections_pkey") {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionConflict
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+
+	installation := *detail.GitHubAppInstallation
+	installation.AppRegistrationID = registration.ID
+	const insertInstallationQuery = `
+		INSERT INTO github_app_installations (
+			connection_id, app_registration_id, installation_id, account_login, account_type, account_id, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`
+	_, err = tx.ExecContext(ctx, insertInstallationQuery,
+		installation.ConnectionID,
+		installation.AppRegistrationID,
+		installation.InstallationID,
+		installation.AccountLogin,
+		installation.AccountType,
+		installation.AccountID,
+		installation.CreatedAt,
+		installation.UpdatedAt,
+	)
+	if err != nil {
+		if isSCMConnectionUniqueViolation(err, "github_app_installations_app_registration_id_installation_id_key") {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMGitHubAppInstallationConflict
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+	return domain.SCMConnectionDetail{Connection: detail.Connection, GitHubAppRegistration: &registration, GitHubAppInstallation: &installation}, nil
+}
+
+func (r *SCMConnectionRepository) List(ctx context.Context) ([]domain.SCMConnectionDetail, error) {
+	const query = `
+		SELECT ` + scmConnectionColumns + `
+		FROM scm_connections c
+		LEFT JOIN github_app_installations gi ON gi.connection_id = c.id
+		LEFT JOIN github_app_registrations ga ON ga.id = gi.app_registration_id
+		ORDER BY c.created_at DESC, c.id DESC
+	`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]domain.SCMConnectionDetail, 0)
+	for rows.Next() {
+		item, scanErr := scanSCMConnectionDetail(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (r *SCMConnectionRepository) GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error) {
+	const query = `
+		SELECT ` + scmConnectionColumns + `
+		FROM scm_connections c
+		LEFT JOIN github_app_installations gi ON gi.connection_id = c.id
+		LEFT JOIN github_app_registrations ga ON ga.id = gi.app_registration_id
+		WHERE c.id = $1
+	`
+	item, err := scanSCMConnectionDetail(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+	return item, nil
+}
+
+func (r *SCMConnectionRepository) SetEnabled(ctx context.Context, id string, enabled bool, updatedAt time.Time) (domain.SCMConnectionDetail, error) {
+	const query = `
+		UPDATE scm_connections
+		SET enabled = $2, updated_at = $3
+		WHERE id = $1
+		RETURNING id
+	`
+	var returnedID string
+	if err := r.db.QueryRowContext(ctx, query, id, enabled, updatedAt.UTC()).Scan(&returnedID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+	return r.GetByID(ctx, returnedID)
+}
+
+func resolveOrCreateGitHubAppRegistration(ctx context.Context, tx *sql.Tx, registration domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error) {
+	const selectQuery = `
+		SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+		FROM github_app_registrations
+		WHERE app_id = $1 AND api_base_url = $2 AND web_base_url = $3
+	`
+	existing, err := scanGitHubAppRegistration(tx.QueryRowContext(ctx, selectQuery, registration.AppID, registration.APIBaseURL, registration.WebBaseURL))
+	if err == nil {
+		if existing.PrivateKeySecretRef != registration.PrivateKeySecretRef || existing.WebhookSecretRef != registration.WebhookSecretRef {
+			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+		}
+		return existing, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return domain.GitHubAppRegistration{}, err
+	}
+
+	const insertQuery = `
+		INSERT INTO github_app_registrations (
+			id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+	`
+	inserted, insertErr := scanGitHubAppRegistration(tx.QueryRowContext(ctx, insertQuery,
+		registration.ID,
+		registration.AppID,
+		registration.DisplayName,
+		registration.APIBaseURL,
+		registration.WebBaseURL,
+		registration.PrivateKeySecretRef,
+		registration.WebhookSecretRef,
+		registration.CreatedAt,
+		registration.UpdatedAt,
+	))
+	if insertErr != nil {
+		if isSCMConnectionUniqueViolation(insertErr, "github_app_registrations_app_id_api_base_url_web_base_url_key") {
+			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+		}
+		return domain.GitHubAppRegistration{}, insertErr
+	}
+	return inserted, nil
+}
+
+type scmConnectionDetailScanner interface{ Scan(dest ...any) error }
+
+func scanSCMConnectionDetail(scanner scmConnectionDetailScanner) (domain.SCMConnectionDetail, error) {
+	var detail domain.SCMConnectionDetail
+	var provider string
+	var deploymentKind string
+	var healthStatus string
+	var connectionHealthSummary sql.NullString
+	var connectionLastHealthCheckedAt sql.NullTime
+	var registrationID sql.NullString
+	var registrationAppID sql.NullString
+	var registrationDisplayName sql.NullString
+	var registrationAPIBaseURL sql.NullString
+	var registrationWebBaseURL sql.NullString
+	var registrationPrivateKeySecretRef sql.NullString
+	var registrationWebhookSecretRef sql.NullString
+	var registrationCreatedAt sql.NullTime
+	var registrationUpdatedAt sql.NullTime
+	var installationConnectionID sql.NullString
+	var installationAppRegistrationID sql.NullString
+	var installationID sql.NullString
+	var installationAccountLogin sql.NullString
+	var installationAccountType sql.NullString
+	var installationAccountID sql.NullString
+	var installationCreatedAt sql.NullTime
+	var installationUpdatedAt sql.NullTime
+	if err := scanner.Scan(
+		&detail.Connection.ID,
+		&provider,
+		&detail.Connection.DisplayName,
+		&deploymentKind,
+		&detail.Connection.APIBaseURL,
+		&detail.Connection.WebBaseURL,
+		&detail.Connection.Enabled,
+		&healthStatus,
+		&connectionHealthSummary,
+		&connectionLastHealthCheckedAt,
+		&detail.Connection.CreatedAt,
+		&detail.Connection.UpdatedAt,
+		&registrationID,
+		&registrationAppID,
+		&registrationDisplayName,
+		&registrationAPIBaseURL,
+		&registrationWebBaseURL,
+		&registrationPrivateKeySecretRef,
+		&registrationWebhookSecretRef,
+		&registrationCreatedAt,
+		&registrationUpdatedAt,
+		&installationConnectionID,
+		&installationAppRegistrationID,
+		&installationID,
+		&installationAccountLogin,
+		&installationAccountType,
+		&installationAccountID,
+		&installationCreatedAt,
+		&installationUpdatedAt,
+	); err != nil {
+		return domain.SCMConnectionDetail{}, err
+	}
+	detail.Connection.Provider = domain.SCMProvider(provider)
+	detail.Connection.DeploymentKind = domain.SCMDeploymentKind(deploymentKind)
+	detail.Connection.HealthStatus = domain.SCMConnectionHealthStatus(healthStatus)
+	if connectionHealthSummary.Valid {
+		value := connectionHealthSummary.String
+		detail.Connection.HealthSummary = &value
+	}
+	if connectionLastHealthCheckedAt.Valid {
+		value := connectionLastHealthCheckedAt.Time
+		detail.Connection.LastHealthCheckedAt = &value
+	}
+	if registrationID.Valid {
+		registration := domain.GitHubAppRegistration{
+			ID:                  registrationID.String,
+			AppID:               registrationAppID.String,
+			APIBaseURL:          registrationAPIBaseURL.String,
+			WebBaseURL:          registrationWebBaseURL.String,
+			PrivateKeySecretRef: registrationPrivateKeySecretRef.String,
+			WebhookSecretRef:    registrationWebhookSecretRef.String,
+		}
+		if registrationDisplayName.Valid {
+			value := registrationDisplayName.String
+			registration.DisplayName = &value
+		}
+		if registrationCreatedAt.Valid {
+			registration.CreatedAt = registrationCreatedAt.Time
+		}
+		if registrationUpdatedAt.Valid {
+			registration.UpdatedAt = registrationUpdatedAt.Time
+		}
+		detail.GitHubAppRegistration = &registration
+	}
+	if installationConnectionID.Valid {
+		installation := domain.GitHubAppInstallation{
+			ConnectionID:      installationConnectionID.String,
+			AppRegistrationID: installationAppRegistrationID.String,
+			InstallationID:    installationID.String,
+			AccountLogin:      installationAccountLogin.String,
+			AccountType:       installationAccountType.String,
+			AccountID:         installationAccountID.String,
+		}
+		if installationCreatedAt.Valid {
+			installation.CreatedAt = installationCreatedAt.Time
+		}
+		if installationUpdatedAt.Valid {
+			installation.UpdatedAt = installationUpdatedAt.Time
+		}
+		detail.GitHubAppInstallation = &installation
+	}
+	return detail.Normalize(), nil
+}
+
+type githubAppRegistrationScanner interface{ Scan(dest ...any) error }
+
+func scanGitHubAppRegistration(scanner githubAppRegistrationScanner) (domain.GitHubAppRegistration, error) {
+	var registration domain.GitHubAppRegistration
+	var displayName sql.NullString
+	if err := scanner.Scan(
+		&registration.ID,
+		&registration.AppID,
+		&displayName,
+		&registration.APIBaseURL,
+		&registration.WebBaseURL,
+		&registration.PrivateKeySecretRef,
+		&registration.WebhookSecretRef,
+		&registration.CreatedAt,
+		&registration.UpdatedAt,
+	); err != nil {
+		return domain.GitHubAppRegistration{}, err
+	}
+	if displayName.Valid {
+		value := displayName.String
+		registration.DisplayName = &value
+	}
+	return registration.Normalize(), nil
+}
+
+func isSCMConnectionUniqueViolation(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "23505" && pgErr.ConstraintName == constraint
+}

--- a/backend/internal/repository/postgres/scm_connection_repository.go
+++ b/backend/internal/repository/postgres/scm_connection_repository.go
@@ -24,6 +24,80 @@ const scmConnectionColumns = `c.id, c.provider, c.display_name, c.deployment_kin
 	ga.id, ga.app_id, ga.display_name, ga.api_base_url, ga.web_base_url, ga.private_key_secret_ref, ga.webhook_secret_ref, ga.created_at, ga.updated_at,
 	gi.connection_id, gi.app_registration_id, gi.installation_id, gi.account_login, gi.account_type, gi.account_id, gi.created_at, gi.updated_at`
 
+func (r *SCMConnectionRepository) CreateGitHubAppRegistration(ctx context.Context, registration domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error) {
+	registration = registration.Normalize()
+	if err := registration.Validate(); err != nil {
+		return domain.GitHubAppRegistration{}, err
+	}
+
+	const query = `
+		INSERT INTO github_app_registrations (
+			id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+	`
+	created, err := scanGitHubAppRegistration(r.db.QueryRowContext(ctx, query,
+		registration.ID,
+		registration.AppID,
+		registration.DisplayName,
+		registration.APIBaseURL,
+		registration.WebBaseURL,
+		registration.PrivateKeySecretRef,
+		registration.WebhookSecretRef,
+		registration.CreatedAt,
+		registration.UpdatedAt,
+	))
+	if err != nil {
+		if isSCMConnectionUniqueViolation(err, "github_app_registrations_app_id_api_base_url_web_base_url_key") || isSCMConnectionUniqueViolation(err, "github_app_registrations_pkey") {
+			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+		}
+		return domain.GitHubAppRegistration{}, err
+	}
+	return created, nil
+}
+
+func (r *SCMConnectionRepository) ListGitHubAppRegistrations(ctx context.Context) ([]domain.GitHubAppRegistration, error) {
+	const query = `
+		SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+		FROM github_app_registrations
+		ORDER BY created_at DESC, id DESC
+	`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]domain.GitHubAppRegistration, 0)
+	for rows.Next() {
+		item, scanErr := scanGitHubAppRegistration(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (r *SCMConnectionRepository) GetGitHubAppRegistrationByID(ctx context.Context, id string) (domain.GitHubAppRegistration, error) {
+	const query = `
+		SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
+		FROM github_app_registrations
+		WHERE id = $1
+	`
+	registration, err := scanGitHubAppRegistration(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationNotFound
+		}
+		return domain.GitHubAppRegistration{}, err
+	}
+	return registration, nil
+}
+
 func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(ctx context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error) {
 	detail = detail.Normalize()
 	if err := detail.Validate(); err != nil {
@@ -35,8 +109,7 @@ func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(ctx cont
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	registration := *detail.GitHubAppRegistration
-	registration, err = resolveOrCreateGitHubAppRegistration(ctx, tx, registration)
+	registration, err := getGitHubAppRegistrationForUpdate(ctx, tx, detail.GitHubAppRegistration.ID)
 	if err != nil {
 		return domain.SCMConnectionDetail{}, err
 	}
@@ -69,7 +142,6 @@ func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(ctx cont
 	}
 
 	installation := *detail.GitHubAppInstallation
-	installation.AppRegistrationID = registration.ID
 	const insertInstallationQuery = `
 		INSERT INTO github_app_installations (
 			connection_id, app_registration_id, installation_id, account_login, account_type, account_id, created_at, updated_at
@@ -161,48 +233,21 @@ func (r *SCMConnectionRepository) SetEnabled(ctx context.Context, id string, ena
 	return r.GetByID(ctx, returnedID)
 }
 
-func resolveOrCreateGitHubAppRegistration(ctx context.Context, tx *sql.Tx, registration domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error) {
-	const selectQuery = `
+func getGitHubAppRegistrationForUpdate(ctx context.Context, tx *sql.Tx, registrationID string) (domain.GitHubAppRegistration, error) {
+	const query = `
 		SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
 		FROM github_app_registrations
-		WHERE app_id = $1 AND api_base_url = $2 AND web_base_url = $3
+		WHERE id = $1
+		FOR UPDATE
 	`
-	existing, err := scanGitHubAppRegistration(tx.QueryRowContext(ctx, selectQuery, registration.AppID, registration.APIBaseURL, registration.WebBaseURL))
-	if err == nil {
-		if existing.PrivateKeySecretRef != registration.PrivateKeySecretRef || existing.WebhookSecretRef != registration.WebhookSecretRef {
-			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
+	registration, err := scanGitHubAppRegistration(tx.QueryRowContext(ctx, query, registrationID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationNotFound
 		}
-		return existing, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
 		return domain.GitHubAppRegistration{}, err
 	}
-
-	const insertQuery = `
-		INSERT INTO github_app_registrations (
-			id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
-		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		RETURNING id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at
-	`
-	inserted, insertErr := scanGitHubAppRegistration(tx.QueryRowContext(ctx, insertQuery,
-		registration.ID,
-		registration.AppID,
-		registration.DisplayName,
-		registration.APIBaseURL,
-		registration.WebBaseURL,
-		registration.PrivateKeySecretRef,
-		registration.WebhookSecretRef,
-		registration.CreatedAt,
-		registration.UpdatedAt,
-	))
-	if insertErr != nil {
-		if isSCMConnectionUniqueViolation(insertErr, "github_app_registrations_app_id_api_base_url_web_base_url_key") {
-			return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationConflict
-		}
-		return domain.GitHubAppRegistration{}, insertErr
-	}
-	return inserted, nil
+	return registration, nil
 }
 
 type scmConnectionDetailScanner interface{ Scan(dest ...any) error }

--- a/backend/internal/repository/postgres/scm_connection_repository_test.go
+++ b/backend/internal/repository/postgres/scm_connection_repository_test.go
@@ -7,10 +7,85 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 )
+
+func TestSCMConnectionRepository_CreateGitHubAppRegistration(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	registration := testPostgresGitHubAppRegistration(now)
+
+	registrationRows := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now, now)
+	mock.ExpectQuery("INSERT INTO github_app_registrations").WillReturnRows(registrationRows)
+
+	created, createErr := repo.CreateGitHubAppRegistration(context.Background(), registration)
+	if createErr != nil {
+		t.Fatalf("create registration failed: %v", createErr)
+	}
+	if created.ID != registration.ID {
+		t.Fatalf("expected registration id to round-trip, got %q", created.ID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestSCMConnectionRepository_ListAndGetGitHubAppRegistrations(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	listRows := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-2", "54321", "second", "https://ghe.example/api/v3", "https://ghe.example", "", "secret/github/webhook-2", now, now).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now.Add(-time.Minute), now.Add(-time.Minute))
+	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations ORDER BY").WillReturnRows(listRows)
+	list, listErr := repo.ListGitHubAppRegistrations(context.Background())
+	if listErr != nil {
+		t.Fatalf("list registrations failed: %v", listErr)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected two registrations, got %d", len(list))
+	}
+	if list[0].ID != "registration-2" || list[1].ID != "registration-1" {
+		t.Fatalf("unexpected registration ordering: %+v", list)
+	}
+
+	getRows := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now, now)
+	mock.ExpectQuery(`SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations WHERE id = \$1`).WithArgs("registration-1").WillReturnRows(getRows)
+	fetched, getErr := repo.GetGitHubAppRegistrationByID(context.Background(), "registration-1")
+	if getErr != nil {
+		t.Fatalf("get registration failed: %v", getErr)
+	}
+	if fetched.ID != "registration-1" {
+		t.Fatalf("expected registration-1, got %q", fetched.ID)
+	}
+
+	mock.ExpectQuery(`SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations WHERE id = \$1`).WithArgs("missing").WillReturnError(sql.ErrNoRows)
+	_, missingErr := repo.GetGitHubAppRegistrationByID(context.Background(), "missing")
+	if missingErr != repository.ErrSCMGitHubAppRegistrationNotFound {
+		t.Fatalf("expected not found error, got %v", missingErr)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
 
 func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -28,9 +103,8 @@ func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection(t *testin
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").
-		WithArgs("12345", "https://api.github.com", "https://github.com").
-		WillReturnError(sql.ErrNoRows)
-	mock.ExpectQuery("INSERT INTO github_app_registrations").WillReturnRows(registrationRows)
+		WithArgs("registration-1").
+		WillReturnRows(registrationRows)
 	mock.ExpectExec("INSERT INTO scm_connections").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO github_app_installations").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -48,7 +122,7 @@ func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection(t *testin
 	}
 }
 
-func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection_ReusedRegistrationConflict(t *testing.T) {
+func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection_RegistrationNotFound(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create sqlmock: %v", err)
@@ -59,15 +133,41 @@ func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection_ReusedReg
 	now := time.Now().UTC()
 	detail := testPostgresGitHubConnectionDetail(now)
 
-	existing := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
-		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "other/private-key", "secret/github/webhook", now, now)
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").WillReturnRows(existing)
+	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").WillReturnError(sql.ErrNoRows)
 	mock.ExpectRollback()
 
 	_, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
-	if createErr != repository.ErrSCMGitHubAppRegistrationConflict {
-		t.Fatalf("expected github app registration conflict, got %v", createErr)
+	if createErr != repository.ErrSCMGitHubAppRegistrationNotFound {
+		t.Fatalf("expected github app registration not found, got %v", createErr)
+	}
+}
+
+func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection_DuplicateInstallationConflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	detail := testPostgresGitHubConnectionDetail(now)
+
+	registrationRows := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now, now)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").
+		WithArgs("registration-1").
+		WillReturnRows(registrationRows)
+	mock.ExpectExec("INSERT INTO scm_connections").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO github_app_installations").WillReturnError(&pgconn.PgError{Code: "23505", ConstraintName: "github_app_installations_app_registration_id_installation_id_key"})
+	mock.ExpectRollback()
+
+	_, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
+	if createErr != repository.ErrSCMGitHubAppInstallationConflict {
+		t.Fatalf("expected github app installation conflict, got %v", createErr)
 	}
 }
 
@@ -116,11 +216,16 @@ func TestSCMConnectionRepository_GetListAndSetEnabled(t *testing.T) {
 }
 
 func testPostgresGitHubConnectionDetail(now time.Time) domain.SCMConnectionDetail {
+	registration := testPostgresGitHubAppRegistration(now)
 	return domain.SCMConnectionDetail{
 		Connection:            domain.SCMConnection{ID: "connection-1", Provider: domain.SCMProviderGitHub, DisplayName: "octo connection", DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
-		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: "registration-1", AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &registration,
 		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: "connection-1", AppRegistrationID: "registration-1", InstallationID: "999", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now},
 	}
+}
+
+func testPostgresGitHubAppRegistration(now time.Time) domain.GitHubAppRegistration {
+	return domain.GitHubAppRegistration{ID: "registration-1", AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now}
 }
 
 func scmConnectionDetailTestRows(now time.Time) *sqlmock.Rows {

--- a/backend/internal/repository/postgres/scm_connection_repository_test.go
+++ b/backend/internal/repository/postgres/scm_connection_repository_test.go
@@ -36,8 +36,8 @@ func TestSCMConnectionRepository_CreateGitHubAppRegistration(t *testing.T) {
 		t.Fatalf("expected registration id to round-trip, got %q", created.ID)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}
 }
 
@@ -82,8 +82,8 @@ func TestSCMConnectionRepository_ListAndGetGitHubAppRegistrations(t *testing.T) 
 		t.Fatalf("expected not found error, got %v", missingErr)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}
 }
 
@@ -117,8 +117,8 @@ func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection(t *testin
 		t.Fatalf("expected registration to round-trip, got %+v", created.GitHubAppRegistration)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}
 }
 
@@ -210,8 +210,8 @@ func TestSCMConnectionRepository_GetListAndSetEnabled(t *testing.T) {
 		t.Fatalf("expected updated connection id, got %q", updated.Connection.ID)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}
 }
 

--- a/backend/internal/repository/postgres/scm_connection_repository_test.go
+++ b/backend/internal/repository/postgres/scm_connection_repository_test.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	detail := testPostgresGitHubConnectionDetail(now)
+
+	registrationRows := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now, now)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").
+		WithArgs("12345", "https://api.github.com", "https://github.com").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("INSERT INTO github_app_registrations").WillReturnRows(registrationRows)
+	mock.ExpectExec("INSERT INTO scm_connections").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO github_app_installations").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	created, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
+	if createErr != nil {
+		t.Fatalf("create failed: %v", createErr)
+	}
+	if created.GitHubAppRegistration == nil || created.GitHubAppRegistration.ID != "registration-1" {
+		t.Fatalf("expected registration to round-trip, got %+v", created.GitHubAppRegistration)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestSCMConnectionRepository_CreateGitHubAppInstallationConnection_ReusedRegistrationConflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	detail := testPostgresGitHubConnectionDetail(now)
+
+	existing := sqlmock.NewRows([]string{"id", "app_id", "display_name", "api_base_url", "web_base_url", "private_key_secret_ref", "webhook_secret_ref", "created_at", "updated_at"}).
+		AddRow("registration-1", "12345", nil, "https://api.github.com", "https://github.com", "other/private-key", "secret/github/webhook", now, now)
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at FROM github_app_registrations").WillReturnRows(existing)
+	mock.ExpectRollback()
+
+	_, createErr := repo.CreateGitHubAppInstallationConnection(context.Background(), detail)
+	if createErr != repository.ErrSCMGitHubAppRegistrationConflict {
+		t.Fatalf("expected github app registration conflict, got %v", createErr)
+	}
+}
+
+func TestSCMConnectionRepository_GetListAndSetEnabled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	rows := scmConnectionDetailTestRows(now)
+
+	mock.ExpectQuery("SELECT .* FROM scm_connections c").WillReturnRows(rows)
+	list, listErr := repo.List(context.Background())
+	if listErr != nil {
+		t.Fatalf("list failed: %v", listErr)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one connection, got %d", len(list))
+	}
+
+	mock.ExpectQuery(`SELECT .* FROM scm_connections c.*WHERE c.id = \$1`).WithArgs("connection-1").WillReturnRows(scmConnectionDetailTestRows(now))
+	fetched, getErr := repo.GetByID(context.Background(), "connection-1")
+	if getErr != nil {
+		t.Fatalf("get failed: %v", getErr)
+	}
+	if fetched.Connection.ID != "connection-1" {
+		t.Fatalf("expected fetched connection id, got %q", fetched.Connection.ID)
+	}
+
+	mock.ExpectQuery("UPDATE scm_connections").WithArgs("connection-1", false, now.Add(time.Minute)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("connection-1"))
+	mock.ExpectQuery(`SELECT .* FROM scm_connections c.*WHERE c.id = \$1`).WithArgs("connection-1").WillReturnRows(scmConnectionDetailTestRows(now))
+	updated, updateErr := repo.SetEnabled(context.Background(), "connection-1", false, now.Add(time.Minute))
+	if updateErr != nil {
+		t.Fatalf("set enabled failed: %v", updateErr)
+	}
+	if updated.Connection.ID != "connection-1" {
+		t.Fatalf("expected updated connection id, got %q", updated.Connection.ID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func testPostgresGitHubConnectionDetail(now time.Time) domain.SCMConnectionDetail {
+	return domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: "connection-1", Provider: domain.SCMProviderGitHub, DisplayName: "octo connection", DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: "registration-1", AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now},
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: "connection-1", AppRegistrationID: "registration-1", InstallationID: "999", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now},
+	}
+}
+
+func scmConnectionDetailTestRows(now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "provider", "display_name", "deployment_kind", "api_base_url", "web_base_url", "enabled", "health_status", "health_summary", "last_health_checked_at", "created_at", "updated_at", "ga_id", "ga_app_id", "ga_display_name", "ga_api_base_url", "ga_web_base_url", "ga_private_key_secret_ref", "ga_webhook_secret_ref", "ga_created_at", "ga_updated_at", "gi_connection_id", "gi_app_registration_id", "gi_installation_id", "gi_account_login", "gi_account_type", "gi_account_id", "gi_created_at", "gi_updated_at"}).
+		AddRow("connection-1", "github", "octo connection", "cloud", "https://api.github.com", "https://github.com", true, "unknown", nil, nil, now, now, "registration-1", "12345", nil, "https://api.github.com", "https://github.com", "secret/github/private-key", "secret/github/webhook", now, now, "connection-1", "registration-1", "999", "octo", "organization", "42", now, now)
+}

--- a/backend/internal/repository/postgres/scm_repository_registration_repository.go
+++ b/backend/internal/repository/postgres/scm_repository_registration_repository.go
@@ -1,0 +1,177 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+type SCMRepositoryRegistrationRepository struct {
+	db *sql.DB
+}
+
+func NewSCMRepositoryRegistrationRepository(db *sql.DB) *SCMRepositoryRegistrationRepository {
+	return &SCMRepositoryRegistrationRepository{db: db}
+}
+
+func (r *SCMRepositoryRegistrationRepository) Create(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
+	const query = `
+		INSERT INTO scm_registered_repositories (
+			id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		RETURNING id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at
+	`
+	created, err := scanSCMRepositoryRegistration(r.db.QueryRowContext(ctx, query,
+		registration.ID,
+		registration.ConnectionID,
+		registration.ProviderRepositoryID,
+		registration.Owner,
+		registration.Name,
+		registration.FullName,
+		registration.CloneURL,
+		registration.WebURL,
+		registration.DefaultBranch,
+		registration.Archived,
+		registration.Disabled,
+		registration.MetadataRefreshedAt,
+		registration.CreatedAt,
+		registration.UpdatedAt,
+	))
+	if err != nil {
+		if isSCMRepositoryRegistrationUniqueViolation(err, "scm_registered_repositories_connection_id_provider_repository_id_key") {
+			return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationDuplicate
+		}
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	return created, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) List(ctx context.Context) ([]domain.SCMRepositoryRegistration, error) {
+	const query = `
+		SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at
+		FROM scm_registered_repositories
+		ORDER BY created_at DESC, id DESC
+	`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	items := make([]domain.SCMRepositoryRegistration, 0)
+	for rows.Next() {
+		item, scanErr := scanSCMRepositoryRegistration(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) GetByID(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error) {
+	const query = `
+		SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at
+		FROM scm_registered_repositories
+		WHERE id = $1
+	`
+	item, err := scanSCMRepositoryRegistration(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationNotFound
+		}
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	return item, nil
+}
+
+func (r *SCMRepositoryRegistrationRepository) Update(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
+	const query = `
+		UPDATE scm_registered_repositories
+		SET connection_id = $2,
+			provider_repository_id = $3,
+			owner_name = $4,
+			repository_name = $5,
+			full_name = $6,
+			clone_url = $7,
+			web_url = $8,
+			default_branch = $9,
+			archived = $10,
+			disabled = $11,
+			metadata_refreshed_at = $12,
+			updated_at = $13
+		WHERE id = $1
+		RETURNING id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at
+	`
+	updated, err := scanSCMRepositoryRegistration(r.db.QueryRowContext(ctx, query,
+		registration.ID,
+		registration.ConnectionID,
+		registration.ProviderRepositoryID,
+		registration.Owner,
+		registration.Name,
+		registration.FullName,
+		registration.CloneURL,
+		registration.WebURL,
+		registration.DefaultBranch,
+		registration.Archived,
+		registration.Disabled,
+		registration.MetadataRefreshedAt,
+		registration.UpdatedAt,
+	))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationNotFound
+		}
+		if isSCMRepositoryRegistrationUniqueViolation(err, "scm_registered_repositories_connection_id_provider_repository_id_key") {
+			return domain.SCMRepositoryRegistration{}, repository.ErrSCMRepositoryRegistrationDuplicate
+		}
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	return updated, nil
+}
+
+type scmRepositoryRegistrationScanner interface{ Scan(dest ...any) error }
+
+func scanSCMRepositoryRegistration(scanner scmRepositoryRegistrationScanner) (domain.SCMRepositoryRegistration, error) {
+	var registration domain.SCMRepositoryRegistration
+	var defaultBranch sql.NullString
+	if err := scanner.Scan(
+		&registration.ID,
+		&registration.ConnectionID,
+		&registration.ProviderRepositoryID,
+		&registration.Owner,
+		&registration.Name,
+		&registration.FullName,
+		&registration.CloneURL,
+		&registration.WebURL,
+		&defaultBranch,
+		&registration.Archived,
+		&registration.Disabled,
+		&registration.MetadataRefreshedAt,
+		&registration.CreatedAt,
+		&registration.UpdatedAt,
+	); err != nil {
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	if defaultBranch.Valid {
+		value := defaultBranch.String
+		registration.DefaultBranch = &value
+	}
+	return registration.Normalize(), nil
+}
+
+func isSCMRepositoryRegistrationUniqueViolation(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "23505" && pgErr.ConstraintName == constraint
+}

--- a/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
+++ b/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
@@ -36,8 +36,8 @@ func TestSCMRepositoryRegistrationRepository_CreateGetListAndUpdate(t *testing.T
 	}
 
 	mock.ExpectQuery(`SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at FROM scm_registered_repositories WHERE id = \$1`).WithArgs("repo-1").WillReturnRows(scmRepositoryRegistrationTestRows(now))
-	if _, err := repo.GetByID(context.Background(), "repo-1"); err != nil {
-		t.Fatalf("get failed: %v", err)
+	if _, getErr := repo.GetByID(context.Background(), "repo-1"); getErr != nil {
+		t.Fatalf("get failed: %v", getErr)
 	}
 
 	mock.ExpectQuery(`SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at FROM scm_registered_repositories ORDER BY`).WillReturnRows(scmRepositoryRegistrationTestRows(now))
@@ -64,8 +64,8 @@ func TestSCMRepositoryRegistrationRepository_CreateGetListAndUpdate(t *testing.T
 		t.Fatalf("expected updated full name, got %q", updated.FullName)
 	}
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("unmet expectations: %v", err)
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}
 }
 

--- a/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
+++ b/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -82,6 +83,33 @@ func TestSCMRepositoryRegistrationRepository_CreateDuplicateMapsToConflict(t *te
 	_, createErr := repo.Create(context.Background(), registration)
 	if createErr != repository.ErrSCMRepositoryRegistrationDuplicate {
 		t.Fatalf("expected duplicate error, got %v", createErr)
+	}
+}
+
+func TestSCMRepositoryRegistrationRepository_GetAndUpdateNotFoundAndUpdateDuplicate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMRepositoryRegistrationRepository(db)
+	now := time.Now().UTC()
+	registration := domain.SCMRepositoryRegistration{ID: "repo-1", ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	mock.ExpectQuery(`SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at FROM scm_registered_repositories WHERE id = \$1`).WithArgs("missing").WillReturnError(sql.ErrNoRows)
+	if _, err := repo.GetByID(context.Background(), "missing"); err != repository.ErrSCMRepositoryRegistrationNotFound {
+		t.Fatalf("expected missing repository error, got %v", err)
+	}
+	mock.ExpectQuery("UPDATE scm_registered_repositories").WillReturnError(sql.ErrNoRows)
+	if _, err := repo.Update(context.Background(), registration); err != repository.ErrSCMRepositoryRegistrationNotFound {
+		t.Fatalf("expected update missing repository error, got %v", err)
+	}
+	mock.ExpectQuery("UPDATE scm_registered_repositories").WillReturnError(&pgconn.PgError{Code: "23505", ConstraintName: "scm_registered_repositories_connection_id_provider_repository_id_key"})
+	if _, err := repo.Update(context.Background(), registration); err != repository.ErrSCMRepositoryRegistrationDuplicate {
+		t.Fatalf("expected update duplicate error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 

--- a/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
+++ b/backend/internal/repository/postgres/scm_repository_registration_repository_test.go
@@ -1,0 +1,91 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+func TestSCMRepositoryRegistrationRepository_CreateGetListAndUpdate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMRepositoryRegistrationRepository(db)
+	now := time.Now().UTC()
+	branch := "main"
+	registration := domain.SCMRepositoryRegistration{ID: "repo-1", ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", DefaultBranch: &branch, MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	rows := scmRepositoryRegistrationTestRows(now)
+
+	mock.ExpectQuery("INSERT INTO scm_registered_repositories").WillReturnRows(rows)
+	created, createErr := repo.Create(context.Background(), registration)
+	if createErr != nil {
+		t.Fatalf("create failed: %v", createErr)
+	}
+	if created.ProviderRepositoryID != "1001" {
+		t.Fatalf("expected provider repository id to round-trip, got %q", created.ProviderRepositoryID)
+	}
+
+	mock.ExpectQuery(`SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at FROM scm_registered_repositories WHERE id = \$1`).WithArgs("repo-1").WillReturnRows(scmRepositoryRegistrationTestRows(now))
+	if _, err := repo.GetByID(context.Background(), "repo-1"); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+
+	mock.ExpectQuery(`SELECT id, connection_id, provider_repository_id, owner_name, repository_name, full_name, clone_url, web_url, default_branch, archived, disabled, metadata_refreshed_at, created_at, updated_at FROM scm_registered_repositories ORDER BY`).WillReturnRows(scmRepositoryRegistrationTestRows(now))
+	list, listErr := repo.List(context.Background())
+	if listErr != nil {
+		t.Fatalf("list failed: %v", listErr)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one repository, got %d", len(list))
+	}
+
+	registration.Owner = "acme"
+	registration.Name = "platform"
+	registration.FullName = "acme/platform"
+	registration.CloneURL = "https://github.com/acme/platform.git"
+	registration.WebURL = "https://github.com/acme/platform"
+	registration.UpdatedAt = now.Add(time.Minute)
+	mock.ExpectQuery("UPDATE scm_registered_repositories").WillReturnRows(sqlmock.NewRows([]string{"id", "connection_id", "provider_repository_id", "owner_name", "repository_name", "full_name", "clone_url", "web_url", "default_branch", "archived", "disabled", "metadata_refreshed_at", "created_at", "updated_at"}).AddRow("repo-1", "connection-1", "1001", "acme", "platform", "acme/platform", "https://github.com/acme/platform.git", "https://github.com/acme/platform", "main", false, false, now, now, now.Add(time.Minute)))
+	updated, updateErr := repo.Update(context.Background(), registration)
+	if updateErr != nil {
+		t.Fatalf("update failed: %v", updateErr)
+	}
+	if updated.FullName != "acme/platform" {
+		t.Fatalf("expected updated full name, got %q", updated.FullName)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestSCMRepositoryRegistrationRepository_CreateDuplicateMapsToConflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMRepositoryRegistrationRepository(db)
+	now := time.Now().UTC()
+	registration := domain.SCMRepositoryRegistration{ID: "repo-1", ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "widgets", FullName: "octo/widgets", CloneURL: "https://github.com/octo/widgets.git", WebURL: "https://github.com/octo/widgets", MetadataRefreshedAt: now, CreatedAt: now, UpdatedAt: now}
+	mock.ExpectQuery("INSERT INTO scm_registered_repositories").WillReturnError(&pgconn.PgError{Code: "23505", ConstraintName: "scm_registered_repositories_connection_id_provider_repository_id_key"})
+	_, createErr := repo.Create(context.Background(), registration)
+	if createErr != repository.ErrSCMRepositoryRegistrationDuplicate {
+		t.Fatalf("expected duplicate error, got %v", createErr)
+	}
+}
+
+func scmRepositoryRegistrationTestRows(now time.Time) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "connection_id", "provider_repository_id", "owner_name", "repository_name", "full_name", "clone_url", "web_url", "default_branch", "archived", "disabled", "metadata_refreshed_at", "created_at", "updated_at"}).
+		AddRow("repo-1", "connection-1", "1001", "octo", "widgets", "octo/widgets", "https://github.com/octo/widgets.git", "https://github.com/octo/widgets", "main", false, false, now, now, now)
+}

--- a/backend/internal/repository/scm_connection_repository.go
+++ b/backend/internal/repository/scm_connection_repository.go
@@ -10,10 +10,14 @@ import (
 
 var ErrSCMConnectionNotFound = errors.New("scm connection not found")
 var ErrSCMConnectionConflict = errors.New("scm connection conflict")
+var ErrSCMGitHubAppRegistrationNotFound = errors.New("github app registration not found")
 var ErrSCMGitHubAppRegistrationConflict = errors.New("github app registration conflict")
 var ErrSCMGitHubAppInstallationConflict = errors.New("github app installation conflict")
 
 type SCMConnectionRepository interface {
+	CreateGitHubAppRegistration(ctx context.Context, registration domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error)
+	ListGitHubAppRegistrations(ctx context.Context) ([]domain.GitHubAppRegistration, error)
+	GetGitHubAppRegistrationByID(ctx context.Context, id string) (domain.GitHubAppRegistration, error)
 	CreateGitHubAppInstallationConnection(ctx context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error)
 	List(ctx context.Context) ([]domain.SCMConnectionDetail, error)
 	GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error)

--- a/backend/internal/repository/scm_connection_repository.go
+++ b/backend/internal/repository/scm_connection_repository.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+)
+
+var ErrSCMConnectionNotFound = errors.New("scm connection not found")
+var ErrSCMConnectionConflict = errors.New("scm connection conflict")
+var ErrSCMGitHubAppRegistrationConflict = errors.New("github app registration conflict")
+var ErrSCMGitHubAppInstallationConflict = errors.New("github app installation conflict")
+
+type SCMConnectionRepository interface {
+	CreateGitHubAppInstallationConnection(ctx context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error)
+	List(ctx context.Context) ([]domain.SCMConnectionDetail, error)
+	GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
+	SetEnabled(ctx context.Context, id string, enabled bool, updatedAt time.Time) (domain.SCMConnectionDetail, error)
+}

--- a/backend/internal/repository/scm_repository_registration_repository.go
+++ b/backend/internal/repository/scm_repository_registration_repository.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+)
+
+var ErrSCMRepositoryRegistrationNotFound = errors.New("scm registered repository not found")
+var ErrSCMRepositoryRegistrationDuplicate = errors.New("scm registered repository already exists for this connection and provider repository id")
+
+type SCMRepositoryRegistrationRepository interface {
+	Create(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error)
+	List(ctx context.Context) ([]domain.SCMRepositoryRegistration, error)
+	GetByID(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error)
+	Update(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error)
+}

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+var ErrSCMConnectionDisplayNameRequired = errors.New("display_name is required")
+var ErrSCMConnectionDeploymentKindInvalid = errors.New("deployment_kind must be one of cloud, self_hosted")
+var ErrSCMGitHubAppIDRequired = errors.New("github app app_id is required")
+var ErrSCMGitHubPrivateKeySecretRefRequired = errors.New("github app private_key_secret_ref is required")
+var ErrSCMGitHubWebhookSecretRefRequired = errors.New("github app webhook_secret_ref is required")
+var ErrSCMGitHubInstallationIDRequired = errors.New("github installation installation_id is required")
+var ErrSCMGitHubAccountLoginRequired = errors.New("github installation account_login is required")
+var ErrSCMGitHubAccountTypeRequired = errors.New("github installation account_type is required")
+var ErrSCMGitHubAccountIDRequired = errors.New("github installation account_id is required")
+var ErrSCMConnectionEnabledRequired = errors.New("enabled is required")
+var ErrSCMRegisteredRepositoryConnectionIDRequired = errors.New("connection_id is required")
+var ErrSCMRegisteredRepositoryProviderRepositoryIDRequired = errors.New("provider_repository_id is required")
+var ErrSCMRegisteredRepositoryOwnerRequired = errors.New("owner is required")
+var ErrSCMRegisteredRepositoryNameRequired = errors.New("name is required")
+var ErrSCMRegisteredRepositoryFullNameRequired = errors.New("full_name is required")
+var ErrSCMRegisteredRepositoryCloneURLRequired = errors.New("clone_url is required")
+var ErrSCMRegisteredRepositoryWebURLRequired = errors.New("web_url is required")
+
+type SCMAdminService struct {
+	connections  repository.SCMConnectionRepository
+	repositories repository.SCMRepositoryRegistrationRepository
+	now          func() time.Time
+}
+
+type CreateGitHubAppInstallationConnectionInput struct {
+	DisplayName         string
+	DeploymentKind      string
+	APIBaseURL          string
+	WebBaseURL          string
+	AppID               string
+	AppDisplayName      *string
+	PrivateKeySecretRef string
+	WebhookSecretRef    string
+	InstallationID      string
+	AccountLogin        string
+	AccountType         string
+	AccountID           string
+}
+
+type CreateSCMRepositoryRegistrationInput struct {
+	ConnectionID         string
+	ProviderRepositoryID string
+	Owner                string
+	Name                 string
+	FullName             string
+	CloneURL             string
+	WebURL               string
+	DefaultBranch        *string
+	Archived             bool
+	Disabled             bool
+	MetadataRefreshedAt  *time.Time
+}
+
+func NewSCMAdminService(connections repository.SCMConnectionRepository, repositories repository.SCMRepositoryRegistrationRepository) *SCMAdminService {
+	return &SCMAdminService{connections: connections, repositories: repositories, now: time.Now}
+}
+
+func (s *SCMAdminService) ListConnections(ctx context.Context) ([]domain.SCMConnectionDetail, error) {
+	return s.connections.List(ctx)
+}
+
+func (s *SCMAdminService) GetConnection(ctx context.Context, id string) (domain.SCMConnectionDetail, error) {
+	return s.connections.GetByID(ctx, strings.TrimSpace(id))
+}
+
+func (s *SCMAdminService) CreateGitHubAppInstallationConnection(ctx context.Context, input CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error) {
+	displayName := strings.TrimSpace(input.DisplayName)
+	if displayName == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMConnectionDisplayNameRequired
+	}
+	deploymentKind := domain.SCMDeploymentKind(strings.TrimSpace(input.DeploymentKind))
+	if !deploymentKind.IsValid() {
+		return domain.SCMConnectionDetail{}, ErrSCMConnectionDeploymentKindInvalid
+	}
+	if strings.TrimSpace(input.AppID) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubAppIDRequired
+	}
+	if strings.TrimSpace(input.PrivateKeySecretRef) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubPrivateKeySecretRefRequired
+	}
+	if strings.TrimSpace(input.WebhookSecretRef) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubWebhookSecretRefRequired
+	}
+	if strings.TrimSpace(input.InstallationID) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubInstallationIDRequired
+	}
+	if strings.TrimSpace(input.AccountLogin) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubAccountLoginRequired
+	}
+	if strings.TrimSpace(input.AccountType) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubAccountTypeRequired
+	}
+	if strings.TrimSpace(input.AccountID) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubAccountIDRequired
+	}
+
+	now := s.now().UTC()
+	connectionID := uuid.NewString()
+	registrationID := uuid.NewString()
+	detail := domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: displayName, DeploymentKind: deploymentKind, APIBaseURL: input.APIBaseURL, WebBaseURL: input.WebBaseURL, Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: registrationID, AppID: strings.TrimSpace(input.AppID), DisplayName: input.AppDisplayName, APIBaseURL: input.APIBaseURL, WebBaseURL: input.WebBaseURL, PrivateKeySecretRef: strings.TrimSpace(input.PrivateKeySecretRef), WebhookSecretRef: strings.TrimSpace(input.WebhookSecretRef), CreatedAt: now, UpdatedAt: now},
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registrationID, InstallationID: strings.TrimSpace(input.InstallationID), AccountLogin: strings.TrimSpace(input.AccountLogin), AccountType: strings.TrimSpace(input.AccountType), AccountID: strings.TrimSpace(input.AccountID), CreatedAt: now, UpdatedAt: now},
+	}
+	return s.connections.CreateGitHubAppInstallationConnection(ctx, detail)
+}
+
+func (s *SCMAdminService) SetConnectionEnabled(ctx context.Context, id string, enabled *bool) (domain.SCMConnectionDetail, error) {
+	if enabled == nil {
+		return domain.SCMConnectionDetail{}, ErrSCMConnectionEnabledRequired
+	}
+	return s.connections.SetEnabled(ctx, strings.TrimSpace(id), *enabled, s.now().UTC())
+}
+
+func (s *SCMAdminService) ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error) {
+	return s.repositories.List(ctx)
+}
+
+func (s *SCMAdminService) GetRegisteredRepository(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error) {
+	return s.repositories.GetByID(ctx, strings.TrimSpace(id))
+}
+
+func (s *SCMAdminService) CreateRegisteredRepository(ctx context.Context, input CreateSCMRepositoryRegistrationInput) (domain.SCMRepositoryRegistration, error) {
+	if strings.TrimSpace(input.ConnectionID) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryConnectionIDRequired
+	}
+	if strings.TrimSpace(input.ProviderRepositoryID) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryProviderRepositoryIDRequired
+	}
+	if strings.TrimSpace(input.Owner) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryOwnerRequired
+	}
+	if strings.TrimSpace(input.Name) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryNameRequired
+	}
+	if strings.TrimSpace(input.FullName) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryFullNameRequired
+	}
+	if strings.TrimSpace(input.CloneURL) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryCloneURLRequired
+	}
+	if strings.TrimSpace(input.WebURL) == "" {
+		return domain.SCMRepositoryRegistration{}, ErrSCMRegisteredRepositoryWebURLRequired
+	}
+	if _, err := s.connections.GetByID(ctx, strings.TrimSpace(input.ConnectionID)); err != nil {
+		return domain.SCMRepositoryRegistration{}, err
+	}
+	now := s.now().UTC()
+	metadataRefreshedAt := now
+	if input.MetadataRefreshedAt != nil {
+		metadataRefreshedAt = input.MetadataRefreshedAt.UTC()
+	}
+	registration := domain.SCMRepositoryRegistration{
+		ID:                   uuid.NewString(),
+		ConnectionID:         strings.TrimSpace(input.ConnectionID),
+		ProviderRepositoryID: strings.TrimSpace(input.ProviderRepositoryID),
+		Owner:                strings.TrimSpace(input.Owner),
+		Name:                 strings.TrimSpace(input.Name),
+		FullName:             strings.TrimSpace(input.FullName),
+		CloneURL:             strings.TrimSpace(input.CloneURL),
+		WebURL:               strings.TrimSpace(input.WebURL),
+		DefaultBranch:        input.DefaultBranch,
+		Archived:             input.Archived,
+		Disabled:             input.Disabled,
+		MetadataRefreshedAt:  metadataRefreshedAt,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	return s.repositories.Create(ctx, registration)
+}
+
+func (s *SCMAdminService) UpdateRegisteredRepository(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
+	registration.UpdatedAt = s.now().UTC()
+	return s.repositories.Update(ctx, registration)
+}

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -13,7 +13,7 @@ import (
 )
 
 var ErrSCMConnectionDisplayNameRequired = errors.New("display_name is required")
-var ErrSCMGitHubAppRegistrationIDRequired = errors.New("github app app_registration_id is required")
+var ErrSCMGitHubAppRegistrationIDRequired = errors.New("github installation app_registration_id is required")
 var ErrSCMGitHubAppIDRequired = errors.New("github app app_id is required")
 var ErrSCMGitHubPrivateKeySecretRefRequired = errors.New("github app private_key_secret_ref is required")
 var ErrSCMGitHubWebhookSecretRefRequired = errors.New("github app webhook_secret_ref is required")

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -13,14 +13,14 @@ import (
 )
 
 var ErrSCMConnectionDisplayNameRequired = errors.New("display_name is required")
-var ErrSCMConnectionDeploymentKindInvalid = errors.New("deployment_kind must be one of cloud, self_hosted")
+var ErrSCMGitHubAppRegistrationIDRequired = errors.New("github app app_registration_id is required")
 var ErrSCMGitHubAppIDRequired = errors.New("github app app_id is required")
 var ErrSCMGitHubPrivateKeySecretRefRequired = errors.New("github app private_key_secret_ref is required")
 var ErrSCMGitHubWebhookSecretRefRequired = errors.New("github app webhook_secret_ref is required")
 var ErrSCMGitHubInstallationIDRequired = errors.New("github installation installation_id is required")
 var ErrSCMGitHubAccountLoginRequired = errors.New("github installation account_login is required")
 var ErrSCMGitHubAccountTypeRequired = errors.New("github installation account_type is required")
-var ErrSCMGitHubAccountIDRequired = errors.New("github installation account_id is required")
+var ErrSCMGitHubTargetIDRequired = errors.New("github installation target_id is required")
 var ErrSCMConnectionEnabledRequired = errors.New("enabled is required")
 var ErrSCMRegisteredRepositoryConnectionIDRequired = errors.New("connection_id is required")
 var ErrSCMRegisteredRepositoryProviderRepositoryIDRequired = errors.New("provider_repository_id is required")
@@ -37,18 +37,22 @@ type SCMAdminService struct {
 }
 
 type CreateGitHubAppInstallationConnectionInput struct {
-	DisplayName         string
-	DeploymentKind      string
+	AppRegistrationID string
+	DisplayName       string
+	Enabled           *bool
+	InstallationID    string
+	AccountLogin      string
+	AccountType       string
+	TargetID          string
+}
+
+type CreateGitHubAppRegistrationInput struct {
+	AppID               string
+	DisplayName         *string
 	APIBaseURL          string
 	WebBaseURL          string
-	AppID               string
-	AppDisplayName      *string
 	PrivateKeySecretRef string
 	WebhookSecretRef    string
-	InstallationID      string
-	AccountLogin        string
-	AccountType         string
-	AccountID           string
 }
 
 type CreateSCMRepositoryRegistrationInput struct {
@@ -77,23 +81,50 @@ func (s *SCMAdminService) GetConnection(ctx context.Context, id string) (domain.
 	return s.connections.GetByID(ctx, strings.TrimSpace(id))
 }
 
+func (s *SCMAdminService) ListGitHubAppRegistrations(ctx context.Context) ([]domain.GitHubAppRegistration, error) {
+	return s.connections.ListGitHubAppRegistrations(ctx)
+}
+
+func (s *SCMAdminService) GetGitHubAppRegistration(ctx context.Context, id string) (domain.GitHubAppRegistration, error) {
+	return s.connections.GetGitHubAppRegistrationByID(ctx, strings.TrimSpace(id))
+}
+
+func (s *SCMAdminService) CreateGitHubAppRegistration(ctx context.Context, input CreateGitHubAppRegistrationInput) (domain.GitHubAppRegistration, error) {
+	if strings.TrimSpace(input.AppID) == "" {
+		return domain.GitHubAppRegistration{}, ErrSCMGitHubAppIDRequired
+	}
+	if strings.TrimSpace(input.PrivateKeySecretRef) == "" {
+		return domain.GitHubAppRegistration{}, ErrSCMGitHubPrivateKeySecretRefRequired
+	}
+	if strings.TrimSpace(input.WebhookSecretRef) == "" {
+		return domain.GitHubAppRegistration{}, ErrSCMGitHubWebhookSecretRefRequired
+	}
+
+	now := s.now().UTC()
+	registration := domain.GitHubAppRegistration{
+		ID:                  uuid.NewString(),
+		AppID:               strings.TrimSpace(input.AppID),
+		DisplayName:         input.DisplayName,
+		APIBaseURL:          input.APIBaseURL,
+		WebBaseURL:          input.WebBaseURL,
+		PrivateKeySecretRef: strings.TrimSpace(input.PrivateKeySecretRef),
+		WebhookSecretRef:    strings.TrimSpace(input.WebhookSecretRef),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	return s.connections.CreateGitHubAppRegistration(ctx, registration)
+}
+
 func (s *SCMAdminService) CreateGitHubAppInstallationConnection(ctx context.Context, input CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error) {
+	if strings.TrimSpace(input.AppRegistrationID) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubAppRegistrationIDRequired
+	}
 	displayName := strings.TrimSpace(input.DisplayName)
 	if displayName == "" {
 		return domain.SCMConnectionDetail{}, ErrSCMConnectionDisplayNameRequired
 	}
-	deploymentKind := domain.SCMDeploymentKind(strings.TrimSpace(input.DeploymentKind))
-	if !deploymentKind.IsValid() {
-		return domain.SCMConnectionDetail{}, ErrSCMConnectionDeploymentKindInvalid
-	}
-	if strings.TrimSpace(input.AppID) == "" {
-		return domain.SCMConnectionDetail{}, ErrSCMGitHubAppIDRequired
-	}
-	if strings.TrimSpace(input.PrivateKeySecretRef) == "" {
-		return domain.SCMConnectionDetail{}, ErrSCMGitHubPrivateKeySecretRefRequired
-	}
-	if strings.TrimSpace(input.WebhookSecretRef) == "" {
-		return domain.SCMConnectionDetail{}, ErrSCMGitHubWebhookSecretRefRequired
+	if input.Enabled == nil {
+		return domain.SCMConnectionDetail{}, ErrSCMConnectionEnabledRequired
 	}
 	if strings.TrimSpace(input.InstallationID) == "" {
 		return domain.SCMConnectionDetail{}, ErrSCMGitHubInstallationIDRequired
@@ -104,17 +135,21 @@ func (s *SCMAdminService) CreateGitHubAppInstallationConnection(ctx context.Cont
 	if strings.TrimSpace(input.AccountType) == "" {
 		return domain.SCMConnectionDetail{}, ErrSCMGitHubAccountTypeRequired
 	}
-	if strings.TrimSpace(input.AccountID) == "" {
-		return domain.SCMConnectionDetail{}, ErrSCMGitHubAccountIDRequired
+	if strings.TrimSpace(input.TargetID) == "" {
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubTargetIDRequired
+	}
+	registration, err := s.connections.GetGitHubAppRegistrationByID(ctx, strings.TrimSpace(input.AppRegistrationID))
+	if err != nil {
+		return domain.SCMConnectionDetail{}, err
 	}
 
 	now := s.now().UTC()
 	connectionID := uuid.NewString()
-	registrationID := uuid.NewString()
+	deploymentKind := inferGitHubDeploymentKind(registration.APIBaseURL, registration.WebBaseURL)
 	detail := domain.SCMConnectionDetail{
-		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: displayName, DeploymentKind: deploymentKind, APIBaseURL: input.APIBaseURL, WebBaseURL: input.WebBaseURL, Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
-		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: registrationID, AppID: strings.TrimSpace(input.AppID), DisplayName: input.AppDisplayName, APIBaseURL: input.APIBaseURL, WebBaseURL: input.WebBaseURL, PrivateKeySecretRef: strings.TrimSpace(input.PrivateKeySecretRef), WebhookSecretRef: strings.TrimSpace(input.WebhookSecretRef), CreatedAt: now, UpdatedAt: now},
-		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registrationID, InstallationID: strings.TrimSpace(input.InstallationID), AccountLogin: strings.TrimSpace(input.AccountLogin), AccountType: strings.TrimSpace(input.AccountType), AccountID: strings.TrimSpace(input.AccountID), CreatedAt: now, UpdatedAt: now},
+		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: displayName, DeploymentKind: deploymentKind, APIBaseURL: registration.APIBaseURL, WebBaseURL: registration.WebBaseURL, Enabled: *input.Enabled, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &registration,
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registration.ID, InstallationID: strings.TrimSpace(input.InstallationID), AccountLogin: strings.TrimSpace(input.AccountLogin), AccountType: strings.TrimSpace(input.AccountType), AccountID: strings.TrimSpace(input.TargetID), CreatedAt: now, UpdatedAt: now},
 	}
 	return s.connections.CreateGitHubAppInstallationConnection(ctx, detail)
 }
@@ -186,4 +221,11 @@ func (s *SCMAdminService) CreateRegisteredRepository(ctx context.Context, input 
 func (s *SCMAdminService) UpdateRegisteredRepository(ctx context.Context, registration domain.SCMRepositoryRegistration) (domain.SCMRepositoryRegistration, error) {
 	registration.UpdatedAt = s.now().UTC()
 	return s.repositories.Update(ctx, registration)
+}
+
+func inferGitHubDeploymentKind(apiBaseURL string, webBaseURL string) domain.SCMDeploymentKind {
+	if strings.TrimSpace(apiBaseURL) == "https://api.github.com" && strings.TrimSpace(webBaseURL) == "https://github.com" {
+		return domain.SCMDeploymentKindCloud
+	}
+	return domain.SCMDeploymentKindSelfHosted
 }

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
+)
+
+func TestSCMAdminService_CreateConnectionAndRepository(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Now().UTC()
+	svc.now = func() time.Time { return now }
+
+	connection, createErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		DisplayName:         "octo cloud",
+		DeploymentKind:      "cloud",
+		AppID:               "12345",
+		PrivateKeySecretRef: "secret/github/private-key",
+		WebhookSecretRef:    "secret/github/webhook",
+		InstallationID:      "999",
+		AccountLogin:        "octo",
+		AccountType:         "organization",
+		AccountID:           "42",
+	})
+	if createErr != nil {
+		t.Fatalf("create connection failed: %v", createErr)
+	}
+
+	branch := "main"
+	repository, repoErr := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{
+		ConnectionID:         connection.Connection.ID,
+		ProviderRepositoryID: "1001",
+		Owner:                "octo",
+		Name:                 "widgets",
+		FullName:             "octo/widgets",
+		CloneURL:             "https://github.com/octo/widgets.git",
+		WebURL:               "https://github.com/octo/widgets",
+		DefaultBranch:        &branch,
+	})
+	if repoErr != nil {
+		t.Fatalf("create repository failed: %v", repoErr)
+	}
+	if repository.ConnectionID != connection.Connection.ID {
+		t.Fatalf("expected repository to attach to connection, got %+v", repository)
+	}
+}

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
 )
@@ -193,5 +194,82 @@ func TestSCMAdminService_GitHubRegistrationSharedAcrossInstallationsAndSiblingDi
 	})
 	if duplicateErr != repository.ErrSCMGitHubAppInstallationConflict {
 		t.Fatalf("expected duplicate installation conflict, got %v", duplicateErr)
+	}
+}
+
+func TestSCMAdminServiceValidationAndReadBranches(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Now().UTC()
+	svc.now = func() time.Time { return now }
+
+	if _, err := svc.ListConnections(context.Background()); err != nil {
+		t.Fatalf("list connections should succeed on empty repo: %v", err)
+	}
+	if _, err := svc.ListGitHubAppRegistrations(context.Background()); err != nil {
+		t.Fatalf("list registrations should succeed on empty repo: %v", err)
+	}
+	if _, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{}); err != ErrSCMGitHubAppIDRequired {
+		t.Fatalf("expected missing app id error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345"}); err != ErrSCMGitHubPrivateKeySecretRefRequired {
+		t.Fatalf("expected missing private key ref error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345", PrivateKeySecretRef: "secret/a"}); err != ErrSCMGitHubWebhookSecretRefRequired {
+		t.Fatalf("expected missing webhook ref error, got %v", err)
+	}
+
+	enabled := true
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{}); err != ErrSCMGitHubAppRegistrationIDRequired {
+		t.Fatalf("expected missing app registration id error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg"}); err != ErrSCMConnectionDisplayNameRequired {
+		t.Fatalf("expected missing display name error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg", DisplayName: "name"}); err != ErrSCMConnectionEnabledRequired {
+		t.Fatalf("expected missing enabled error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg", DisplayName: "name", Enabled: &enabled}); err != ErrSCMGitHubInstallationIDRequired {
+		t.Fatalf("expected missing installation id error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg", DisplayName: "name", Enabled: &enabled, InstallationID: "inst"}); err != ErrSCMGitHubAccountLoginRequired {
+		t.Fatalf("expected missing account login error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg", DisplayName: "name", Enabled: &enabled, InstallationID: "inst", AccountLogin: "octo"}); err != ErrSCMGitHubAccountTypeRequired {
+		t.Fatalf("expected missing account type error, got %v", err)
+	}
+	if _, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: "reg", DisplayName: "name", Enabled: &enabled, InstallationID: "inst", AccountLogin: "octo", AccountType: "organization"}); err != ErrSCMGitHubTargetIDRequired {
+		t.Fatalf("expected missing target id error, got %v", err)
+	}
+	if _, err := svc.SetConnectionEnabled(context.Background(), "connection-1", nil); err != ErrSCMConnectionEnabledRequired {
+		t.Fatalf("expected missing enabled patch error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{}); err != ErrSCMRegisteredRepositoryConnectionIDRequired {
+		t.Fatalf("expected missing connection id error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1"}); err != ErrSCMRegisteredRepositoryProviderRepositoryIDRequired {
+		t.Fatalf("expected missing provider repository id error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1", ProviderRepositoryID: "1001"}); err != ErrSCMRegisteredRepositoryOwnerRequired {
+		t.Fatalf("expected missing owner error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo"}); err != ErrSCMRegisteredRepositoryNameRequired {
+		t.Fatalf("expected missing name error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "repo"}); err != ErrSCMRegisteredRepositoryFullNameRequired {
+		t.Fatalf("expected missing full name error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "repo", FullName: "octo/repo"}); err != ErrSCMRegisteredRepositoryCloneURLRequired {
+		t.Fatalf("expected missing clone url error, got %v", err)
+	}
+	if _, err := svc.CreateRegisteredRepository(context.Background(), CreateSCMRepositoryRegistrationInput{ConnectionID: "connection-1", ProviderRepositoryID: "1001", Owner: "octo", Name: "repo", FullName: "octo/repo", CloneURL: "https://github.com/octo/repo.git"}); err != ErrSCMRegisteredRepositoryWebURLRequired {
+		t.Fatalf("expected missing web url error, got %v", err)
+	}
+	if inferGitHubDeploymentKind("https://api.github.com", "https://github.com") != domain.SCMDeploymentKindCloud {
+		t.Fatal("expected public GitHub hosts to infer cloud deployment")
+	}
+	if inferGitHubDeploymentKind("https://ghe.example/api/v3", "https://ghe.example") != domain.SCMDeploymentKindSelfHosted {
+		t.Fatal("expected non-public GitHub hosts to infer self-hosted deployment")
 	}
 }

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
 )
 
@@ -14,17 +15,24 @@ func TestSCMAdminService_CreateConnectionAndRepository(t *testing.T) {
 	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
 	now := time.Now().UTC()
 	svc.now = func() time.Time { return now }
-
-	connection, createErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
-		DisplayName:         "octo cloud",
-		DeploymentKind:      "cloud",
+	registration, registrationErr := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{
 		AppID:               "12345",
 		PrivateKeySecretRef: "secret/github/private-key",
 		WebhookSecretRef:    "secret/github/webhook",
-		InstallationID:      "999",
-		AccountLogin:        "octo",
-		AccountType:         "organization",
-		AccountID:           "42",
+	})
+	if registrationErr != nil {
+		t.Fatalf("create github app registration failed: %v", registrationErr)
+	}
+	enabled := true
+
+	connection, createErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		AppRegistrationID: registration.ID,
+		DisplayName:       "octo cloud",
+		Enabled:           &enabled,
+		InstallationID:    "999",
+		AccountLogin:      "octo",
+		AccountType:       "organization",
+		TargetID:          "42",
 	})
 	if createErr != nil {
 		t.Fatalf("create connection failed: %v", createErr)
@@ -46,5 +54,144 @@ func TestSCMAdminService_CreateConnectionAndRepository(t *testing.T) {
 	}
 	if repository.ConnectionID != connection.Connection.ID {
 		t.Fatalf("expected repository to attach to connection, got %+v", repository)
+	}
+}
+
+func TestSCMAdminService_ListAndGetGitHubAppRegistrations(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Now().UTC()
+	svc.now = func() time.Time { return now }
+	_, firstErr := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{
+		AppID:               "12345",
+		PrivateKeySecretRef: "secret/github/private-key",
+		WebhookSecretRef:    "secret/github/webhook",
+	})
+	if firstErr != nil {
+		t.Fatalf("create first registration failed: %v", firstErr)
+	}
+	_, secondErr := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{
+		AppID:               "54321",
+		APIBaseURL:          "https://ghe.example/api/v3",
+		WebBaseURL:          "https://ghe.example",
+		WebhookSecretRef:    "secret/github/webhook-2",
+		PrivateKeySecretRef: "secret/github/private-key-2",
+	})
+	if secondErr != nil {
+		t.Fatalf("create second registration failed: %v", secondErr)
+	}
+	list, listErr := svc.ListGitHubAppRegistrations(context.Background())
+	if listErr != nil {
+		t.Fatalf("list registrations failed: %v", listErr)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected two registrations, got %d", len(list))
+	}
+	fetched, getErr := svc.GetGitHubAppRegistration(context.Background(), list[0].ID)
+	if getErr != nil {
+		t.Fatalf("get registration failed: %v", getErr)
+	}
+	if fetched.ID != list[0].ID {
+		t.Fatalf("expected fetched registration id %q, got %q", list[0].ID, fetched.ID)
+	}
+	_, missingErr := svc.GetGitHubAppRegistration(context.Background(), "missing")
+	if missingErr != repository.ErrSCMGitHubAppRegistrationNotFound {
+		t.Fatalf("expected missing registration error, got %v", missingErr)
+	}
+}
+
+func TestSCMAdminService_GitHubRegistrationSharedAcrossInstallationsAndSiblingDisableIndependence(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Now().UTC()
+	svc.now = func() time.Time { return now }
+
+	registration, registrationErr := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{
+		AppID:               "12345",
+		PrivateKeySecretRef: "secret/github/private-key",
+		WebhookSecretRef:    "secret/github/webhook",
+	})
+	if registrationErr != nil {
+		t.Fatalf("create github app registration failed: %v", registrationErr)
+	}
+	enabled := true
+	first, firstErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		AppRegistrationID: registration.ID,
+		DisplayName:       "octo cloud",
+		Enabled:           &enabled,
+		InstallationID:    "999",
+		AccountLogin:      "octo",
+		AccountType:       "organization",
+		TargetID:          "42",
+	})
+	if firstErr != nil {
+		t.Fatalf("create first connection failed: %v", firstErr)
+	}
+	second, secondErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		AppRegistrationID: registration.ID,
+		DisplayName:       "octo sibling",
+		Enabled:           &enabled,
+		InstallationID:    "1000",
+		AccountLogin:      "octo-two",
+		AccountType:       "organization",
+		TargetID:          "84",
+	})
+	if secondErr != nil {
+		t.Fatalf("create second connection failed: %v", secondErr)
+	}
+	if first.GitHubAppRegistration == nil || second.GitHubAppRegistration == nil || first.GitHubAppRegistration.ID != second.GitHubAppRegistration.ID {
+		t.Fatalf("expected shared registration, got first=%+v second=%+v", first.GitHubAppRegistration, second.GitHubAppRegistration)
+	}
+
+	disable := false
+	updated, updateErr := svc.SetConnectionEnabled(context.Background(), first.Connection.ID, &disable)
+	if updateErr != nil {
+		t.Fatalf("disable first connection failed: %v", updateErr)
+	}
+	if updated.Connection.Enabled {
+		t.Fatal("expected first connection to be disabled")
+	}
+	fetchedSecond, getErr := svc.GetConnection(context.Background(), second.Connection.ID)
+	if getErr != nil {
+		t.Fatalf("get second connection failed: %v", getErr)
+	}
+	if !fetchedSecond.Connection.Enabled {
+		t.Fatal("expected sibling connection to remain enabled")
+	}
+	if fetchedSecond.GitHubAppRegistration == nil || fetchedSecond.GitHubAppRegistration.ID != registration.ID {
+		t.Fatalf("expected shared registration to remain attached, got %+v", fetchedSecond.GitHubAppRegistration)
+	}
+	storedRegistration, storedRegistrationErr := connectionRepo.GetGitHubAppRegistrationByID(context.Background(), registration.ID)
+	if storedRegistrationErr != nil {
+		t.Fatalf("get registration failed: %v", storedRegistrationErr)
+	}
+	if storedRegistration.UpdatedAt != registration.UpdatedAt {
+		t.Fatalf("expected registration timestamps unchanged, got %s want %s", storedRegistration.UpdatedAt, registration.UpdatedAt)
+	}
+	_, missingErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		AppRegistrationID: "missing-registration",
+		DisplayName:       "missing",
+		Enabled:           &enabled,
+		InstallationID:    "1001",
+		AccountLogin:      "octo-three",
+		AccountType:       "organization",
+		TargetID:          "126",
+	})
+	if missingErr != repository.ErrSCMGitHubAppRegistrationNotFound {
+		t.Fatalf("expected missing registration error, got %v", missingErr)
+	}
+	_, duplicateErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{
+		AppRegistrationID: registration.ID,
+		DisplayName:       "duplicate",
+		Enabled:           &enabled,
+		InstallationID:    "999",
+		AccountLogin:      "octo-duplicate",
+		AccountType:       "organization",
+		TargetID:          "168",
+	})
+	if duplicateErr != repository.ErrSCMGitHubAppInstallationConflict {
+		t.Fatalf("expected duplicate installation conflict, got %v", duplicateErr)
 	}
 }


### PR DESCRIPTION
# Multi-Connection SCM Foundation

## Summary

Adds the durable backend foundation for supporting multiple SCM connections and registered repositories in a single Coyote deployment.

The new model supports multiple connections for the same provider and host, separates reusable GitHub App registrations from individual installations, and scopes repository identity by connection plus stable provider repository ID. This enables enterprise layouts with multiple GitHub organizations or GitHub Enterprise instances while leaving room for future GitLab and Bitbucket adapters.

This slice is intentionally foundational. It does not yet add GitHub App JWT generation, installation-token exchange, repository discovery, status-delivery migration, connection-aware webhook routing, or automatic PR builds.

## What Changed

- Added provider-neutral SCM connection persistence and domain models.
- Added reusable GitHub App registration persistence.
- Added GitHub App installation persistence linked to:
  - one SCM connection;
  - one reusable GitHub App registration.
- Added registered repository persistence keyed by:
  - `connection_id`;
  - stable `provider_repository_id`.
- Added additive migration:
  - `backend/db/migrations/00039_add_scm_connection_foundation.sql`
- Added memory and PostgreSQL repositories.
- Added SCM administration services.
- Added admin JSON APIs for:
  - SCM connections;
  - GitHub App registrations;
  - GitHub App installation connections;
  - registered repositories.
- Added safe GitHub App registration list/show endpoints.
- Added server composition and HTTP routing.
- Added Swagger/OpenAPI coverage.
- Added focused domain, repository, service, handler, and router tests.

## Identity Model

### SCM Connection

An SCM connection represents one provider installation or independently managed SCM boundary.

Connections include provider-neutral metadata such as:

- provider;
- display name;
- deployment kind;
- API base URL;
- web base URL;
- enabled state;
- health metadata;
- timestamps.

Multiple connections may exist for the same provider and host.

### GitHub App Registration

A GitHub App registration represents reusable app-level identity and credentials.

It owns:

- GitHub App ID;
- display name;
- API and web base URLs;
- private-key secret reference;
- webhook-secret reference;
- timestamps.

Secret values are not persisted directly.

One registration may be reused by multiple GitHub App installation connections.

### GitHub App Installation

Each GitHub App installation is modeled as one SCM connection linked to an existing GitHub App registration.

Installation metadata includes:

- installation ID;
- account login;
- account type;
- target/account ID;
- timestamps.

This supports:

```text
one GitHub App registration
  ├─ installation / connection A
  ├─ installation / connection B
  └─ installation / connection C
```

Disabling one installation connection does not disable the shared app registration or sibling installations.

### Registered Repository

A repository is identified by:

```text
connection_id + provider_repository_id
```

Cached metadata includes:

- owner or namespace;
- repository name;
- full name;
- clone URL;
- web URL;
- default branch;
- archived/disabled state;
- metadata refresh timestamp.

Repository rename or transfer can update descriptive metadata without changing durable identity.

Identical owner/name pairs may exist under separate connections.

## API Surface

### GitHub App Registrations

```text
POST /api/settings/scm/github-apps
GET  /api/settings/scm/github-apps
GET  /api/settings/scm/github-apps/{registrationID}
```

Create accepts app metadata plus secret references.

List/show responses expose only safe metadata, including:

- registration ID;
- app ID;
- display name;
- API/web base URLs;
- timestamps;
- `private_key_configured`;
- `webhook_configured`.

Secret references and secret material are not returned.

### GitHub App Installation Connections

```text
POST /api/settings/scm/connections/github-app-installations
```

Installation creation requires an existing:

```text
app_registration_id
```

Multiple installations may reference the same registration.

Duplicate installation registration under the same app registration is rejected.

### SCM Connections

The admin API supports listing, inspecting, and enabling/disabling SCM connections through the new SCM settings surface.

### Registered Repositories

The admin API supports creating, listing, and inspecting registered repositories from supplied provider metadata.

This slice does not call GitHub to verify or hydrate repository metadata.

## Persistence Invariants

The schema and repositories enforce:

- multiple SCM connections per provider;
- reusable GitHub App registrations;
- multiple installations per GitHub App registration;
- duplicate installation rejection under the same registration;
- repository uniqueness by connection plus provider repository ID;
- same owner/name values across separate connections;
- independent connection enabled state;
- preserved repository identity through rename or transfer;
- secret references stored separately from secret values.

## Backward Compatibility

Existing runtime behavior remains unchanged.

This slice does not migrate:

- `job.repository_url`;
- build SCM provenance;
- webhook delivery routing;
- SCM status-delivery identity;
- `GITHUB_STATUS_TOKEN`;
- current GitHub webhook behavior.

The new model is additive and will be adopted by later slices.

## Security Boundaries

The APIs do not expose:

- private keys;
- webhook secrets;
- resolved secret values;
- JWTs;
- installation access tokens;
- authorization headers.

GitHub App registration read responses expose only configuration booleans rather than secret-reference identifiers.

## Tests

Coverage includes:

- SCM connection domain validation;
- GitHub App registration validation;
- GitHub installation relationships;
- shared registration across multiple installations;
- duplicate installation rejection;
- sibling installation independence;
- connection enable/disable behavior;
- registered repository uniqueness;
- identical owner/name values across separate connections;
- repository metadata updates after rename/transfer;
- memory/PostgreSQL parity;
- API create/list/show flows;
- registration list/show behavior;
- safe configured booleans;
- no secret leakage;
- router registration;
- not-found behavior.

## Validation

Reported focused validation included:

```text
go test ./internal/domain ./internal/repository/memory ./internal/repository/postgres ./internal/service ./internal/http/handler ./internal/http ./internal/platform/db
make backend-architecture backend-vet
```

The GitHub App registration read follow-up also passed:

```text
go test ./internal/repository/memory ./internal/repository/postgres ./internal/service ./internal/http/handler ./internal/http
make swagger
```

The normal pre-push hook remains the final repository validation gate before push.

## Deferred

- GitHub App JWT generation
- Installation-token exchange and caching
- Real GitHub connection health checks
- Repository metadata discovery or refresh
- Job-to-registered-repository mapping
- SCM commit-status migration to connection-backed credentials
- Connection-aware webhook routing
- Automatic push or PR build changes
- GitHub Checks
- GitLab and Bitbucket implementations
- CLI commands
- Web UI
- Generalized enterprise secret-management infrastructure

## Next Step

Implement GitHub App authentication and installation-token handling on top of this foundation:

- resolve private-key secret references;
- mint short-lived GitHub App JWTs;
- exchange JWTs for installation access tokens;
- cache tokens process-locally with expiry skew;
- expose a fakeable connection health test;
- keep external GitHub behavior behind narrow provider-specific adapters.