### PR TITLE
Add github app authentication

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3658,6 +3658,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/settings/scm/connections/{connectionID}/test": {
+            "post": {
+                "description": "Verifies GitHub App installation authentication for one SCM connection and updates bounded health metadata.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Test installation-backed SCM connection",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SCMConnectionEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/scm/github-apps": {
             "get": {
                 "description": "Returns safe GitHub App registration metadata for operator rediscovery.",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3654,6 +3654,62 @@
                 }
             }
         },
+        "/settings/scm/connections/{connectionID}/test": {
+            "post": {
+                "description": "Verifies GitHub App installation authentication for one SCM connection and updates bounded health metadata.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "scm"
+                ],
+                "summary": "Test installation-backed SCM connection",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SCMConnectionEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/scm/github-apps": {
             "get": {
                 "description": "Returns safe GitHub App registration metadata for operator rediscovery.",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -4289,6 +4289,44 @@ paths:
       summary: Update notification defaults
       tags:
       - notifications
+  /settings/scm/connections/{connectionID}/test:
+    post:
+      description: Verifies GitHub App installation authentication for one SCM connection
+        and updates bounded health metadata.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SCMConnectionEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      summary: Test installation-backed SCM connection
+      tags:
+      - scm
   /settings/scm/connections/github-app-installations:
     post:
       consumes:

--- a/backend/internal/http/handler/scm_handler.go
+++ b/backend/internal/http/handler/scm_handler.go
@@ -25,6 +25,7 @@ type scmAdminService interface {
 	CreateGitHubAppRegistration(ctx context.Context, input service.CreateGitHubAppRegistrationInput) (domain.GitHubAppRegistration, error)
 	CreateGitHubAppInstallationConnection(ctx context.Context, input service.CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error)
 	SetConnectionEnabled(ctx context.Context, id string, enabled *bool) (domain.SCMConnectionDetail, error)
+	TestConnection(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
 	ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error)
 	GetRegisteredRepository(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error)
 	CreateRegisteredRepository(ctx context.Context, input service.CreateSCMRepositoryRegistrationInput) (domain.SCMRepositoryRegistration, error)
@@ -215,6 +216,31 @@ func (h *SCMHandler) PatchConnection(w http.ResponseWriter, r *http.Request) {
 	writeDataJSON(w, http.StatusOK, toSCMConnectionResponse(connection))
 }
 
+// TestConnection godoc
+// @Summary Test installation-backed SCM connection
+// @Description Verifies GitHub App installation authentication for one SCM connection and updates bounded health metadata.
+// @Tags scm
+// @Produce json
+// @Success 200 {object} api.SCMConnectionEnvelope
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 401 {object} api.ErrorResponse
+// @Failure 403 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 502 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Router /settings/scm/connections/{connectionID}/test [post]
+func (h *SCMHandler) TestConnection(w http.ResponseWriter, r *http.Request) {
+	if !h.authorizeAdmin(w, r) {
+		return
+	}
+	connection, err := h.admin.TestConnection(r.Context(), strings.TrimSpace(chi.URLParam(r, "connectionID")))
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	writeDataJSON(w, http.StatusOK, toSCMConnectionResponse(connection))
+}
+
 func (h *SCMHandler) ListRegisteredRepositories(w http.ResponseWriter, r *http.Request) {
 	if !h.authorizeAdmin(w, r) {
 		return
@@ -300,6 +326,8 @@ func (h *SCMHandler) writeError(w http.ResponseWriter, err error) {
 		errors.Is(err, service.ErrSCMGitHubAccountTypeRequired) ||
 		errors.Is(err, service.ErrSCMGitHubTargetIDRequired) ||
 		errors.Is(err, service.ErrSCMConnectionEnabledRequired) ||
+		errors.Is(err, service.ErrSCMConnectionDisabled) ||
+		errors.Is(err, service.ErrSCMGitHubConnectionConfigurationInvalid) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryConnectionIDRequired) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryProviderRepositoryIDRequired) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryOwnerRequired) ||
@@ -308,6 +336,26 @@ func (h *SCMHandler) writeError(w http.ResponseWriter, err error) {
 		errors.Is(err, service.ErrSCMRegisteredRepositoryCloneURLRequired) ||
 		errors.Is(err, service.ErrSCMRegisteredRepositoryWebURLRequired) {
 		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMGitHubPrivateKeyResolveFailed) {
+		writeErrorJSON(w, http.StatusBadGateway, "secret_resolution_failed", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMGitHubAuthenticationFailed) {
+		writeErrorJSON(w, http.StatusBadGateway, "provider_auth_failed", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMGitHubInstallationUnavailable) {
+		writeErrorJSON(w, http.StatusBadGateway, "installation_unavailable", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMGitHubRateLimited) {
+		writeErrorJSON(w, http.StatusBadGateway, "rate_limited", err.Error())
+		return
+	}
+	if errors.Is(err, service.ErrSCMGitHubProviderUnavailable) || errors.Is(err, service.ErrSCMGitHubProviderMalformedResponse) {
+		writeErrorJSON(w, http.StatusBadGateway, "provider_unavailable", err.Error())
 		return
 	}
 	writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/backend/internal/http/handler/scm_handler_test.go
+++ b/backend/internal/http/handler/scm_handler_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -282,4 +283,82 @@ func TestSCMHandler_ErrorPaths(t *testing.T) {
 	if missingRepositoryRes.Code != http.StatusNotFound {
 		t.Fatalf("expected missing repository status %d, got %d body=%s", http.StatusNotFound, missingRepositoryRes.Code, missingRepositoryRes.Body.String())
 	}
+}
+
+func TestSCMHandler_TestConnectionRoute(t *testing.T) {
+	now := time.Now().UTC()
+	admin := &fakeSCMAdminServiceForHandler{testConnection: domain.SCMConnectionDetail{Connection: domain.SCMConnection{ID: "connection-1", Provider: domain.SCMProviderGitHub, DisplayName: "octo", DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusHealthy, CreatedAt: now, UpdatedAt: now}, GitHubAppRegistration: &domain.GitHubAppRegistration{ID: "registration-1", AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/private", WebhookSecretRef: "secret/webhook", CreatedAt: now, UpdatedAt: now}, GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: "connection-1", AppRegistrationID: "registration-1", InstallationID: "999", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}}}
+	h := NewSCMHandler(admin)
+	req := addURLParam(httptest.NewRequest(http.MethodPost, "/settings/scm/connections/connection-1/test", nil), "connectionID", "connection-1")
+	res := httptest.NewRecorder()
+	h.TestConnection(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected test connection status %d, got %d body=%s", http.StatusOK, res.Code, res.Body.String())
+	}
+	body := res.Body.String()
+	if bytes.Contains([]byte(body), []byte("secret/private")) || bytes.Contains([]byte(body), []byte("ghs_")) {
+		t.Fatalf("expected sanitized response, got %s", body)
+	}
+
+	admin.testConnectionErr = service.ErrSCMGitHubAuthenticationFailed
+	res = httptest.NewRecorder()
+	h.TestConnection(res, req)
+	if res.Code != http.StatusBadGateway {
+		t.Fatalf("expected auth failure status %d, got %d body=%s", http.StatusBadGateway, res.Code, res.Body.String())
+	}
+	if !bytes.Contains(res.Body.Bytes(), []byte(`"code":"provider_auth_failed"`)) {
+		t.Fatalf("expected provider_auth_failed code, got %s", res.Body.String())
+	}
+}
+
+type fakeSCMAdminServiceForHandler struct {
+	testConnection    domain.SCMConnectionDetail
+	testConnectionErr error
+}
+
+func (f *fakeSCMAdminServiceForHandler) ListConnections(context.Context) ([]domain.SCMConnectionDetail, error) {
+	return nil, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) GetConnection(context.Context, string) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) ListGitHubAppRegistrations(context.Context) ([]domain.GitHubAppRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) GetGitHubAppRegistration(context.Context, string) (domain.GitHubAppRegistration, error) {
+	return domain.GitHubAppRegistration{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) CreateGitHubAppRegistration(context.Context, service.CreateGitHubAppRegistrationInput) (domain.GitHubAppRegistration, error) {
+	return domain.GitHubAppRegistration{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) CreateGitHubAppInstallationConnection(context.Context, service.CreateGitHubAppInstallationConnectionInput) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) SetConnectionEnabled(context.Context, string, *bool) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) TestConnection(context.Context, string) (domain.SCMConnectionDetail, error) {
+	if f.testConnectionErr != nil {
+		return domain.SCMConnectionDetail{}, f.testConnectionErr
+	}
+	return f.testConnection, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) ListRegisteredRepositories(context.Context) ([]domain.SCMRepositoryRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) GetRegisteredRepository(context.Context, string) (domain.SCMRepositoryRegistration, error) {
+	return domain.SCMRepositoryRegistration{}, nil
+}
+
+func (f *fakeSCMAdminServiceForHandler) CreateRegisteredRepository(context.Context, service.CreateSCMRepositoryRegistrationInput) (domain.SCMRepositoryRegistration, error) {
+	return domain.SCMRepositoryRegistration{}, nil
 }

--- a/backend/internal/http/handler/scm_handler_test.go
+++ b/backend/internal/http/handler/scm_handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -308,6 +309,35 @@ func TestSCMHandler_TestConnectionRoute(t *testing.T) {
 	}
 	if !bytes.Contains(res.Body.Bytes(), []byte(`"code":"provider_auth_failed"`)) {
 		t.Fatalf("expected provider_auth_failed code, got %s", res.Body.String())
+	}
+}
+
+func TestSCMHandler_TestConnectionRoute_ErrorMappings(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{name: "secret resolution failed", err: service.ErrSCMGitHubPrivateKeyResolveFailed, wantCode: http.StatusBadGateway, wantBody: `"code":"secret_resolution_failed"`},
+		{name: "installation unavailable", err: service.ErrSCMGitHubInstallationUnavailable, wantCode: http.StatusBadGateway, wantBody: `"code":"installation_unavailable"`},
+		{name: "rate limited", err: service.ErrSCMGitHubRateLimited, wantCode: http.StatusBadGateway, wantBody: `"code":"rate_limited"`},
+		{name: "provider unavailable", err: service.ErrSCMGitHubProviderUnavailable, wantCode: http.StatusBadGateway, wantBody: `"code":"provider_unavailable"`},
+		{name: "provider malformed", err: service.ErrSCMGitHubProviderMalformedResponse, wantCode: http.StatusBadGateway, wantBody: `"code":"provider_unavailable"`},
+		{name: "internal", err: errors.New("boom"), wantCode: http.StatusInternalServerError, wantBody: `"code":"internal_error"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewSCMHandler(&fakeSCMAdminServiceForHandler{testConnectionErr: tc.err})
+			req := addURLParam(httptest.NewRequest(http.MethodPost, "/settings/scm/connections/connection-1/test", nil), "connectionID", "connection-1")
+			res := httptest.NewRecorder()
+			h.TestConnection(res, req)
+			if res.Code != tc.wantCode {
+				t.Fatalf("expected status %d, got %d body=%s", tc.wantCode, res.Code, res.Body.String())
+			}
+			if !bytes.Contains(res.Body.Bytes(), []byte(tc.wantBody)) {
+				t.Fatalf("expected body to contain %s, got %s", tc.wantBody, res.Body.String())
+			}
+		})
 	}
 }
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -210,6 +210,7 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 						r.Post("/github-app-installations", cfg.scmHandler.CreateGitHubAppInstallationConnection)
 						r.Get("/{connectionID}", cfg.scmHandler.GetConnection)
 						r.Patch("/{connectionID}", cfg.scmHandler.PatchConnection)
+						r.Post("/{connectionID}/test", cfg.scmHandler.TestConnection)
 					})
 					r.Route("/repositories", func(r chi.Router) {
 						r.Get("/", cfg.scmHandler.ListRegisteredRepositories)

--- a/backend/internal/platform/githubapp/client.go
+++ b/backend/internal/platform/githubapp/client.go
@@ -17,6 +17,9 @@ const defaultAPIVersion = "2022-11-28"
 
 var defaultTokenRefreshSkew = time.Minute
 
+const maxGitHubProbeResponseBytes = 64 << 10
+const maxGitHubTokenResponseBytes = 64 << 10
+
 type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -45,6 +48,14 @@ type installationProbeResponse struct {
 	Repositories []struct {
 		ID int64 `json:"id"`
 	} `json:"repositories"`
+}
+
+type installationDetailsResponse struct {
+	ID          json.Number `json:"id"`
+	SuspendedAt *string     `json:"suspended_at"`
+	Account     struct {
+		Login string `json:"login"`
+	} `json:"account"`
 }
 
 type Client struct {
@@ -169,7 +180,7 @@ func (c *Client) exchangeInstallationToken(ctx context.Context, input Installati
 		Token     string `json:"token"`
 		ExpiresAt string `json:"expires_at"`
 	}
-	decodeErr := json.NewDecoder(resp.Body).Decode(&payload)
+	decodeErr := decodeGitHubJSON(resp.Body, maxGitHubTokenResponseBytes, &payload)
 	if decodeErr != nil {
 		return InstallationToken{}, ErrMalformedResponse
 	}
@@ -267,6 +278,10 @@ func installationIDString(value int64) string {
 	return strconv.FormatInt(value, 10)
 }
 
+func decodeGitHubJSON(body io.Reader, maxBytes int64, target any) error {
+	return json.NewDecoder(io.LimitReader(body, maxBytes)).Decode(target)
+}
+
 func (c *Client) probeInstallationWithToken(ctx context.Context, input InstallationTokenRequest, token InstallationToken) (InstallationProbeResult, error) {
 	probeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/installation/repositories?per_page=1"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
@@ -286,12 +301,55 @@ func (c *Client) probeInstallationWithToken(ctx context.Context, input Installat
 		return InstallationProbeResult{}, classifyGitHubResponse(resp)
 	}
 	var payload installationProbeResponse
-	decodeErr := json.NewDecoder(resp.Body).Decode(&payload)
-	if decodeErr != nil {
+	if err := decodeGitHubJSON(resp.Body, maxGitHubProbeResponseBytes, &payload); err != nil {
 		return InstallationProbeResult{}, ErrMalformedResponse
 	}
 	if payload.TotalCount == nil || payload.Repositories == nil {
 		return InstallationProbeResult{}, ErrMalformedResponse
 	}
-	return InstallationProbeResult{InstallationID: strings.TrimSpace(input.InstallationID), Suspended: false}, nil
+	return c.fetchInstallationDetails(ctx, input)
+}
+
+func (c *Client) fetchInstallationDetails(ctx context.Context, input InstallationTokenRequest) (InstallationProbeResult, error) {
+	jwtToken, err := c.signer.Sign(input.AppID, input.PrivateKeyPEM)
+	if err != nil {
+		return InstallationProbeResult{}, err
+	}
+	probeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/app/installations/" + url.PathEscape(strings.TrimSpace(input.InstallationID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return InstallationProbeResult{}, err
+	}
+	setGitHubHeaders(req, jwtToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return InstallationProbeResult{}, ctx.Err()
+		}
+		return InstallationProbeResult{}, ErrProviderUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return InstallationProbeResult{}, classifyGitHubResponse(resp)
+	}
+	var payload installationDetailsResponse
+	if err := decodeGitHubJSON(resp.Body, maxGitHubProbeResponseBytes, &payload); err != nil {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	installationID := strings.TrimSpace(payload.ID.String())
+	if installationID == "" {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	if installationID != strings.TrimSpace(input.InstallationID) {
+		return InstallationProbeResult{}, ErrInstallationUnavailable
+	}
+	accountLogin := strings.TrimSpace(payload.Account.Login)
+	if accountLogin == "" {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	suspended := payload.SuspendedAt != nil && strings.TrimSpace(*payload.SuspendedAt) != ""
+	if suspended {
+		return InstallationProbeResult{}, ErrInstallationUnavailable
+	}
+	return InstallationProbeResult{InstallationID: installationID, AccountLogin: accountLogin, Suspended: false}, nil
 }

--- a/backend/internal/platform/githubapp/client.go
+++ b/backend/internal/platform/githubapp/client.go
@@ -40,6 +40,13 @@ type InstallationProbeResult struct {
 	Suspended      bool
 }
 
+type installationProbeResponse struct {
+	TotalCount   *int `json:"total_count"`
+	Repositories []struct {
+		ID int64 `json:"id"`
+	} `json:"repositories"`
+}
+
 type Client struct {
 	httpClient  httpDoer
 	signer      *JWTSigner
@@ -70,6 +77,11 @@ func NewClient(httpClient *http.Client) *Client {
 }
 
 func (c *Client) GetInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, error) {
+	token, _, err := c.getInstallationToken(ctx, input)
+	return token, err
+}
+
+func (c *Client) getInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, bool, error) {
 	key := installationCacheKey(input)
 	for {
 		now := c.now().UTC()
@@ -77,13 +89,13 @@ func (c *Client) GetInstallationToken(ctx context.Context, input InstallationTok
 		if entry, ok := c.cache[key]; ok && entry.token.Value != "" && now.Before(entry.token.ExpiresAt.Add(-c.refreshSkew)) {
 			token := entry.token
 			c.mu.Unlock()
-			return token, nil
+			return token, true, nil
 		}
 		if waitCh, ok := c.wait[key]; ok {
 			c.mu.Unlock()
 			select {
 			case <-ctx.Done():
-				return InstallationToken{}, ctx.Err()
+				return InstallationToken{}, false, ctx.Err()
 			case <-waitCh:
 				continue
 			}
@@ -104,56 +116,30 @@ func (c *Client) GetInstallationToken(ctx context.Context, input InstallationTok
 		c.mu.Unlock()
 
 		if err != nil {
-			return InstallationToken{}, err
+			return InstallationToken{}, false, err
 		}
-		return token, nil
+		return token, false, nil
 	}
 }
 
 func (c *Client) ProbeInstallation(ctx context.Context, input InstallationTokenRequest) (InstallationProbeResult, error) {
-	token, err := c.GetInstallationToken(ctx, input)
+	token, fromCache, err := c.getInstallationToken(ctx, input)
 	if err != nil {
 		return InstallationProbeResult{}, err
 	}
-	probeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/installation"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
-	if err != nil {
-		return InstallationProbeResult{}, err
+	result, err := c.probeInstallationWithToken(ctx, input, token)
+	if err == nil {
+		return result, nil
 	}
-	setGitHubHeaders(req, token.Value)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return InstallationProbeResult{}, ctx.Err()
+	if err == ErrAuthentication && fromCache {
+		c.invalidateCachedToken(input, token)
+		refreshedToken, _, refreshErr := c.getInstallationToken(ctx, input)
+		if refreshErr != nil {
+			return InstallationProbeResult{}, refreshErr
 		}
-		return InstallationProbeResult{}, ErrProviderUnavailable
+		return c.probeInstallationWithToken(ctx, input, refreshedToken)
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return InstallationProbeResult{}, classifyGitHubResponse(resp)
-	}
-	var payload struct {
-		ID          json.Number `json:"id"`
-		SuspendedAt *string     `json:"suspended_at"`
-		Account     struct {
-			Login string `json:"login"`
-		} `json:"account"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return InstallationProbeResult{}, ErrMalformedResponse
-	}
-	installationID := strings.TrimSpace(payload.ID.String())
-	if installationID == "" {
-		return InstallationProbeResult{}, ErrMalformedResponse
-	}
-	if installationID != strings.TrimSpace(input.InstallationID) {
-		return InstallationProbeResult{}, ErrInstallationUnavailable
-	}
-	suspended := payload.SuspendedAt != nil && strings.TrimSpace(*payload.SuspendedAt) != ""
-	if suspended {
-		return InstallationProbeResult{}, ErrInstallationUnavailable
-	}
-	return InstallationProbeResult{InstallationID: installationID, AccountLogin: strings.TrimSpace(payload.Account.Login), Suspended: false}, nil
+	return InstallationProbeResult{}, err
 }
 
 func (c *Client) exchangeInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, error) {
@@ -199,6 +185,19 @@ func (c *Client) exchangeInstallationToken(ctx context.Context, input Installati
 
 func installationCacheKey(input InstallationTokenRequest) string {
 	return strings.TrimSpace(input.AppRegistrationID) + "|" + strings.TrimSpace(input.InstallationID) + "|" + strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/")
+}
+
+func (c *Client) invalidateCachedToken(input InstallationTokenRequest, failedToken InstallationToken) {
+	key := installationCacheKey(input)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.cache[key]
+	if !ok {
+		return
+	}
+	if entry.token == failedToken {
+		delete(c.cache, key)
+	}
 }
 
 func setGitHubHeaders(req *http.Request, bearerToken string) {
@@ -266,4 +265,33 @@ func readGitHubMessage(body io.Reader) string {
 
 func installationIDString(value int64) string {
 	return strconv.FormatInt(value, 10)
+}
+
+func (c *Client) probeInstallationWithToken(ctx context.Context, input InstallationTokenRequest, token InstallationToken) (InstallationProbeResult, error) {
+	probeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/installation/repositories?per_page=1"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return InstallationProbeResult{}, err
+	}
+	setGitHubHeaders(req, token.Value)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return InstallationProbeResult{}, ctx.Err()
+		}
+		return InstallationProbeResult{}, ErrProviderUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return InstallationProbeResult{}, classifyGitHubResponse(resp)
+	}
+	var payload installationProbeResponse
+	decodeErr := json.NewDecoder(resp.Body).Decode(&payload)
+	if decodeErr != nil {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	if payload.TotalCount == nil || payload.Repositories == nil {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	return InstallationProbeResult{InstallationID: strings.TrimSpace(input.InstallationID), Suspended: false}, nil
 }

--- a/backend/internal/platform/githubapp/client.go
+++ b/backend/internal/platform/githubapp/client.go
@@ -1,0 +1,269 @@
+package githubapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultAPIVersion = "2022-11-28"
+
+var defaultTokenRefreshSkew = time.Minute
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type InstallationTokenRequest struct {
+	AppRegistrationID string
+	AppID             string
+	InstallationID    string
+	APIBaseURL        string
+	PrivateKeyPEM     string
+}
+
+type InstallationToken struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+type InstallationProbeResult struct {
+	InstallationID string
+	AccountLogin   string
+	Suspended      bool
+}
+
+type Client struct {
+	httpClient  httpDoer
+	signer      *JWTSigner
+	now         func() time.Time
+	refreshSkew time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedInstallationToken
+	wait  map[string]chan struct{}
+}
+
+type cachedInstallationToken struct {
+	token InstallationToken
+}
+
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		httpClient:  httpClient,
+		signer:      NewJWTSigner(),
+		now:         time.Now,
+		refreshSkew: defaultTokenRefreshSkew,
+		cache:       map[string]cachedInstallationToken{},
+		wait:        map[string]chan struct{}{},
+	}
+}
+
+func (c *Client) GetInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, error) {
+	key := installationCacheKey(input)
+	for {
+		now := c.now().UTC()
+		c.mu.Lock()
+		if entry, ok := c.cache[key]; ok && entry.token.Value != "" && now.Before(entry.token.ExpiresAt.Add(-c.refreshSkew)) {
+			token := entry.token
+			c.mu.Unlock()
+			return token, nil
+		}
+		if waitCh, ok := c.wait[key]; ok {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return InstallationToken{}, ctx.Err()
+			case <-waitCh:
+				continue
+			}
+		}
+		waitCh := make(chan struct{})
+		c.wait[key] = waitCh
+		c.mu.Unlock()
+
+		token, err := c.exchangeInstallationToken(ctx, input)
+
+		c.mu.Lock()
+		if err == nil {
+			c.cache[key] = cachedInstallationToken{token: token}
+		}
+		waitCh = c.wait[key]
+		delete(c.wait, key)
+		close(waitCh)
+		c.mu.Unlock()
+
+		if err != nil {
+			return InstallationToken{}, err
+		}
+		return token, nil
+	}
+}
+
+func (c *Client) ProbeInstallation(ctx context.Context, input InstallationTokenRequest) (InstallationProbeResult, error) {
+	token, err := c.GetInstallationToken(ctx, input)
+	if err != nil {
+		return InstallationProbeResult{}, err
+	}
+	probeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/installation"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return InstallationProbeResult{}, err
+	}
+	setGitHubHeaders(req, token.Value)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return InstallationProbeResult{}, ctx.Err()
+		}
+		return InstallationProbeResult{}, ErrProviderUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return InstallationProbeResult{}, classifyGitHubResponse(resp)
+	}
+	var payload struct {
+		ID          json.Number `json:"id"`
+		SuspendedAt *string     `json:"suspended_at"`
+		Account     struct {
+			Login string `json:"login"`
+		} `json:"account"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	installationID := strings.TrimSpace(payload.ID.String())
+	if installationID == "" {
+		return InstallationProbeResult{}, ErrMalformedResponse
+	}
+	if installationID != strings.TrimSpace(input.InstallationID) {
+		return InstallationProbeResult{}, ErrInstallationUnavailable
+	}
+	suspended := payload.SuspendedAt != nil && strings.TrimSpace(*payload.SuspendedAt) != ""
+	if suspended {
+		return InstallationProbeResult{}, ErrInstallationUnavailable
+	}
+	return InstallationProbeResult{InstallationID: installationID, AccountLogin: strings.TrimSpace(payload.Account.Login), Suspended: false}, nil
+}
+
+func (c *Client) exchangeInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, error) {
+	jwtToken, err := c.signer.Sign(input.AppID, input.PrivateKeyPEM)
+	if err != nil {
+		return InstallationToken{}, err
+	}
+	exchangeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/app/installations/" + url.PathEscape(strings.TrimSpace(input.InstallationID)) + "/access_tokens"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, exchangeURL, bytes.NewBufferString("{}"))
+	if err != nil {
+		return InstallationToken{}, err
+	}
+	setGitHubHeaders(req, jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return InstallationToken{}, ctx.Err()
+		}
+		return InstallationToken{}, ErrProviderUnavailable
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		return InstallationToken{}, classifyGitHubResponse(resp)
+	}
+	var payload struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	decodeErr := json.NewDecoder(resp.Body).Decode(&payload)
+	if decodeErr != nil {
+		return InstallationToken{}, ErrMalformedResponse
+	}
+	expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(payload.ExpiresAt))
+	if err != nil {
+		return InstallationToken{}, ErrMalformedResponse
+	}
+	if strings.TrimSpace(payload.Token) == "" {
+		return InstallationToken{}, ErrMalformedResponse
+	}
+	return InstallationToken{Value: strings.TrimSpace(payload.Token), ExpiresAt: expiresAt.UTC()}, nil
+}
+
+func installationCacheKey(input InstallationTokenRequest) string {
+	return strings.TrimSpace(input.AppRegistrationID) + "|" + strings.TrimSpace(input.InstallationID) + "|" + strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/")
+}
+
+func setGitHubHeaders(req *http.Request, bearerToken string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(bearerToken))
+	req.Header.Set("X-GitHub-Api-Version", defaultAPIVersion)
+}
+
+func classifyGitHubResponse(resp *http.Response) error {
+	message := readGitHubMessage(resp.Body)
+	if isRateLimited(resp, message) {
+		return ErrRateLimited
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrAuthentication
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		if strings.Contains(message, "suspend") || strings.Contains(message, "revok") || strings.Contains(message, "removed") {
+			return ErrInstallationUnavailable
+		}
+		return ErrAuthentication
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrInstallationUnavailable
+	}
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return ErrProviderUnavailable
+	}
+	return ErrProviderUnavailable
+}
+
+func isRateLimited(resp *http.Response, message string) bool {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if strings.TrimSpace(resp.Header.Get("Retry-After")) != "" {
+		return true
+	}
+	if strings.TrimSpace(resp.Header.Get("X-RateLimit-Remaining")) == "0" {
+		return true
+	}
+	return strings.Contains(message, "rate limit")
+}
+
+func readGitHubMessage(body io.Reader) string {
+	data, err := io.ReadAll(io.LimitReader(body, 4096))
+	if err != nil {
+		return ""
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return ""
+	}
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(payload.Message) != "" {
+		return strings.ToLower(strings.TrimSpace(payload.Message))
+	}
+	if json.Valid(data) {
+		return ""
+	}
+	return strings.ToLower(trimmed)
+}
+
+func installationIDString(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -3,8 +3,11 @@ package githubapp
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -89,20 +92,21 @@ func TestClient_GetInstallationToken_ClassifiesResponses(t *testing.T) {
 	}
 }
 
-func TestClient_ProbeInstallation_SuspendedAndHealthy(t *testing.T) {
+func TestClient_ProbeInstallation_UsesDocumentedEndpointsAndPopulatesIdentity(t *testing.T) {
 	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
 	for _, tc := range []struct {
 		name       string
 		apiBaseURL string
-		wantPath   string
+		wantRepo   string
+		wantDetail string
 	}{
-		{name: "github.com", apiBaseURL: "https://api.github.com", wantPath: "/installation/repositories"},
-		{name: "ghes", apiBaseURL: "/api/v3", wantPath: "/api/v3/installation/repositories"},
+		{name: "github.com", apiBaseURL: "https://api.github.com", wantRepo: "/installation/repositories", wantDetail: "/app/installations/999"},
+		{name: "ghes", apiBaseURL: "/api/v3", wantRepo: "/api/v3/installation/repositories", wantDetail: "/api/v3/app/installations/999"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
-				case tc.wantPath:
+				case tc.wantRepo:
 					if got := r.URL.Query().Get("per_page"); got != "1" {
 						t.Fatalf("expected per_page=1, got %q", got)
 					}
@@ -110,6 +114,11 @@ func TestClient_ProbeInstallation_SuspendedAndHealthy(t *testing.T) {
 						t.Fatalf("expected installation token auth, got %q", got)
 					}
 					_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "repositories": []map[string]any{{"id": 1}}})
+				case tc.wantDetail:
+					if got := r.Header.Get("Authorization"); got == "" || got == "Bearer ghs_probe" {
+						t.Fatalf("expected app jwt auth, got %q", got)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
 				default:
 					http.NotFound(w, r)
 				}
@@ -125,8 +134,41 @@ func TestClient_ProbeInstallation_SuspendedAndHealthy(t *testing.T) {
 			if err != nil {
 				t.Fatalf("probe installation: %v", err)
 			}
-			if result.InstallationID != "999" {
+			if result.InstallationID != "999" || result.AccountLogin != "octo" || result.Suspended {
 				t.Fatalf("unexpected probe result: %+v", result)
+			}
+		})
+	}
+}
+
+func TestClient_ProbeInstallation_RejectsSuspendedAndMismatchedInstallation(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, tc := range []struct {
+		name            string
+		installationDoc map[string]any
+		wantErr         error
+	}{
+		{name: "suspended", installationDoc: map[string]any{"id": 999, "suspended_at": time.Now().UTC().Format(time.RFC3339), "account": map[string]any{"login": "octo"}}, wantErr: ErrInstallationUnavailable},
+		{name: "mismatched id", installationDoc: map[string]any{"id": 1000, "account": map[string]any{"login": "octo"}}, wantErr: ErrInstallationUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/installation/repositories":
+					_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "repositories": []map[string]any{{"id": 1}}})
+				case "/app/installations/999":
+					_ = json.NewEncoder(w).Encode(tc.installationDoc)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			client := NewClient(server.Client())
+			request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+			client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "ghs_probe", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+			_, err := client.ProbeInstallation(context.Background(), request)
+			if err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
 			}
 		})
 	}
@@ -153,6 +195,8 @@ func TestClient_ProbeInstallation_Cached401InvalidatesRefreshesAndRetriesOnce(t 
 			default:
 				t.Fatalf("unexpected auth header %q", r.Header.Get("Authorization"))
 			}
+		case "/app/installations/999":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -188,6 +232,8 @@ func TestClient_ProbeInstallation_Second401ReturnsFailureWithoutExtraRetry(t *te
 			probeCalls.Add(1)
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"message":"bad credentials"}`))
+		case "/app/installations/999":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -228,20 +274,33 @@ func TestClient_ProbeInstallation_MalformedAndFailureClassification(t *testing.T
 		statusCode int
 		headers    map[string]string
 		body       string
+		detailBody map[string]any
 		wantErr    error
 	}{
-		{name: "malformed success", statusCode: http.StatusOK, body: `{"repositories":[]}`, wantErr: ErrMalformedResponse},
+		{name: "malformed repositories", statusCode: http.StatusOK, body: `{"repositories":[]}`, wantErr: ErrMalformedResponse},
 		{name: "installation unavailable", statusCode: http.StatusNotFound, body: `{"message":"not found"}`, wantErr: ErrInstallationUnavailable},
 		{name: "rate limited", statusCode: http.StatusForbidden, headers: map[string]string{"X-RateLimit-Remaining": "0"}, body: `{"message":"API rate limit exceeded"}`, wantErr: ErrRateLimited},
 		{name: "provider unavailable", statusCode: http.StatusBadGateway, body: `{"message":"bad gateway"}`, wantErr: ErrProviderUnavailable},
+		{name: "malformed installation details", statusCode: http.StatusOK, body: `{"total_count":0,"repositories":[]}`, detailBody: map[string]any{"id": 999}, wantErr: ErrMalformedResponse},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				for key, value := range tc.headers {
-					w.Header().Set(key, value)
+				switch r.URL.Path {
+				case "/installation/repositories":
+					for key, value := range tc.headers {
+						w.Header().Set(key, value)
+					}
+					w.WriteHeader(tc.statusCode)
+					_, _ = w.Write([]byte(tc.body))
+				case "/app/installations/999":
+					if tc.detailBody == nil {
+						_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(tc.detailBody)
+				default:
+					http.NotFound(w, r)
 				}
-				w.WriteHeader(tc.statusCode)
-				_, _ = w.Write([]byte(tc.body))
 			}))
 			defer server.Close()
 			client := NewClient(server.Client())
@@ -252,6 +311,28 @@ func TestClient_ProbeInstallation_MalformedAndFailureClassification(t *testing.T
 				t.Fatalf("expected %v, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestClient_ProbeInstallation_BoundsLargeSuccessBodyReads(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/installation/repositories":
+			_, _ = w.Write([]byte(`{"total_count":1,"repositories":[{"id":1,"name":"` + strings.Repeat("a", maxGitHubProbeResponseBytes) + `"}]}`))
+		case "/app/installations/999":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+	client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "ghs_probe", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+	_, err := client.ProbeInstallation(context.Background(), request)
+	if err != ErrMalformedResponse {
+		t.Fatalf("expected malformed response for oversized success body, got %v", err)
 	}
 }
 
@@ -380,9 +461,74 @@ func TestClient_TokenCacheKeyIsolation(t *testing.T) {
 	}
 }
 
+func TestClient_ResponseHelpers(t *testing.T) {
+	if got := readGitHubMessage(strings.NewReader(`{"message":"Bad Credentials"}`)); got != "bad credentials" {
+		t.Fatalf("expected lower-cased github message, got %q", got)
+	}
+	if got := readGitHubMessage(strings.NewReader(`{"other":"value"}`)); got != "" {
+		t.Fatalf("expected empty message for valid json without message field, got %q", got)
+	}
+	if got := readGitHubMessage(strings.NewReader("  Plain Failure  ")); got != "plain failure" {
+		t.Fatalf("expected lower-cased raw body, got %q", got)
+	}
+
+	var payload map[string]any
+	decodeErr := decodeGitHubJSON(strings.NewReader(`{"message":"abcdefghijklmnopqrstuvwxyz"}`), 8, &payload)
+	if decodeErr == nil {
+		t.Fatal("expected bounded decode failure")
+	}
+
+	if !isRateLimited(&http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header)}, "") {
+		t.Fatal("expected 429 to be treated as rate limited")
+	}
+	resp := &http.Response{StatusCode: http.StatusForbidden, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"message":"Installation suspended"}`))}
+	if got := classifyGitHubResponse(resp); got != ErrInstallationUnavailable {
+		t.Fatalf("expected suspended installation classification, got %v", got)
+	}
+	resp = &http.Response{StatusCode: http.StatusForbidden, Header: http.Header{"Retry-After": []string{"60"}}, Body: io.NopCloser(strings.NewReader(`{"message":"slow down"}`))}
+	if got := classifyGitHubResponse(resp); got != ErrRateLimited {
+		t.Fatalf("expected retry-after classification, got %v", got)
+	}
+	resp = &http.Response{StatusCode: http.StatusForbidden, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"message":"Bad credentials"}`))}
+	if got := classifyGitHubResponse(resp); got != ErrAuthentication {
+		t.Fatalf("expected auth classification, got %v", got)
+	}
+}
+
+func TestClient_GetInstallationToken_TransportErrorBranches(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: "https://api.github.com", PrivateKeyPEM: privateKeyPEM}
+
+	client := NewClient(nil)
+	client.httpClient = stubHTTPDoer(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	})
+	_, err := client.GetInstallationToken(context.Background(), request)
+	if err != ErrProviderUnavailable {
+		t.Fatalf("expected provider unavailable, got %v", err)
+	}
+
+	canceledClient := NewClient(nil)
+	canceledClient.httpClient = stubHTTPDoer(func(req *http.Request) (*http.Response, error) {
+		return nil, req.Context().Err()
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = canceledClient.GetInstallationToken(ctx, request)
+	if err != context.Canceled {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
 func probeBaseURL(serverURL string, apiBaseURL string) string {
 	if apiBaseURL == "https://api.github.com" {
 		return serverURL
 	}
 	return serverURL + apiBaseURL
+}
+
+type stubHTTPDoer func(req *http.Request) (*http.Response, error)
+
+func (f stubHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -91,44 +91,167 @@ func TestClient_GetInstallationToken_ClassifiesResponses(t *testing.T) {
 
 func TestClient_ProbeInstallation_SuspendedAndHealthy(t *testing.T) {
 	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, tc := range []struct {
+		name       string
+		apiBaseURL string
+		wantPath   string
+	}{
+		{name: "github.com", apiBaseURL: "https://api.github.com", wantPath: "/installation/repositories"},
+		{name: "ghes", apiBaseURL: "/api/v3", wantPath: "/api/v3/installation/repositories"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case tc.wantPath:
+					if got := r.URL.Query().Get("per_page"); got != "1" {
+						t.Fatalf("expected per_page=1, got %q", got)
+					}
+					if got := r.Header.Get("Authorization"); got != "Bearer ghs_probe" {
+						t.Fatalf("expected installation token auth, got %q", got)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "repositories": []map[string]any{{"id": 1}}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			client := NewClient(server.Client())
+			client.cache = map[string]cachedInstallationToken{
+				installationCacheKey(InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: probeBaseURL(server.URL, tc.apiBaseURL), PrivateKeyPEM: privateKeyPEM}): {
+					token: InstallationToken{Value: "ghs_probe", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()},
+				},
+			}
+			result, err := client.ProbeInstallation(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: probeBaseURL(server.URL, tc.apiBaseURL), PrivateKeyPEM: privateKeyPEM})
+			if err != nil {
+				t.Fatalf("probe installation: %v", err)
+			}
+			if result.InstallationID != "999" {
+				t.Fatalf("unexpected probe result: %+v", result)
+			}
+		})
+	}
+}
+
+func TestClient_ProbeInstallation_Cached401InvalidatesRefreshesAndRetriesOnce(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var exchangeCalls atomic.Int32
+	var probeCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/app/installations/999/access_tokens":
+			exchangeCalls.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_probe", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
-		case "/installation":
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_fresh", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+		case "/installation/repositories":
+			probeCalls.Add(1)
+			switch r.Header.Get("Authorization") {
+			case "Bearer ghs_cached":
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"message":"bad credentials"}`))
+			case "Bearer ghs_fresh":
+				_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "repositories": []map[string]any{}})
+			default:
+				t.Fatalf("unexpected auth header %q", r.Header.Get("Authorization"))
+			}
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
 	client := NewClient(server.Client())
-	result, err := client.ProbeInstallation(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM})
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+	client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "ghs_cached", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+
+	result, err := client.ProbeInstallation(context.Background(), request)
 	if err != nil {
 		t.Fatalf("probe installation: %v", err)
 	}
-	if result.InstallationID != "999" || result.AccountLogin != "octo" {
-		t.Fatalf("unexpected probe result: %+v", result)
+	if result.InstallationID != "999" {
+		t.Fatalf("unexpected result: %+v", result)
 	}
+	if exchangeCalls.Load() != 1 || probeCalls.Load() != 2 {
+		t.Fatalf("expected 1 exchange and 2 probe calls, got exchanges=%d probes=%d", exchangeCalls.Load(), probeCalls.Load())
+	}
+}
 
-	suspendedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestClient_ProbeInstallation_Second401ReturnsFailureWithoutExtraRetry(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var exchangeCalls atomic.Int32
+	var probeCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/app/installations/999/access_tokens":
+			exchangeCalls.Add(1)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_probe", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
-		case "/installation":
-			timestamp := time.Now().UTC().Format(time.RFC3339)
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "suspended_at": timestamp})
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_fresh", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+		case "/installation/repositories":
+			probeCalls.Add(1)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"bad credentials"}`))
 		default:
 			http.NotFound(w, r)
 		}
 	}))
-	defer suspendedServer.Close()
-	client = NewClient(suspendedServer.Client())
-	_, err = client.ProbeInstallation(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: suspendedServer.URL, PrivateKeyPEM: privateKeyPEM})
-	if err != ErrInstallationUnavailable {
-		t.Fatalf("expected installation unavailable, got %v", err)
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+	client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "ghs_cached", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+
+	_, err := client.ProbeInstallation(context.Background(), request)
+	if err != ErrAuthentication {
+		t.Fatalf("expected auth failure, got %v", err)
+	}
+	if exchangeCalls.Load() != 1 || probeCalls.Load() != 2 {
+		t.Fatalf("expected one refresh retry, got exchanges=%d probes=%d", exchangeCalls.Load(), probeCalls.Load())
+	}
+}
+
+func TestClient_ProbeInstallation_ConditionalInvalidationKeepsNewerToken(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: "https://api.github.com", PrivateKeyPEM: privateKeyPEM}
+	cacheKey := installationCacheKey(request)
+	client := NewClient(nil)
+	oldToken := InstallationToken{Value: "ghs_old", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}
+	newToken := InstallationToken{Value: "ghs_new", ExpiresAt: time.Now().Add(20 * time.Minute).UTC()}
+	client.cache[cacheKey] = cachedInstallationToken{token: newToken}
+	client.invalidateCachedToken(request, oldToken)
+	entry, ok := client.cache[cacheKey]
+	if !ok || entry.token != newToken {
+		t.Fatalf("expected newer token to remain cached, got %+v exists=%t", entry.token, ok)
+	}
+}
+
+func TestClient_ProbeInstallation_MalformedAndFailureClassification(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		headers    map[string]string
+		body       string
+		wantErr    error
+	}{
+		{name: "malformed success", statusCode: http.StatusOK, body: `{"repositories":[]}`, wantErr: ErrMalformedResponse},
+		{name: "installation unavailable", statusCode: http.StatusNotFound, body: `{"message":"not found"}`, wantErr: ErrInstallationUnavailable},
+		{name: "rate limited", statusCode: http.StatusForbidden, headers: map[string]string{"X-RateLimit-Remaining": "0"}, body: `{"message":"API rate limit exceeded"}`, wantErr: ErrRateLimited},
+		{name: "provider unavailable", statusCode: http.StatusBadGateway, body: `{"message":"bad gateway"}`, wantErr: ErrProviderUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for key, value := range tc.headers {
+					w.Header().Set(key, value)
+				}
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			client := NewClient(server.Client())
+			request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+			client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "ghs_probe", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+			_, err := client.ProbeInstallation(context.Background(), request)
+			if err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 
@@ -255,4 +378,11 @@ func TestClient_TokenCacheKeyIsolation(t *testing.T) {
 	if callCount.Load() != int32(len(requests)) {
 		t.Fatalf("expected isolated cache keys, got %d calls", callCount.Load())
 	}
+}
+
+func probeBaseURL(serverURL string, apiBaseURL string) string {
+	if apiBaseURL == "https://api.github.com" {
+		return serverURL
+	}
+	return serverURL + apiBaseURL
 }

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -1,0 +1,258 @@
+package githubapp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClient_GetInstallationToken_ExchangesTokenForGitHubDotComAndGHES(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, tc := range []struct {
+		name       string
+		apiBaseURL string
+		wantPath   string
+	}{
+		{name: "github.com", apiBaseURL: "https://api.github.com", wantPath: "/app/installations/999/access_tokens"},
+		{name: "ghes", apiBaseURL: "/api/v3", wantPath: "/api/v3/app/installations/999/access_tokens"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.wantPath {
+					t.Fatalf("expected path %q, got %q", tc.wantPath, r.URL.Path)
+				}
+				if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+					t.Fatalf("expected github accept header, got %q", got)
+				}
+				if got := r.Header.Get("Authorization"); got == "" {
+					t.Fatal("expected authorization header")
+				}
+				if got := r.Header.Get("X-GitHub-Api-Version"); got != defaultAPIVersion {
+					t.Fatalf("expected github api version header, got %q", got)
+				}
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_token", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+			}))
+			defer server.Close()
+			client := NewClient(server.Client())
+			client.now = func() time.Time { return time.Date(2026, 7, 17, 16, 0, 0, 0, time.UTC) }
+			apiBaseURL := server.URL + tc.apiBaseURL
+			if tc.name == "github.com" {
+				apiBaseURL = server.URL
+			}
+			token, err := client.GetInstallationToken(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: apiBaseURL, PrivateKeyPEM: privateKeyPEM})
+			if err != nil {
+				t.Fatalf("get token: %v", err)
+			}
+			if token.Value != "ghs_token" {
+				t.Fatalf("expected token value, got %q", token.Value)
+			}
+		})
+	}
+}
+
+func TestClient_GetInstallationToken_ClassifiesResponses(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		headers    map[string]string
+		body       string
+		wantErr    error
+	}{
+		{name: "malformed success", statusCode: http.StatusCreated, body: `{"token":"","expires_at":"bad"}`, wantErr: ErrMalformedResponse},
+		{name: "auth", statusCode: http.StatusUnauthorized, body: `{"message":"bad credentials"}`, wantErr: ErrAuthentication},
+		{name: "installation unavailable", statusCode: http.StatusNotFound, body: `{"message":"not found"}`, wantErr: ErrInstallationUnavailable},
+		{name: "rate limited", statusCode: http.StatusForbidden, headers: map[string]string{"X-RateLimit-Remaining": "0"}, body: `{"message":"API rate limit exceeded"}`, wantErr: ErrRateLimited},
+		{name: "server", statusCode: http.StatusBadGateway, body: `{"message":"bad gateway"}`, wantErr: ErrProviderUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for key, value := range tc.headers {
+					w.Header().Set(key, value)
+				}
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			client := NewClient(server.Client())
+			_, err := client.GetInstallationToken(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM})
+			if err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestClient_ProbeInstallation_SuspendedAndHealthy(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations/999/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_probe", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+		case "/installation":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "account": map[string]any{"login": "octo"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	result, err := client.ProbeInstallation(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM})
+	if err != nil {
+		t.Fatalf("probe installation: %v", err)
+	}
+	if result.InstallationID != "999" || result.AccountLogin != "octo" {
+		t.Fatalf("unexpected probe result: %+v", result)
+	}
+
+	suspendedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/app/installations/999/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "ghs_probe", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+		case "/installation":
+			timestamp := time.Now().UTC().Format(time.RFC3339)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 999, "suspended_at": timestamp})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer suspendedServer.Close()
+	client = NewClient(suspendedServer.Client())
+	_, err = client.ProbeInstallation(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: suspendedServer.URL, PrivateKeyPEM: privateKeyPEM})
+	if err != ErrInstallationUnavailable {
+		t.Fatalf("expected installation unavailable, got %v", err)
+	}
+}
+
+func TestClient_TokenCacheBehavior(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": installationIDString(int64(callCount.Load())), "expires_at": time.Date(2026, 7, 17, 17, 0, 0, 0, time.UTC).Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	clock := time.Date(2026, 7, 17, 16, 0, 0, 0, time.UTC)
+	client.now = func() time.Time { return clock }
+	client.refreshSkew = time.Minute
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+
+	first, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first token: %v", err)
+	}
+	second, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("second token: %v", err)
+	}
+	if first.Value != second.Value || callCount.Load() != 1 {
+		t.Fatalf("expected cached token reuse, got first=%q second=%q calls=%d", first.Value, second.Value, callCount.Load())
+	}
+
+	clock = time.Date(2026, 7, 17, 16, 59, 30, 0, time.UTC)
+	third, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("third token: %v", err)
+	}
+	if third.Value == first.Value || callCount.Load() != 2 {
+		t.Fatalf("expected refresh after skew, got first=%q third=%q calls=%d", first.Value, third.Value, callCount.Load())
+	}
+}
+
+func TestClient_TokenCacheSingleflightAndFailureRecovery(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var callCount atomic.Int32
+	start := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := callCount.Add(1)
+		if current == 1 {
+			close(start)
+			<-release
+		}
+		if current == 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"boom"}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": installationIDString(int64(current)), "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 4)
+	results := make(chan InstallationToken, 4)
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			token, err := client.GetInstallationToken(context.Background(), request)
+			errs <- err
+			results <- token
+		}()
+	}
+	<-start
+	close(release)
+	wg.Wait()
+	close(errs)
+	close(results)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("expected no concurrent refresh errors, got %v", err)
+		}
+	}
+	if callCount.Load() != 1 {
+		t.Fatalf("expected one refresh call, got %d", callCount.Load())
+	}
+
+	client.cache = map[string]cachedInstallationToken{}
+	_, err := client.GetInstallationToken(context.Background(), request)
+	if err != ErrProviderUnavailable {
+		t.Fatalf("expected provider unavailable on failed refresh, got %v", err)
+	}
+	token, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("expected refresh recovery, got %v", err)
+	}
+	if token.Value != "3" {
+		t.Fatalf("expected recovered token value 3, got %q", token.Value)
+	}
+}
+
+func TestClient_TokenCacheKeyIsolation(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": installationIDString(int64(callCount.Load())), "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	requests := []InstallationTokenRequest{
+		{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM},
+		{AppRegistrationID: "registration-2", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM},
+		{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "1000", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM},
+	}
+	for _, request := range requests {
+		if _, err := client.GetInstallationToken(context.Background(), request); err != nil {
+			t.Fatalf("get token: %v", err)
+		}
+	}
+	if callCount.Load() != int32(len(requests)) {
+		t.Fatalf("expected isolated cache keys, got %d calls", callCount.Load())
+	}
+}

--- a/backend/internal/platform/githubapp/errors.go
+++ b/backend/internal/platform/githubapp/errors.go
@@ -1,0 +1,12 @@
+package githubapp
+
+import "errors"
+
+var ErrPrivateKeyMissing = errors.New("github app private key is required")
+var ErrPrivateKeyMalformed = errors.New("github app private key is malformed")
+var ErrPrivateKeyNotRSA = errors.New("github app private key must be an rsa private key")
+var ErrAuthentication = errors.New("github app authentication failed")
+var ErrInstallationUnavailable = errors.New("github app installation is unavailable")
+var ErrRateLimited = errors.New("github app request was rate limited")
+var ErrProviderUnavailable = errors.New("github app provider is unavailable")
+var ErrMalformedResponse = errors.New("github app provider response was malformed")

--- a/backend/internal/platform/githubapp/jwt.go
+++ b/backend/internal/platform/githubapp/jwt.go
@@ -1,0 +1,99 @@
+package githubapp
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"time"
+)
+
+const (
+	jwtIssuedAtSkew = time.Minute
+	jwtLifetime     = 9 * time.Minute
+)
+
+type JWTSigner struct {
+	now func() time.Time
+}
+
+func NewJWTSigner() *JWTSigner {
+	return &JWTSigner{now: time.Now}
+}
+
+func (s *JWTSigner) Sign(appID string, privateKeyPEM string) (string, error) {
+	trimmedAppID := strings.TrimSpace(appID)
+	if trimmedAppID == "" {
+		return "", ErrAuthentication
+	}
+	privateKey, err := parseRSAPrivateKey(privateKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	now := time.Now().UTC()
+	if s != nil && s.now != nil {
+		now = s.now().UTC()
+	}
+	issuedAt := now.Add(-jwtIssuedAtSkew).Unix()
+	expiresAt := now.Add(jwtLifetime).Unix()
+
+	headerBytes, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+	claimsBytes, err := json.Marshal(map[string]any{"iss": trimmedAppID, "iat": issuedAt, "exp": expiresAt})
+	if err != nil {
+		return "", err
+	}
+	encodedHeader := base64.RawURLEncoding.EncodeToString(headerBytes)
+	encodedClaims := base64.RawURLEncoding.EncodeToString(claimsBytes)
+	signingInput := encodedHeader + "." + encodedClaims
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func parseRSAPrivateKey(privateKeyPEM string) (*rsa.PrivateKey, error) {
+	trimmed := strings.TrimSpace(privateKeyPEM)
+	if trimmed == "" {
+		return nil, ErrPrivateKeyMissing
+	}
+	block, _ := pem.Decode([]byte(trimmed))
+	if block == nil {
+		return nil, ErrPrivateKeyMalformed
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, ErrPrivateKeyMalformed
+	}
+	rsaKey, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, ErrPrivateKeyNotRSA
+	}
+	return rsaKey, nil
+}
+
+func verifyJWTSignature(token string, publicKey *rsa.PublicKey) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return errors.New("invalid token")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, digest[:], signature)
+}

--- a/backend/internal/platform/githubapp/jwt_test.go
+++ b/backend/internal/platform/githubapp/jwt_test.go
@@ -55,6 +55,9 @@ func TestJWTSigner_SignsRS256WithExpectedClaims(t *testing.T) {
 
 func TestJWTSigner_PrivateKeyValidation(t *testing.T) {
 	signer := NewJWTSigner()
+	if _, err := signer.Sign("", "not-used"); err != ErrAuthentication {
+		t.Fatalf("expected blank app id auth error, got %v", err)
+	}
 	if _, err := signer.Sign("12345", ""); err != ErrPrivateKeyMissing {
 		t.Fatalf("expected missing key error, got %v", err)
 	}
@@ -72,6 +75,36 @@ func TestJWTSigner_PrivateKeyValidation(t *testing.T) {
 	ecPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: ecDER}))
 	if _, err := signer.Sign("12345", ecPEM); err != ErrPrivateKeyNotRSA {
 		t.Fatalf("expected non-rsa key error, got %v", err)
+	}
+}
+
+func TestJWTSigner_SupportsPKCS8AndRejectsInvalidSignatures(t *testing.T) {
+	pkcs1PEM, privateKey := testRSAPrivateKeyPEM(t)
+	parsedKey, parseErr := parseRSAPrivateKey(pkcs1PEM)
+	if parseErr != nil {
+		t.Fatalf("parse pkcs1 private key: %v", parseErr)
+	}
+	pkcs8DER, marshalErr := x509.MarshalPKCS8PrivateKey(parsedKey)
+	if marshalErr != nil {
+		t.Fatalf("marshal pkcs8 private key: %v", marshalErr)
+	}
+	pkcs8PEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8DER}))
+	signer := NewJWTSigner()
+	token, signErr := signer.Sign("12345", pkcs8PEM)
+	if signErr != nil {
+		t.Fatalf("sign pkcs8 jwt: %v", signErr)
+	}
+	if err := verifyJWTSignature(token, &privateKey.PublicKey); err != nil {
+		t.Fatalf("verify pkcs8 signature: %v", err)
+	}
+	if err := verifyJWTSignature("bad.token", &privateKey.PublicKey); err == nil {
+		t.Fatal("expected invalid token verification failure")
+	}
+	parts := strings.Split(token, ".")
+	tamperedClaims := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"tampered"}`))
+	tampered := parts[0] + "." + tamperedClaims + "." + parts[2]
+	if err := verifyJWTSignature(tampered, &privateKey.PublicKey); err == nil {
+		t.Fatal("expected tampered token verification failure")
 	}
 }
 

--- a/backend/internal/platform/githubapp/jwt_test.go
+++ b/backend/internal/platform/githubapp/jwt_test.go
@@ -1,0 +1,96 @@
+package githubapp
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJWTSigner_SignsRS256WithExpectedClaims(t *testing.T) {
+	privateKeyPEM, privateKey := testRSAPrivateKeyPEM(t)
+	clock := time.Date(2026, 7, 17, 15, 0, 0, 0, time.UTC)
+	signer := NewJWTSigner()
+	signer.now = func() time.Time { return clock }
+
+	token, err := signer.Sign("12345", privateKeyPEM)
+	if err != nil {
+		t.Fatalf("sign jwt: %v", err)
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected jwt with 3 parts, got %d", len(parts))
+	}
+	var header map[string]string
+	decodeJWTPart(t, parts[0], &header)
+	if header["alg"] != "RS256" || header["typ"] != "JWT" {
+		t.Fatalf("unexpected jwt header: %+v", header)
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	decodeJWTPart(t, parts[1], &claims)
+	if claims.Iss != "12345" {
+		t.Fatalf("expected iss claim 12345, got %v", claims.Iss)
+	}
+	if got := claims.Iat; got != clock.Add(-jwtIssuedAtSkew).Unix() {
+		t.Fatalf("expected iat %d, got %d", clock.Add(-jwtIssuedAtSkew).Unix(), got)
+	}
+	if got := claims.Exp; got != clock.Add(jwtLifetime).Unix() {
+		t.Fatalf("expected exp %d, got %d", clock.Add(jwtLifetime).Unix(), got)
+	}
+	if err := verifyJWTSignature(token, &privateKey.PublicKey); err != nil {
+		t.Fatalf("verify signature: %v", err)
+	}
+}
+
+func TestJWTSigner_PrivateKeyValidation(t *testing.T) {
+	signer := NewJWTSigner()
+	if _, err := signer.Sign("12345", ""); err != ErrPrivateKeyMissing {
+		t.Fatalf("expected missing key error, got %v", err)
+	}
+	if _, err := signer.Sign("12345", "not-pem"); err != ErrPrivateKeyMalformed {
+		t.Fatalf("expected malformed key error, got %v", err)
+	}
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ec key: %v", err)
+	}
+	ecDER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		t.Fatalf("marshal ec key: %v", err)
+	}
+	ecPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: ecDER}))
+	if _, err := signer.Sign("12345", ecPEM); err != ErrPrivateKeyNotRSA {
+		t.Fatalf("expected non-rsa key error, got %v", err)
+	}
+}
+
+func decodeJWTPart(t *testing.T, value string, dest any) {
+	t.Helper()
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		t.Fatalf("decode jwt part: %v", err)
+	}
+	if err := json.Unmarshal(decoded, dest); err != nil {
+		t.Fatalf("unmarshal jwt part: %v", err)
+	}
+}
+
+func testRSAPrivateKeyPEM(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})), privateKey
+}

--- a/backend/internal/platform/secret/resolver.go
+++ b/backend/internal/platform/secret/resolver.go
@@ -1,0 +1,40 @@
+package secret
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+)
+
+var ErrSecretRefRequired = errors.New("secret ref is required")
+var ErrSecretNotFound = errors.New("secret is not configured")
+
+type Resolver interface {
+	Resolve(ctx context.Context, ref string) (string, error)
+}
+
+type EnvResolver struct {
+	lookup func(string) (string, bool)
+}
+
+func NewEnvResolver() *EnvResolver {
+	return &EnvResolver{lookup: os.LookupEnv}
+}
+
+func (r *EnvResolver) Resolve(_ context.Context, ref string) (string, error) {
+	trimmedRef := strings.TrimSpace(ref)
+	if trimmedRef == "" {
+		return "", ErrSecretRefRequired
+	}
+	lookup := os.LookupEnv
+	if r != nil && r.lookup != nil {
+		lookup = r.lookup
+	}
+	value, ok := lookup(trimmedRef)
+	trimmedValue := strings.TrimSpace(value)
+	if !ok || trimmedValue == "" {
+		return "", ErrSecretNotFound
+	}
+	return trimmedValue, nil
+}

--- a/backend/internal/repository/memory/scm_connection_repository.go
+++ b/backend/internal/repository/memory/scm_connection_repository.go
@@ -146,6 +146,22 @@ func (r *SCMConnectionRepository) SetEnabled(_ context.Context, id string, enabl
 	return r.detailLocked(id), nil
 }
 
+func (r *SCMConnectionRepository) UpdateHealth(_ context.Context, id string, status domain.SCMConnectionHealthStatus, summary *string, checkedAt time.Time, updatedAt time.Time) (domain.SCMConnectionDetail, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	connection, ok := r.connections[id]
+	if !ok {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+	}
+	connection.HealthStatus = status
+	connection.HealthSummary = summary
+	checkedAtUTC := checkedAt.UTC()
+	connection.LastHealthCheckedAt = &checkedAtUTC
+	connection.UpdatedAt = updatedAt.UTC()
+	r.connections[id] = connection
+	return r.detailLocked(id), nil
+}
+
 func (r *SCMConnectionRepository) detailLocked(connectionID string) domain.SCMConnectionDetail {
 	connection := r.connections[connectionID]
 	installation, ok := r.githubAppInstallations[connectionID]

--- a/backend/internal/repository/memory/scm_connection_repository_test.go
+++ b/backend/internal/repository/memory/scm_connection_repository_test.go
@@ -50,6 +50,13 @@ func TestSCMConnectionRepository_CreateListGetAndSetEnabled(t *testing.T) {
 	if updated.Connection.Enabled {
 		t.Fatal("expected connection to be disabled")
 	}
+	healthy, healthErr := repo.UpdateHealth(context.Background(), "connection-1", domain.SCMConnectionHealthStatusHealthy, stringPointer("ok"), now.Add(2*time.Minute), now.Add(2*time.Minute))
+	if healthErr != nil {
+		t.Fatalf("update health failed: %v", healthErr)
+	}
+	if healthy.Connection.HealthStatus != domain.SCMConnectionHealthStatusHealthy || healthy.Connection.HealthSummary == nil || *healthy.Connection.HealthSummary != "ok" {
+		t.Fatalf("expected healthy metadata, got %+v", healthy.Connection)
+	}
 }
 
 func TestSCMConnectionRepository_ListAndGetGitHubAppRegistrations(t *testing.T) {
@@ -160,4 +167,8 @@ func testGitHubConnectionDetail(now time.Time, connectionID string, registration
 		GitHubAppRegistration: &registration,
 		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registration.ID, InstallationID: installationID, AccountLogin: accountLogin, AccountType: "organization", AccountID: installationID + "-account", CreatedAt: now, UpdatedAt: now},
 	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }

--- a/backend/internal/repository/memory/scm_connection_repository_test.go
+++ b/backend/internal/repository/memory/scm_connection_repository_test.go
@@ -105,6 +105,15 @@ func TestSCMConnectionRepository_ListAndGetGitHubAppRegistrations(t *testing.T) 
 	}
 }
 
+func TestSCMConnectionRepository_UpdateHealthMissingConnection(t *testing.T) {
+	repo := NewSCMConnectionRepository()
+	now := time.Now().UTC()
+	_, err := repo.UpdateHealth(context.Background(), "missing", domain.SCMConnectionHealthStatusHealthy, stringPointer("ok"), now, now)
+	if !errors.Is(err, repository.ErrSCMConnectionNotFound) {
+		t.Fatalf("expected missing connection error, got %v", err)
+	}
+}
+
 func TestSCMConnectionRepository_ReusesMatchingGitHubAppRegistrationAndScopesInstallationUniqueness(t *testing.T) {
 	repo := NewSCMConnectionRepository()
 	now := time.Now().UTC()

--- a/backend/internal/repository/postgres/scm_connection_repository.go
+++ b/backend/internal/repository/postgres/scm_connection_repository.go
@@ -233,6 +233,23 @@ func (r *SCMConnectionRepository) SetEnabled(ctx context.Context, id string, ena
 	return r.GetByID(ctx, returnedID)
 }
 
+func (r *SCMConnectionRepository) UpdateHealth(ctx context.Context, id string, status domain.SCMConnectionHealthStatus, summary *string, checkedAt time.Time, updatedAt time.Time) (domain.SCMConnectionDetail, error) {
+	const query = `
+		UPDATE scm_connections
+		SET health_status = $2, health_summary = $3, last_health_checked_at = $4, updated_at = $5
+		WHERE id = $1
+		RETURNING id
+	`
+	var returnedID string
+	if err := r.db.QueryRowContext(ctx, query, id, string(status), summary, checkedAt.UTC(), updatedAt.UTC()).Scan(&returnedID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+	return r.GetByID(ctx, returnedID)
+}
+
 func getGitHubAppRegistrationForUpdate(ctx context.Context, tx *sql.Tx, registrationID string) (domain.GitHubAppRegistration, error) {
 	const query = `
 		SELECT id, app_id, display_name, api_base_url, web_base_url, private_key_secret_ref, webhook_secret_ref, created_at, updated_at

--- a/backend/internal/repository/postgres/scm_connection_repository_test.go
+++ b/backend/internal/repository/postgres/scm_connection_repository_test.go
@@ -210,6 +210,14 @@ func TestSCMConnectionRepository_GetListAndSetEnabled(t *testing.T) {
 		t.Fatalf("expected updated connection id, got %q", updated.Connection.ID)
 	}
 
+	checkedAt := now.Add(2 * time.Minute)
+	summary := "healthy"
+	mock.ExpectQuery("UPDATE scm_connections").WithArgs("connection-1", string(domain.SCMConnectionHealthStatusHealthy), &summary, checkedAt, checkedAt).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("connection-1"))
+	mock.ExpectQuery(`SELECT .* FROM scm_connections c.*WHERE c.id = \$1`).WithArgs("connection-1").WillReturnRows(scmConnectionDetailTestRows(now))
+	if _, err := repo.UpdateHealth(context.Background(), "connection-1", domain.SCMConnectionHealthStatusHealthy, &summary, checkedAt, checkedAt); err != nil {
+		t.Fatalf("update health failed: %v", err)
+	}
+
 	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
 		t.Fatalf("unmet expectations: %v", expectationsErr)
 	}

--- a/backend/internal/repository/scm_connection_repository.go
+++ b/backend/internal/repository/scm_connection_repository.go
@@ -22,4 +22,5 @@ type SCMConnectionRepository interface {
 	List(ctx context.Context) ([]domain.SCMConnectionDetail, error)
 	GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
 	SetEnabled(ctx context.Context, id string, enabled bool, updatedAt time.Time) (domain.SCMConnectionDetail, error)
+	UpdateHealth(ctx context.Context, id string, status domain.SCMConnectionHealthStatus, summary *string, checkedAt time.Time, updatedAt time.Time) (domain.SCMConnectionDetail, error)
 }

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -204,6 +204,9 @@ func (s *SCMAdminService) TestConnection(ctx context.Context, id string) (domain
 	trimmedID := strings.TrimSpace(id)
 	request, detail, err := s.resolveGitHubInstallationTokenRequest(ctx, trimmedID)
 	if err != nil {
+		if isContextCancellation(err) {
+			return domain.SCMConnectionDetail{}, err
+		}
 		if persisted, persistErr := s.persistConnectionHealthFailure(ctx, trimmedID, err); persistErr == nil {
 			return persisted, err
 		}
@@ -211,11 +214,15 @@ func (s *SCMAdminService) TestConnection(ctx context.Context, id string) (domain
 	}
 	probeResult, err := s.githubApps.ProbeInstallation(ctx, request)
 	if err != nil {
-		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, mapSCMGitHubProviderError(err))
-		if persistErr == nil {
-			return persisted, mapSCMGitHubProviderError(err)
+		mappedErr := mapSCMGitHubProviderError(err)
+		if isContextCancellation(mappedErr) {
+			return domain.SCMConnectionDetail{}, mappedErr
 		}
-		return domain.SCMConnectionDetail{}, mapSCMGitHubProviderError(err)
+		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, mappedErr)
+		if persistErr == nil {
+			return persisted, mappedErr
+		}
+		return domain.SCMConnectionDetail{}, mappedErr
 	}
 	if strings.TrimSpace(probeResult.InstallationID) != strings.TrimSpace(detail.GitHubAppInstallation.InstallationID) {
 		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, ErrSCMGitHubInstallationUnavailable)
@@ -371,4 +378,8 @@ func stringPtr(value string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func isContextCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
+	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
+	platformsecret "github.com/radiation/coyote-ci/backend/internal/platform/secret"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 )
 
@@ -22,6 +24,7 @@ var ErrSCMGitHubAccountLoginRequired = errors.New("github installation account_l
 var ErrSCMGitHubAccountTypeRequired = errors.New("github installation account_type is required")
 var ErrSCMGitHubTargetIDRequired = errors.New("github installation target_id is required")
 var ErrSCMConnectionEnabledRequired = errors.New("enabled is required")
+var ErrSCMConnectionDisabled = errors.New("scm connection is disabled")
 var ErrSCMRegisteredRepositoryConnectionIDRequired = errors.New("connection_id is required")
 var ErrSCMRegisteredRepositoryProviderRepositoryIDRequired = errors.New("provider_repository_id is required")
 var ErrSCMRegisteredRepositoryOwnerRequired = errors.New("owner is required")
@@ -29,10 +32,28 @@ var ErrSCMRegisteredRepositoryNameRequired = errors.New("name is required")
 var ErrSCMRegisteredRepositoryFullNameRequired = errors.New("full_name is required")
 var ErrSCMRegisteredRepositoryCloneURLRequired = errors.New("clone_url is required")
 var ErrSCMRegisteredRepositoryWebURLRequired = errors.New("web_url is required")
+var ErrSCMGitHubConnectionConfigurationInvalid = errors.New("github app connection configuration is invalid")
+var ErrSCMGitHubPrivateKeyResolveFailed = errors.New("github app private key could not be resolved")
+var ErrSCMGitHubAuthenticationFailed = errors.New("github app authentication failed")
+var ErrSCMGitHubInstallationUnavailable = errors.New("github app installation is unavailable")
+var ErrSCMGitHubRateLimited = errors.New("github app request was rate limited")
+var ErrSCMGitHubProviderUnavailable = errors.New("github app provider is unavailable")
+var ErrSCMGitHubProviderMalformedResponse = errors.New("github app provider response was malformed")
+
+type scmSecretResolver interface {
+	Resolve(ctx context.Context, ref string) (string, error)
+}
+
+type scmGitHubAppClient interface {
+	GetInstallationToken(ctx context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error)
+	ProbeInstallation(ctx context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationProbeResult, error)
+}
 
 type SCMAdminService struct {
 	connections  repository.SCMConnectionRepository
 	repositories repository.SCMRepositoryRegistrationRepository
+	secrets      scmSecretResolver
+	githubApps   scmGitHubAppClient
 	now          func() time.Time
 }
 
@@ -70,7 +91,13 @@ type CreateSCMRepositoryRegistrationInput struct {
 }
 
 func NewSCMAdminService(connections repository.SCMConnectionRepository, repositories repository.SCMRepositoryRegistrationRepository) *SCMAdminService {
-	return &SCMAdminService{connections: connections, repositories: repositories, now: time.Now}
+	return &SCMAdminService{
+		connections:  connections,
+		repositories: repositories,
+		secrets:      platformsecret.NewEnvResolver(),
+		githubApps:   platformgithubapp.NewClient(nil),
+		now:          time.Now,
+	}
 }
 
 func (s *SCMAdminService) ListConnections(ctx context.Context) ([]domain.SCMConnectionDetail, error) {
@@ -161,6 +188,45 @@ func (s *SCMAdminService) SetConnectionEnabled(ctx context.Context, id string, e
 	return s.connections.SetEnabled(ctx, strings.TrimSpace(id), *enabled, s.now().UTC())
 }
 
+func (s *SCMAdminService) GetGitHubAppInstallationToken(ctx context.Context, id string) (string, error) {
+	request, _, err := s.resolveGitHubInstallationTokenRequest(ctx, strings.TrimSpace(id))
+	if err != nil {
+		return "", err
+	}
+	token, err := s.githubApps.GetInstallationToken(ctx, request)
+	if err != nil {
+		return "", mapSCMGitHubProviderError(err)
+	}
+	return token.Value, nil
+}
+
+func (s *SCMAdminService) TestConnection(ctx context.Context, id string) (domain.SCMConnectionDetail, error) {
+	trimmedID := strings.TrimSpace(id)
+	request, detail, err := s.resolveGitHubInstallationTokenRequest(ctx, trimmedID)
+	if err != nil {
+		if persisted, persistErr := s.persistConnectionHealthFailure(ctx, trimmedID, err); persistErr == nil {
+			return persisted, err
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+	probeResult, err := s.githubApps.ProbeInstallation(ctx, request)
+	if err != nil {
+		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, mapSCMGitHubProviderError(err))
+		if persistErr == nil {
+			return persisted, mapSCMGitHubProviderError(err)
+		}
+		return domain.SCMConnectionDetail{}, mapSCMGitHubProviderError(err)
+	}
+	if strings.TrimSpace(probeResult.InstallationID) != strings.TrimSpace(detail.GitHubAppInstallation.InstallationID) {
+		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, ErrSCMGitHubInstallationUnavailable)
+		if persistErr == nil {
+			return persisted, ErrSCMGitHubInstallationUnavailable
+		}
+		return domain.SCMConnectionDetail{}, ErrSCMGitHubInstallationUnavailable
+	}
+	return s.connections.UpdateHealth(ctx, detail.Connection.ID, domain.SCMConnectionHealthStatusHealthy, stringPtr("github app installation authentication succeeded"), s.now().UTC(), s.now().UTC())
+}
+
 func (s *SCMAdminService) ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error) {
 	return s.repositories.List(ctx)
 }
@@ -228,4 +294,81 @@ func inferGitHubDeploymentKind(apiBaseURL string, webBaseURL string) domain.SCMD
 		return domain.SCMDeploymentKindCloud
 	}
 	return domain.SCMDeploymentKindSelfHosted
+}
+
+func (s *SCMAdminService) resolveGitHubInstallationTokenRequest(ctx context.Context, id string) (platformgithubapp.InstallationTokenRequest, domain.SCMConnectionDetail, error) {
+	detail, err := s.connections.GetByID(ctx, id)
+	if err != nil {
+		return platformgithubapp.InstallationTokenRequest{}, domain.SCMConnectionDetail{}, err
+	}
+	if !detail.Connection.Enabled {
+		return platformgithubapp.InstallationTokenRequest{}, detail, ErrSCMConnectionDisabled
+	}
+	if detail.Connection.Provider != domain.SCMProviderGitHub || detail.GitHubAppRegistration == nil || detail.GitHubAppInstallation == nil {
+		return platformgithubapp.InstallationTokenRequest{}, detail, ErrSCMGitHubConnectionConfigurationInvalid
+	}
+	registration := detail.GitHubAppRegistration.Normalize()
+	installation := detail.GitHubAppInstallation.Normalize()
+	if detail.Connection.APIBaseURL != registration.APIBaseURL || detail.Connection.WebBaseURL != registration.WebBaseURL {
+		return platformgithubapp.InstallationTokenRequest{}, detail, ErrSCMGitHubConnectionConfigurationInvalid
+	}
+	if registration.PrivateKeySecretRef == "" || registration.AppID == "" || installation.InstallationID == "" {
+		return platformgithubapp.InstallationTokenRequest{}, detail, ErrSCMGitHubConnectionConfigurationInvalid
+	}
+	privateKey, resolveErr := s.secrets.Resolve(ctx, registration.PrivateKeySecretRef)
+	if resolveErr != nil || strings.TrimSpace(privateKey) == "" {
+		return platformgithubapp.InstallationTokenRequest{}, detail, ErrSCMGitHubPrivateKeyResolveFailed
+	}
+	return platformgithubapp.InstallationTokenRequest{
+		AppRegistrationID: registration.ID,
+		AppID:             registration.AppID,
+		InstallationID:    installation.InstallationID,
+		APIBaseURL:        registration.APIBaseURL,
+		PrivateKeyPEM:     privateKey,
+	}, detail, nil
+}
+
+func (s *SCMAdminService) persistConnectionHealthFailure(ctx context.Context, id string, err error) (domain.SCMConnectionDetail, error) {
+	status, summary := scmConnectionHealthFailure(err)
+	return s.connections.UpdateHealth(ctx, id, status, stringPtr(summary), s.now().UTC(), s.now().UTC())
+}
+
+func scmConnectionHealthFailure(err error) (domain.SCMConnectionHealthStatus, string) {
+	switch {
+	case errors.Is(err, ErrSCMConnectionDisabled), errors.Is(err, ErrSCMGitHubConnectionConfigurationInvalid), errors.Is(err, ErrSCMGitHubPrivateKeyResolveFailed), errors.Is(err, ErrSCMGitHubAuthenticationFailed):
+		return domain.SCMConnectionHealthStatusUnhealthy, err.Error()
+	case errors.Is(err, ErrSCMGitHubInstallationUnavailable):
+		return domain.SCMConnectionHealthStatusRevoked, err.Error()
+	case errors.Is(err, ErrSCMGitHubRateLimited), errors.Is(err, ErrSCMGitHubProviderUnavailable), errors.Is(err, ErrSCMGitHubProviderMalformedResponse):
+		return domain.SCMConnectionHealthStatusDegraded, err.Error()
+	default:
+		return domain.SCMConnectionHealthStatusUnhealthy, ErrSCMGitHubProviderUnavailable.Error()
+	}
+}
+
+func mapSCMGitHubProviderError(err error) error {
+	switch {
+	case errors.Is(err, platformgithubapp.ErrPrivateKeyMissing), errors.Is(err, platformgithubapp.ErrPrivateKeyMalformed), errors.Is(err, platformgithubapp.ErrPrivateKeyNotRSA):
+		return ErrSCMGitHubPrivateKeyResolveFailed
+	case errors.Is(err, platformgithubapp.ErrAuthentication):
+		return ErrSCMGitHubAuthenticationFailed
+	case errors.Is(err, platformgithubapp.ErrInstallationUnavailable):
+		return ErrSCMGitHubInstallationUnavailable
+	case errors.Is(err, platformgithubapp.ErrRateLimited):
+		return ErrSCMGitHubRateLimited
+	case errors.Is(err, platformgithubapp.ErrMalformedResponse):
+		return ErrSCMGitHubProviderMalformedResponse
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	default:
+		return ErrSCMGitHubProviderUnavailable
+	}
+}
+
+func stringPtr(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }

--- a/backend/internal/service/scm_admin_service.go
+++ b/backend/internal/service/scm_admin_service.go
@@ -212,7 +212,7 @@ func (s *SCMAdminService) TestConnection(ctx context.Context, id string) (domain
 		}
 		return domain.SCMConnectionDetail{}, err
 	}
-	probeResult, err := s.githubApps.ProbeInstallation(ctx, request)
+	_, err = s.githubApps.ProbeInstallation(ctx, request)
 	if err != nil {
 		mappedErr := mapSCMGitHubProviderError(err)
 		if isContextCancellation(mappedErr) {
@@ -224,14 +224,8 @@ func (s *SCMAdminService) TestConnection(ctx context.Context, id string) (domain
 		}
 		return domain.SCMConnectionDetail{}, mappedErr
 	}
-	if strings.TrimSpace(probeResult.InstallationID) != strings.TrimSpace(detail.GitHubAppInstallation.InstallationID) {
-		persisted, persistErr := s.persistConnectionHealthFailure(ctx, detail.Connection.ID, ErrSCMGitHubInstallationUnavailable)
-		if persistErr == nil {
-			return persisted, ErrSCMGitHubInstallationUnavailable
-		}
-		return domain.SCMConnectionDetail{}, ErrSCMGitHubInstallationUnavailable
-	}
-	return s.connections.UpdateHealth(ctx, detail.Connection.ID, domain.SCMConnectionHealthStatusHealthy, stringPtr("github app installation authentication succeeded"), s.now().UTC(), s.now().UTC())
+	now := s.now().UTC()
+	return s.connections.UpdateHealth(ctx, detail.Connection.ID, domain.SCMConnectionHealthStatusHealthy, stringPtr("github app installation authentication succeeded"), now, now)
 }
 
 func (s *SCMAdminService) ListRegisteredRepositories(ctx context.Context) ([]domain.SCMRepositoryRegistration, error) {
@@ -337,7 +331,8 @@ func (s *SCMAdminService) resolveGitHubInstallationTokenRequest(ctx context.Cont
 
 func (s *SCMAdminService) persistConnectionHealthFailure(ctx context.Context, id string, err error) (domain.SCMConnectionDetail, error) {
 	status, summary := scmConnectionHealthFailure(err)
-	return s.connections.UpdateHealth(ctx, id, status, stringPtr(summary), s.now().UTC(), s.now().UTC())
+	now := s.now().UTC()
+	return s.connections.UpdateHealth(ctx, id, status, stringPtr(summary), now, now)
 }
 
 func scmConnectionHealthFailure(err error) (domain.SCMConnectionHealthStatus, string) {

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -2,10 +2,17 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
+	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
 )
@@ -272,4 +279,221 @@ func TestSCMAdminServiceValidationAndReadBranches(t *testing.T) {
 	if inferGitHubDeploymentKind("https://ghe.example/api/v3", "https://ghe.example") != domain.SCMDeploymentKindSelfHosted {
 		t.Fatal("expected non-public GitHub hosts to infer self-hosted deployment")
 	}
+}
+
+func TestSCMAdminService_GitHubInstallationTokenValidationAndSuccess(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Date(2026, 7, 17, 18, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+	privateKeyPEM, _ := testServiceRSAPrivateKeyPEM(t)
+	resolver := &fakeSCMSecretResolver{value: privateKeyPEM}
+	githubApps := &fakeSCMGitHubAppClient{token: platformgithubapp.InstallationToken{Value: "ghs_token", ExpiresAt: now.Add(10 * time.Minute)}}
+	svc.secrets = resolver
+	svc.githubApps = githubApps
+
+	registration, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook"})
+	if err != nil {
+		t.Fatalf("create registration: %v", err)
+	}
+	enabled := true
+	connection, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: registration.ID, DisplayName: "octo", Enabled: &enabled, InstallationID: "999", AccountLogin: "octo", AccountType: "organization", TargetID: "42"})
+	if err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+	token, err := svc.GetGitHubAppInstallationToken(context.Background(), connection.Connection.ID)
+	if err != nil {
+		t.Fatalf("get installation token: %v", err)
+	}
+	if token != "ghs_token" {
+		t.Fatalf("expected token value, got %q", token)
+	}
+	if len(githubApps.tokenRequests) != 1 {
+		t.Fatalf("expected one token request, got %d", len(githubApps.tokenRequests))
+	}
+	if strings.Contains(githubApps.tokenRequests[0].PrivateKeyPEM, "ghs_") {
+		t.Fatal("unexpected token leaked into private key request")
+	}
+
+	disable := false
+	_, setEnabledErr := svc.SetConnectionEnabled(context.Background(), connection.Connection.ID, &disable)
+	if setEnabledErr != nil {
+		t.Fatalf("disable connection: %v", setEnabledErr)
+	}
+	_, err = svc.GetGitHubAppInstallationToken(context.Background(), connection.Connection.ID)
+	if err != ErrSCMConnectionDisabled {
+		t.Fatalf("expected disabled error, got %v", err)
+	}
+}
+
+func TestSCMAdminService_TestConnectionPersistsHealthyAndUnhealthyStates(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Date(2026, 7, 17, 19, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+	privateKeyPEM, _ := testServiceRSAPrivateKeyPEM(t)
+	resolver := &fakeSCMSecretResolver{value: privateKeyPEM}
+	githubApps := &fakeSCMGitHubAppClient{probe: platformgithubapp.InstallationProbeResult{InstallationID: "999", AccountLogin: "octo"}}
+	svc.secrets = resolver
+	svc.githubApps = githubApps
+	registration, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook"})
+	if err != nil {
+		t.Fatalf("create registration: %v", err)
+	}
+	enabled := true
+	connection, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: registration.ID, DisplayName: "octo", Enabled: &enabled, InstallationID: "999", AccountLogin: "octo", AccountType: "organization", TargetID: "42"})
+	if err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+	updated, err := svc.TestConnection(context.Background(), connection.Connection.ID)
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if updated.Connection.HealthStatus != domain.SCMConnectionHealthStatusHealthy {
+		t.Fatalf("expected healthy status, got %q", updated.Connection.HealthStatus)
+	}
+	if updated.Connection.HealthSummary == nil || *updated.Connection.HealthSummary == "" {
+		t.Fatal("expected health summary")
+	}
+	if updated.Connection.LastHealthCheckedAt == nil || !updated.Connection.LastHealthCheckedAt.Equal(now) {
+		t.Fatalf("expected checked at %s, got %+v", now, updated.Connection.LastHealthCheckedAt)
+	}
+
+	githubApps.probeErr = platformgithubapp.ErrRateLimited
+	failed, err := svc.TestConnection(context.Background(), connection.Connection.ID)
+	if err != ErrSCMGitHubRateLimited {
+		t.Fatalf("expected rate limited error, got %v", err)
+	}
+	if failed.Connection.HealthStatus != domain.SCMConnectionHealthStatusDegraded {
+		t.Fatalf("expected degraded status, got %q", failed.Connection.HealthStatus)
+	}
+	if failed.Connection.HealthSummary == nil || *failed.Connection.HealthSummary != ErrSCMGitHubRateLimited.Error() {
+		t.Fatalf("expected degraded summary, got %+v", failed.Connection.HealthSummary)
+	}
+}
+
+func TestSCMAdminService_TestConnectionRejectsMismatchesAndSanitizesFailures(t *testing.T) {
+	connectionRepo := repositorymemory.NewSCMConnectionRepository()
+	repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+	svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+	now := time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC)
+	svc.now = func() time.Time { return now }
+	privateKeyPEM, _ := testServiceRSAPrivateKeyPEM(t)
+	svc.secrets = &fakeSCMSecretResolver{err: errors.New("missing BEGIN PRIVATE KEY ghs_secret")}
+	svc.githubApps = &fakeSCMGitHubAppClient{}
+	registration, err := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook"})
+	if err != nil {
+		t.Fatalf("create registration: %v", err)
+	}
+	enabled := true
+	connection, err := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: registration.ID, DisplayName: "octo", Enabled: &enabled, InstallationID: "999", AccountLogin: "octo", AccountType: "organization", TargetID: "42"})
+	if err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+	failed, err := svc.TestConnection(context.Background(), connection.Connection.ID)
+	if err != ErrSCMGitHubPrivateKeyResolveFailed {
+		t.Fatalf("expected secret resolution failure, got %v", err)
+	}
+	if strings.Contains(err.Error(), "BEGIN PRIVATE KEY") || strings.Contains(err.Error(), "ghs_secret") {
+		t.Fatalf("expected sanitized error, got %v", err)
+	}
+	if failed.Connection.HealthStatus != domain.SCMConnectionHealthStatusUnhealthy {
+		t.Fatalf("expected unhealthy status, got %q", failed.Connection.HealthStatus)
+	}
+
+	svc.secrets = &fakeSCMSecretResolver{value: privateKeyPEM}
+	badDetail := domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: "connection-bad", Provider: domain.SCMProviderGitHub, DisplayName: "bad", DeploymentKind: domain.SCMDeploymentKindSelfHosted, APIBaseURL: "https://other.example/api/v3", WebBaseURL: "https://other.example", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &registration,
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: "connection-bad", AppRegistrationID: registration.ID, InstallationID: "1000", AccountLogin: "octo-two", AccountType: "organization", AccountID: "84", CreatedAt: now, UpdatedAt: now},
+	}
+	svc.connections = &fakeSCMConnectionRepositoryForMismatch{detail: badDetail}
+	_, err = svc.GetGitHubAppInstallationToken(context.Background(), "connection-bad")
+	if err != ErrSCMGitHubConnectionConfigurationInvalid {
+		t.Fatalf("expected config invalid error, got %v", err)
+	}
+}
+
+type fakeSCMSecretResolver struct {
+	value string
+	err   error
+}
+
+func (f *fakeSCMSecretResolver) Resolve(_ context.Context, _ string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.value, nil
+}
+
+func testServiceRSAPrivateKeyPEM(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})), privateKey
+}
+
+type fakeSCMConnectionRepositoryForMismatch struct {
+	detail domain.SCMConnectionDetail
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) CreateGitHubAppRegistration(context.Context, domain.GitHubAppRegistration) (domain.GitHubAppRegistration, error) {
+	return domain.GitHubAppRegistration{}, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) ListGitHubAppRegistrations(context.Context) ([]domain.GitHubAppRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) GetGitHubAppRegistrationByID(context.Context, string) (domain.GitHubAppRegistration, error) {
+	return domain.GitHubAppRegistration{}, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) CreateGitHubAppInstallationConnection(context.Context, domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) List(context.Context) ([]domain.SCMConnectionDetail, error) {
+	return nil, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) GetByID(context.Context, string) (domain.SCMConnectionDetail, error) {
+	return f.detail, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) SetEnabled(context.Context, string, bool, time.Time) (domain.SCMConnectionDetail, error) {
+	return f.detail, nil
+}
+
+func (f *fakeSCMConnectionRepositoryForMismatch) UpdateHealth(context.Context, string, domain.SCMConnectionHealthStatus, *string, time.Time, time.Time) (domain.SCMConnectionDetail, error) {
+	return f.detail, nil
+}
+
+type fakeSCMGitHubAppClient struct {
+	token         platformgithubapp.InstallationToken
+	probe         platformgithubapp.InstallationProbeResult
+	tokenErr      error
+	probeErr      error
+	tokenRequests []platformgithubapp.InstallationTokenRequest
+	probeRequests []platformgithubapp.InstallationTokenRequest
+}
+
+func (f *fakeSCMGitHubAppClient) GetInstallationToken(_ context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error) {
+	f.tokenRequests = append(f.tokenRequests, input)
+	if f.tokenErr != nil {
+		return platformgithubapp.InstallationToken{}, f.tokenErr
+	}
+	return f.token, nil
+}
+
+func (f *fakeSCMGitHubAppClient) ProbeInstallation(_ context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationProbeResult, error) {
+	f.probeRequests = append(f.probeRequests, input)
+	if f.probeErr != nil {
+		return platformgithubapp.InstallationProbeResult{}, f.probeErr
+	}
+	return f.probe, nil
 }

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -475,6 +475,57 @@ func TestSCMAdminService_TestConnectionRejectsMismatchesAndSanitizesFailures(t *
 	}
 }
 
+func TestSCMAdminService_HelperMappingsAndResolutionBranches(t *testing.T) {
+	if status, summary := scmConnectionHealthFailure(ErrSCMGitHubProviderMalformedResponse); status != domain.SCMConnectionHealthStatusDegraded || summary != ErrSCMGitHubProviderMalformedResponse.Error() {
+		t.Fatalf("expected malformed response to degrade health, got status=%q summary=%q", status, summary)
+	}
+	if status, summary := scmConnectionHealthFailure(errors.New("unexpected")); status != domain.SCMConnectionHealthStatusUnhealthy || summary != ErrSCMGitHubProviderUnavailable.Error() {
+		t.Fatalf("expected default provider unavailable summary, got status=%q summary=%q", status, summary)
+	}
+	if mapped := mapSCMGitHubProviderError(platformgithubapp.ErrMalformedResponse); mapped != ErrSCMGitHubProviderMalformedResponse {
+		t.Fatalf("expected malformed provider mapping, got %v", mapped)
+	}
+	if mapped := mapSCMGitHubProviderError(platformgithubapp.ErrPrivateKeyNotRSA); mapped != ErrSCMGitHubPrivateKeyResolveFailed {
+		t.Fatalf("expected private key mapping, got %v", mapped)
+	}
+	if mapped := mapSCMGitHubProviderError(context.DeadlineExceeded); mapped != context.DeadlineExceeded {
+		t.Fatalf("expected deadline to pass through, got %v", mapped)
+	}
+	if got := stringPtr("   "); got != nil {
+		t.Fatalf("expected blank string pointer to be nil, got %v", *got)
+	}
+	if got := stringPtr("  ok  "); got == nil || *got != "ok" {
+		t.Fatalf("expected trimmed pointer, got %+v", got)
+	}
+	if !isContextCancellation(context.Canceled) || !isContextCancellation(context.DeadlineExceeded) || isContextCancellation(errors.New("boom")) {
+		t.Fatal("unexpected context cancellation classification")
+	}
+
+	now := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	validRegistration := domain.GitHubAppRegistration{ID: "registration-1", AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now}
+	validInstallation := &domain.GitHubAppInstallation{ConnectionID: "connection-1", AppRegistrationID: "registration-1", InstallationID: "999", AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now}
+	for _, tc := range []struct {
+		name     string
+		detail   domain.SCMConnectionDetail
+		resolver scmSecretResolver
+		wantErr  error
+	}{
+		{name: "non github provider", detail: domain.SCMConnectionDetail{Connection: domain.SCMConnection{ID: "connection-1", Provider: "", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true}, GitHubAppRegistration: &validRegistration, GitHubAppInstallation: validInstallation}, resolver: &fakeSCMSecretResolver{value: "pem"}, wantErr: ErrSCMGitHubConnectionConfigurationInvalid},
+		{name: "blank app id", detail: domain.SCMConnectionDetail{Connection: domain.SCMConnection{ID: "connection-1", Provider: domain.SCMProviderGitHub, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true}, GitHubAppRegistration: &domain.GitHubAppRegistration{ID: "registration-1", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key"}, GitHubAppInstallation: validInstallation}, resolver: &fakeSCMSecretResolver{value: "pem"}, wantErr: ErrSCMGitHubConnectionConfigurationInvalid},
+		{name: "blank resolved secret", detail: domain.SCMConnectionDetail{Connection: domain.SCMConnection{ID: "connection-1", Provider: domain.SCMProviderGitHub, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true}, GitHubAppRegistration: &validRegistration, GitHubAppInstallation: validInstallation}, resolver: &fakeSCMSecretResolver{value: "   "}, wantErr: ErrSCMGitHubPrivateKeyResolveFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewSCMAdminService(repositorymemory.NewSCMConnectionRepository(), repositorymemory.NewSCMRepositoryRegistrationRepository())
+			svc.connections = &fakeSCMConnectionRepositoryForMismatch{detail: tc.detail}
+			svc.secrets = tc.resolver
+			_, _, err := svc.resolveGitHubInstallationTokenRequest(context.Background(), "connection-1")
+			if err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 type fakeSCMSecretResolver struct {
 	value string
 	err   error

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -361,16 +361,75 @@ func TestSCMAdminService_TestConnectionPersistsHealthyAndUnhealthyStates(t *test
 		t.Fatalf("expected checked at %s, got %+v", now, updated.Connection.LastHealthCheckedAt)
 	}
 
-	githubApps.probeErr = platformgithubapp.ErrRateLimited
-	failed, err := svc.TestConnection(context.Background(), connection.Connection.ID)
-	if err != ErrSCMGitHubRateLimited {
-		t.Fatalf("expected rate limited error, got %v", err)
+	for _, tc := range []struct {
+		name       string
+		probeErr   error
+		wantErr    error
+		wantStatus domain.SCMConnectionHealthStatus
+	}{
+		{name: "auth", probeErr: platformgithubapp.ErrAuthentication, wantErr: ErrSCMGitHubAuthenticationFailed, wantStatus: domain.SCMConnectionHealthStatusUnhealthy},
+		{name: "installation unavailable", probeErr: platformgithubapp.ErrInstallationUnavailable, wantErr: ErrSCMGitHubInstallationUnavailable, wantStatus: domain.SCMConnectionHealthStatusRevoked},
+		{name: "rate limited", probeErr: platformgithubapp.ErrRateLimited, wantErr: ErrSCMGitHubRateLimited, wantStatus: domain.SCMConnectionHealthStatusDegraded},
+		{name: "provider unavailable", probeErr: platformgithubapp.ErrProviderUnavailable, wantErr: ErrSCMGitHubProviderUnavailable, wantStatus: domain.SCMConnectionHealthStatusDegraded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			githubApps.probeErr = tc.probeErr
+			failed, testErr := svc.TestConnection(context.Background(), connection.Connection.ID)
+			if testErr != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, testErr)
+			}
+			if failed.Connection.HealthStatus != tc.wantStatus {
+				t.Fatalf("expected status %q, got %q", tc.wantStatus, failed.Connection.HealthStatus)
+			}
+			if failed.Connection.HealthSummary == nil || *failed.Connection.HealthSummary != tc.wantErr.Error() {
+				t.Fatalf("expected summary %q, got %+v", tc.wantErr.Error(), failed.Connection.HealthSummary)
+			}
+		})
 	}
-	if failed.Connection.HealthStatus != domain.SCMConnectionHealthStatusDegraded {
-		t.Fatalf("expected degraded status, got %q", failed.Connection.HealthStatus)
-	}
-	if failed.Connection.HealthSummary == nil || *failed.Connection.HealthSummary != ErrSCMGitHubRateLimited.Error() {
-		t.Fatalf("expected degraded summary, got %+v", failed.Connection.HealthSummary)
+}
+
+func TestSCMAdminService_TestConnectionDoesNotPersistCanceledContexts(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		probeErr error
+	}{
+		{name: "canceled", probeErr: context.Canceled},
+		{name: "deadline", probeErr: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			connectionRepo := repositorymemory.NewSCMConnectionRepository()
+			repositoryRepo := repositorymemory.NewSCMRepositoryRegistrationRepository()
+			svc := NewSCMAdminService(connectionRepo, repositoryRepo)
+			now := time.Date(2026, 7, 17, 21, 0, 0, 0, time.UTC)
+			svc.now = func() time.Time { return now }
+			privateKeyPEM, _ := testServiceRSAPrivateKeyPEM(t)
+			svc.secrets = &fakeSCMSecretResolver{value: privateKeyPEM}
+			githubApps := &fakeSCMGitHubAppClient{probeErr: tc.probeErr}
+			svc.githubApps = githubApps
+			registration, createRegistrationErr := svc.CreateGitHubAppRegistration(context.Background(), CreateGitHubAppRegistrationInput{AppID: "12345", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook"})
+			if createRegistrationErr != nil {
+				t.Fatalf("create registration: %v", createRegistrationErr)
+			}
+			enabled := true
+			connection, createConnectionErr := svc.CreateGitHubAppInstallationConnection(context.Background(), CreateGitHubAppInstallationConnectionInput{AppRegistrationID: registration.ID, DisplayName: "octo", Enabled: &enabled, InstallationID: "999", AccountLogin: "octo", AccountType: "organization", TargetID: "42"})
+			if createConnectionErr != nil {
+				t.Fatalf("create connection: %v", createConnectionErr)
+			}
+			_, testErr := svc.TestConnection(context.Background(), connection.Connection.ID)
+			if testErr != tc.probeErr {
+				t.Fatalf("expected %v, got %v", tc.probeErr, testErr)
+			}
+			stored, getErr := connectionRepo.GetByID(context.Background(), connection.Connection.ID)
+			if getErr != nil {
+				t.Fatalf("get connection: %v", getErr)
+			}
+			if stored.Connection.HealthStatus != domain.SCMConnectionHealthStatusUnknown {
+				t.Fatalf("expected unknown health status, got %q", stored.Connection.HealthStatus)
+			}
+			if stored.Connection.HealthSummary != nil || stored.Connection.LastHealthCheckedAt != nil {
+				t.Fatalf("expected no persisted health metadata, got summary=%+v checkedAt=%+v", stored.Connection.HealthSummary, stored.Connection.LastHealthCheckedAt)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# GitHub App Authentication

## Summary

Adds operational GitHub App authentication on top of Coyote’s multi-connection SCM foundation.

Coyote can now resolve a GitHub App private key from a secret reference, mint a short-lived app JWT, exchange it for an installation access token, cache that token safely in-process, and test an installation-backed SCM connection through an admin-only health endpoint.

The implementation supports both `github.com` and GitHub Enterprise Server API bases and keeps provider behavior behind a focused, fakeable GitHub adapter.

This slice does not yet migrate commit-status delivery, webhook routing, repository discovery, job mapping, or PR builds onto the new connection model.

## What Changed

- Added a reusable secret-resolution boundary for GitHub App private keys.
- Added GitHub App RS256 JWT generation with injected clock support.
- Added installation-token exchange through the configured GitHub API base URL.
- Added process-local installation-token caching.
- Added per-cache-key concurrent refresh deduplication.
- Added conditional cache invalidation and one-time refresh after an authentication failure.
- Added a documented, read-only GitHub installation health probe.
- Added persistent SCM connection health updates with bounded summaries.
- Added an admin-only connection test endpoint.
- Added GitHub-specific provider error classification.
- Added focused unit, service, repository, handler, and router coverage.

## Authentication Flow

For an installation-backed SCM connection, Coyote now:

1. Loads the enabled SCM connection.
2. Loads its GitHub App installation metadata.
3. Loads the linked reusable GitHub App registration.
4. Validates provider and API-base compatibility.
5. Resolves the registration’s private-key secret reference.
6. Mints a short-lived GitHub App JWT.
7. Exchanges the JWT for an installation access token.
8. Reuses the installation token until shortly before expiration.
9. Returns the valid token through a narrow internal GitHub-specific boundary.

Coyote never persists:

- private-key material;
- signed app JWTs;
- installation access tokens;
- Authorization headers.

## GitHub App JWT

The JWT implementation:

- uses RS256;
- sets the issuer to the GitHub App ID;
- backdates `iat` slightly for clock skew;
- uses an expiration within GitHub’s supported maximum;
- accepts an injected clock for deterministic tests;
- rejects missing, malformed, or non-RSA private keys with classified errors.

## Installation Token Exchange

Installation tokens are requested from the configured GitHub API base using the installation-specific token endpoint.

The client supports:

- `github.com`;
- GitHub Enterprise Server API base URLs;
- bounded response-body reads;
- malformed-success response detection;
- authentication failure classification;
- missing, revoked, or suspended installation classification;
- rate-limit classification;
- provider/server failure classification.

Tokens and provider response bodies are never returned through the admin API.

## Token Cache and Concurrency

Installation tokens are cached process-locally by an identity containing:

```text
app registration ID + installation ID + API base URL
```

Cache behavior:

- tokens are reused until one minute before expiration;
- only one refresh runs at a time for a given cache key;
- concurrent callers wait for the in-flight refresh;
- waiting callers honor context cancellation;
- failed refreshes do not poison the cache;
- installation tokens are never persisted;
- no shared database cache or distributed lock is used.

When a cached token receives `401` during the health probe:

1. Coyote conditionally invalidates only the exact token that failed.
2. A fresh installation token is requested.
3. The probe is retried once.
4. A second failure is returned and classified normally.

Conditional invalidation prevents an older request from removing a newer token inserted concurrently.

## Connection Health Test

Adds:

```text
POST /api/settings/scm/connections/{connectionID}/test
```

The endpoint is protected by the existing SCM administration authorization boundary.

The test:

- validates the connection and GitHub App registration configuration;
- obtains a valid installation token;
- performs a documented read-only GitHub installation probe;
- verifies the expected installation identity;
- detects unavailable, revoked, or suspended installations;
- persists bounded health metadata;
- returns the sanitized SCM connection DTO.

Health outcomes distinguish:

- healthy;
- invalid or incomplete configuration;
- secret-resolution failure;
- authentication failure;
- unavailable, revoked, or suspended installation;
- rate limiting;
- provider unavailability.

Caller cancellation or deadline expiration does not mutate durable connection health, because an abandoned request is not evidence that the provider or connection is unhealthy.

## API Behavior

The connection-test endpoint preserves safe error boundaries:

- missing connection → not found;
- disabled or invalid connection configuration → client error;
- secret-resolution, authentication, installation, rate-limit, or provider failure → sanitized upstream/provider error;
- successful test → updated sanitized connection response.

No secret references, secret values, tokens, JWTs, or raw provider responses are exposed.

## Files Added or Updated

Core platform code includes:

- `backend/internal/platform/secret/resolver.go`
- `backend/internal/platform/githubapp/errors.go`
- `backend/internal/platform/githubapp/jwt.go`
- `backend/internal/platform/githubapp/client.go`

SCM integration changes include:

- SCM connection repository interfaces and memory/PostgreSQL implementations;
- SCM administration service;
- SCM HTTP handler and router wiring;
- connection health persistence.

Focused tests cover the GitHub App platform adapter, SCM service, handlers, repositories, and route contract.

## Tests

Coverage includes:

- valid RS256 JWT claims and signatures;
- issued-at skew and expiration;
- malformed, missing, and non-RSA keys;
- GitHub.com and GHES URL construction;
- successful installation-token exchange;
- malformed success responses;
- authentication, installation, rate-limit, and provider failures;
- token reuse before refresh skew;
- refresh after the skew boundary;
- per-key concurrent single-flight behavior;
- failed-refresh recovery;
- cache-key isolation across registrations, installations, and hosts;
- conditional cache invalidation;
- one-time refresh and retry after cached-token `401`;
- no unbounded authentication retries;
- documented installation health probe behavior;
- disabled or mismatched connection rejection;
- healthy and unhealthy health-state persistence;
- canceled and deadline-expired requests leaving durable health unchanged;
- no token or secret leakage through API responses and errors.

## Validation

Reported focused validation passed for:

```text
backend/internal/platform/githubapp
backend/internal/service
backend/internal/http/handler
backend/internal/http
backend/internal/repository/memory
backend/internal/repository/postgres
```

The normal pre-push hook remains the final repository validation gate before push.

## Security Model

- Private keys are resolved only at runtime.
- App JWTs and installation tokens remain process-local.
- Installation tokens are short-lived and recomputable on every Coyote server.
- No shared token persistence is required for horizontally scaled deployments.
- Logs and durable health summaries contain bounded, sanitized errors only.
- API responses never include credential material.

## Deferred

- Repository discovery and metadata hydration
- Job-to-registered-repository mapping
- Commit-status delivery migration away from `GITHUB_STATUS_TOKEN`
- Connection-aware webhook routing
- Automatic push and PR builds
- GitHub Checks and annotations
- GitLab and Bitbucket authentication
- CLI commands
- Web UI
- Shared or distributed installation-token caching

## Next Step

Use the authenticated installation client to register and refresh repository metadata from GitHub using stable provider repository IDs.

That should remain separate from job mapping and commit-status migration so each part can be validated independently.