### PR TITLE
Add connection-aware GitHub App webhook ingress

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	platformdb "github.com/radiation/coyote-ci/backend/internal/platform/db"
 	"github.com/radiation/coyote-ci/backend/internal/platform/dbopen"
 	platformemail "github.com/radiation/coyote-ci/backend/internal/platform/email"
+	platformsecret "github.com/radiation/coyote-ci/backend/internal/platform/secret"
 	platformslack "github.com/radiation/coyote-ci/backend/internal/platform/slack"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorypostgres "github.com/radiation/coyote-ci/backend/internal/repository/postgres"
@@ -266,7 +267,8 @@ func main() {
 		notificationHandler.SetPersonalSlackIdentityService(personalSlackIdentityService)
 		notificationHandler.SetAuthorization(authMode)
 	}
-	eventHandler := handler.NewEventHandler(jobService, webhookService, webhookMetrics, cfg.GitHubWebhookSecret)
+	githubWebhookResolver := webhooksvc.NewGitHubConnectionResolver(scmConnectionRepo, platformsecret.NewEnvResolver())
+	eventHandler := handler.NewEventHandler(jobService, webhookService, webhookMetrics, githubWebhookResolver)
 	readyHandler := handler.NewReadinessHandler(handler.ReadinessCheckFunc(func(ctx context.Context) error {
 		checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4151,9 +4151,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/webhooks/github": {
+        "/webhooks/github/apps/{registrationID}": {
             "post": {
-                "description": "Verifies a GitHub webhook signature and triggers builds for matching jobs on push events.",
+                "description": "Verifies a GitHub App registration-specific webhook signature, resolves the installation connection, and triggers builds for matching jobs on push events.",
                 "produces": [
                     "application/json"
                 ],
@@ -4161,6 +4161,15 @@ const docTemplate = `{
                     "webhooks"
                 ],
                 "summary": "Ingest GitHub webhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "GitHub App registration ID",
+                        "name": "registrationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4147,9 +4147,9 @@
                 }
             }
         },
-        "/webhooks/github": {
+        "/webhooks/github/apps/{registrationID}": {
             "post": {
-                "description": "Verifies a GitHub webhook signature and triggers builds for matching jobs on push events.",
+                "description": "Verifies a GitHub App registration-specific webhook signature, resolves the installation connection, and triggers builds for matching jobs on push events.",
                 "produces": [
                     "application/json"
                 ],
@@ -4157,6 +4157,15 @@
                     "webhooks"
                 ],
                 "summary": "Ingest GitHub webhook",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "GitHub App registration ID",
+                        "name": "registrationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -4730,10 +4730,17 @@ paths:
       summary: Update user
       tags:
       - users
-  /webhooks/github:
+  /webhooks/github/apps/{registrationID}:
     post:
-      description: Verifies a GitHub webhook signature and triggers builds for matching
-        jobs on push events.
+      description: Verifies a GitHub App registration-specific webhook signature,
+        resolves the installation connection, and triggers builds for matching jobs
+        on push events.
+      parameters:
+      - description: GitHub App registration ID
+        in: path
+        name: registrationID
+        required: true
+        type: string
       produces:
       - application/json
       responses:

--- a/backend/internal/http/handler/event_handler.go
+++ b/backend/internal/http/handler/event_handler.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/radiation/coyote-ci/backend/internal/api"
 	"github.com/radiation/coyote-ci/backend/internal/observability"
 	"github.com/radiation/coyote-ci/backend/internal/service"
@@ -17,17 +19,17 @@ import (
 )
 
 type EventHandler struct {
-	jobService          *service.JobService
-	webhookService      *webhooksvc.DeliveryIngressService
-	metrics             observability.WebhookIngressMetrics
-	githubWebhookSecret string
+	jobService     *service.JobService
+	webhookService *webhooksvc.DeliveryIngressService
+	metrics        observability.WebhookIngressMetrics
+	githubResolver webhooksvc.GitHubWebhookConnectionResolver
 }
 
-func NewEventHandler(jobService *service.JobService, webhookService *webhooksvc.DeliveryIngressService, metrics observability.WebhookIngressMetrics, githubWebhookSecret string) *EventHandler {
+func NewEventHandler(jobService *service.JobService, webhookService *webhooksvc.DeliveryIngressService, metrics observability.WebhookIngressMetrics, githubResolver webhooksvc.GitHubWebhookConnectionResolver) *EventHandler {
 	if metrics == nil {
 		metrics = observability.NewNoopWebhookIngressMetrics()
 	}
-	return &EventHandler{jobService: jobService, webhookService: webhookService, metrics: metrics, githubWebhookSecret: githubWebhookSecret}
+	return &EventHandler{jobService: jobService, webhookService: webhookService, metrics: metrics, githubResolver: githubResolver}
 }
 
 // IngestPushEvent godoc
@@ -84,7 +86,7 @@ func (h *EventHandler) IngestPushEvent(w http.ResponseWriter, r *http.Request) {
 
 // IngestGitHubWebhook godoc
 // @Summary Ingest GitHub webhook
-// @Description Verifies a GitHub webhook signature and triggers builds for matching jobs on push events.
+// @Description Verifies a GitHub App registration-specific webhook signature, resolves the installation connection, and triggers builds for matching jobs on push events.
 // @Tags webhooks
 // @Produce json
 // @Success 200 {object} api.PushEventEnvelope
@@ -93,7 +95,8 @@ func (h *EventHandler) IngestPushEvent(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} api.ErrorResponse
 // @Failure 503 {object} api.ErrorResponse
 // @Failure 500 {object} api.ErrorResponse
-// @Router /webhooks/github [post]
+// @Param registrationID path string true "GitHub App registration ID"
+// @Router /webhooks/github/apps/{registrationID} [post]
 func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	provider := "github"
@@ -114,6 +117,22 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "webhook service not configured")
 		return
 	}
+	registrationID := strings.TrimSpace(chi.URLParam(r, "registrationID"))
+	if registrationID == "" {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		writeErrorJSON(w, http.StatusNotFound, "not_found", "github app registration not found")
+		return
+	}
+	if eventType == "" || deliveryID == "" {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "missing required github webhook headers")
+		return
+	}
+	if h.githubResolver == nil {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "webhook identity resolver not configured")
+		return
+	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1024*1024))
 	if err != nil {
@@ -121,12 +140,51 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid request body")
 		return
 	}
+	secret, secretErr := h.githubResolver.ResolveRegistrationSecret(ctx, registrationID)
+	if secretErr != nil {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		if errors.Is(secretErr, webhooksvc.ErrGitHubWebhookRegistrationNotFound) {
+			writeErrorJSON(w, http.StatusNotFound, "not_found", "github app registration not found")
+			return
+		}
+		log.Printf("ERROR github webhook registration configuration unavailable registration_id=%s err=%v", registrationID, secretErr)
+		writeErrorJSON(w, http.StatusServiceUnavailable, "misconfigured", "github webhook configuration is unavailable")
+		return
+	}
+	if !githubwebhook.VerifySignature(secret, body, r.Header.Get("X-Hub-Signature-256")) {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeInvalidSignature)
+		outcome = observability.WebhookOutcomeInvalidSignature
+		log.Printf("WARN webhook signature validation failed %s", webhooksvc.WebhookLogFields(ctx))
+		writeErrorJSON(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
+		return
+	}
 
+	envelope, envelopeErr := githubwebhook.ParseAppEnvelope(body)
+	if envelopeErr != nil {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		log.Printf("WARN webhook identity parse failed %s err=%v", webhooksvc.WebhookLogFields(ctx), envelopeErr)
+		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid github webhook payload")
+		return
+	}
+	connection, connectionErr := h.githubResolver.ResolveConnection(ctx, registrationID, envelope.InstallationID)
+	if connectionErr != nil {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		log.Printf("ERROR github webhook connection resolution failed registration_id=%s installation_id=%s err=%v", registrationID, envelope.InstallationID, connectionErr)
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		return
+	}
+	trigger := webhooksvc.WebhookTriggerInput{ConnectionID: connection.ConnectionID, SCMProvider: provider, EventType: eventType, DeliveryID: deliveryID, InstallationID: envelope.InstallationID}
+	if !connection.Found || !connection.Enabled {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeNoMatchingJob)
+		outcome = observability.WebhookOutcomeNoMatchingJob
+		writeDataJSON(w, http.StatusOK, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}})
+		return
+	}
 	delivery, duplicate, deliveryErr := h.webhookService.RegisterReceived(ctx, provider, deliveryID, eventType)
 	if deliveryErr != nil {
 		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
 		log.Printf("WARN webhook register failed %s err=%v", webhooksvc.WebhookLogFields(ctx), deliveryErr)
-		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", deliveryErr.Error())
+		writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
 		return
 	}
 	if duplicate {
@@ -136,37 +194,23 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		writeDataJSON(w, http.StatusOK, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}, Duplicate: true})
 		return
 	}
-
-	if h.githubWebhookSecret == "" {
-		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
-		_, _ = h.webhookService.MarkFailed(ctx, delivery, "github webhook secret not configured")
-		log.Printf("ERROR webhook secret missing %s", webhooksvc.WebhookLogFields(ctx))
-		writeErrorJSON(w, http.StatusServiceUnavailable, "misconfigured", "github webhook secret is not configured")
-		return
-	}
-
-	if !githubwebhook.VerifySignature(h.githubWebhookSecret, body, r.Header.Get("X-Hub-Signature-256")) {
-		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeInvalidSignature)
-		outcome = observability.WebhookOutcomeInvalidSignature
-		log.Printf("WARN webhook signature validation failed %s", webhooksvc.WebhookLogFields(ctx))
-		_, _ = h.webhookService.MarkFailed(ctx, delivery, "signature validation failed")
-		writeErrorJSON(w, http.StatusUnauthorized, "unauthorized", "invalid signature")
-		return
-	}
-
-	pushEvent, parseErr := githubwebhook.ParsePushEvent(r.Header, body)
-	if parseErr != nil {
-		if errors.Is(parseErr, githubwebhook.ErrUnsupportedEvent) {
-			h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeUnsupportedEvent)
-			outcome = observability.WebhookOutcomeUnsupportedEvent
-			log.Printf("INFO webhook unsupported event %s", webhooksvc.WebhookLogFields(ctx))
-			_, _ = h.webhookService.MarkUnsupported(ctx, delivery, "unsupported event", webhooksvc.WebhookTriggerInput{SCMProvider: provider, EventType: eventType})
-			writeDataJSON(w, http.StatusAccepted, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}})
+	if eventType != "push" {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeUnsupportedEvent)
+		outcome = observability.WebhookOutcomeUnsupportedEvent
+		log.Printf("INFO webhook unsupported event %s", webhooksvc.WebhookLogFields(ctx))
+		if _, markErr := h.webhookService.MarkUnsupported(ctx, delivery, "unsupported event", trigger); markErr != nil {
+			h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+			writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
 			return
 		}
+		writeDataJSON(w, http.StatusAccepted, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}})
+		return
+	}
+	pushEvent, parseErr := githubwebhook.ParsePushEvent(r.Header, body)
+	if parseErr != nil {
 		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
-		_, _ = h.webhookService.MarkFailed(ctx, delivery, "invalid github webhook payload")
 		log.Printf("WARN webhook payload parse failed %s err=%v", webhooksvc.WebhookLogFields(ctx), parseErr)
+		_, _ = h.webhookService.MarkFailed(ctx, delivery, "invalid github webhook payload")
 		writeErrorJSON(w, http.StatusBadRequest, "invalid_request", "invalid github webhook payload")
 		return
 	}
@@ -178,8 +222,8 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		DeliveryID:    deliveryID,
 		EventType:     eventType,
 	})
-
-	ingressResult, triggerErr := h.webhookService.ProcessVerifiedEvent(ctx, delivery, webhooksvc.WebhookTriggerInput{
+	trigger = webhooksvc.WebhookTriggerInput{
+		ConnectionID:    connection.ConnectionID,
 		SCMProvider:     provider,
 		EventType:       pushEvent.EventType,
 		RepositoryOwner: pushEvent.RepositoryOwner,
@@ -193,7 +237,25 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		CommitSHA:       pushEvent.CommitSHA,
 		DeliveryID:      pushEvent.DeliveryID,
 		Actor:           pushEvent.Actor,
-	})
+		InstallationID:  pushEvent.InstallationID,
+	}
+	if !connection.Found || !connection.Enabled {
+		reason := "github app installation connection is unavailable"
+		if connection.Found {
+			reason = "github app installation connection is disabled"
+		}
+		if _, noMatchErr := h.webhookService.MarkVerifiedNoMatch(ctx, delivery, reason, trigger); noMatchErr != nil {
+			h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+			writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeNoMatchingJob)
+		outcome = observability.WebhookOutcomeNoMatchingJob
+		writeDataJSON(w, http.StatusOK, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}})
+		return
+	}
+
+	ingressResult, triggerErr := h.webhookService.ProcessVerifiedEvent(ctx, delivery, trigger)
 	if triggerErr != nil {
 		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
 		log.Printf("ERROR webhook delivery failed %s err=%v", webhooksvc.WebhookLogFields(ctx), triggerErr)

--- a/backend/internal/http/handler/event_handler.go
+++ b/backend/internal/http/handler/event_handler.go
@@ -151,6 +151,13 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		writeErrorJSON(w, http.StatusServiceUnavailable, "misconfigured", "github webhook configuration is unavailable")
 		return
 	}
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
+		log.Printf("ERROR github webhook registration configuration unavailable registration_id=%s empty webhook secret", registrationID)
+		writeErrorJSON(w, http.StatusServiceUnavailable, "misconfigured", "github webhook configuration is unavailable")
+		return
+	}
 	if !githubwebhook.VerifySignature(secret, body, r.Header.Get("X-Hub-Signature-256")) {
 		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeInvalidSignature)
 		outcome = observability.WebhookOutcomeInvalidSignature
@@ -238,21 +245,6 @@ func (h *EventHandler) IngestGitHubWebhook(w http.ResponseWriter, r *http.Reques
 		DeliveryID:      pushEvent.DeliveryID,
 		Actor:           pushEvent.Actor,
 		InstallationID:  pushEvent.InstallationID,
-	}
-	if !connection.Found || !connection.Enabled {
-		reason := "github app installation connection is unavailable"
-		if connection.Found {
-			reason = "github app installation connection is disabled"
-		}
-		if _, noMatchErr := h.webhookService.MarkVerifiedNoMatch(ctx, delivery, reason, trigger); noMatchErr != nil {
-			h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeFailedProcessing)
-			writeErrorJSON(w, http.StatusInternalServerError, "internal_error", "internal server error")
-			return
-		}
-		h.metrics.IncOutcome(provider, eventType, observability.WebhookOutcomeNoMatchingJob)
-		outcome = observability.WebhookOutcomeNoMatchingJob
-		writeDataJSON(w, http.StatusOK, api.PushEventResponse{MatchedJobs: 0, CreatedBuilds: 0, Builds: []api.PushEventMatchedJob{}})
-		return
 	}
 
 	ingressResult, triggerErr := h.webhookService.ProcessVerifiedEvent(ctx, delivery, trigger)

--- a/backend/internal/http/handler/event_handler_test.go
+++ b/backend/internal/http/handler/event_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/observability"
 	repositorymemory "github.com/radiation/coyote-ci/backend/internal/repository/memory"
@@ -24,7 +26,7 @@ func TestEventHandler_IngestPushEvent(t *testing.T) {
 	buildSvc := buildsvc.NewBuildService(buildRepo, nil, nil)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	webhookSvc := webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc)
-	h := NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "")
+	h := NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{})
 
 	_, err := jobSvc.CreateJob(context.Background(), service.CreateJobInput{
 		ProjectID:     "project-1",
@@ -64,7 +66,7 @@ func TestEventHandler_IngestPushEvent_BadRequest(t *testing.T) {
 	buildRepo := repositorymemory.NewBuildRepository()
 	jobRepo := repositorymemory.NewJobRepository()
 	jobSvc := service.NewJobService(jobRepo, buildsvc.NewBuildService(buildRepo, nil, nil))
-	h := NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	h := NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{})
 
 	req := httptest.NewRequest(http.MethodPost, "/events/push", bytes.NewBufferString(`{"repository_url":"","ref":"","commit_sha":""}`))
 	res := httptest.NewRecorder()
@@ -84,7 +86,7 @@ func TestEventHandler_IngestGitHubWebhook_IdempotentDuplicateNoSecondBuild(t *te
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
 	metrics := observability.NewInMemoryWebhookIngressMetrics()
 	webhookSvc.SetMetrics(metrics)
-	h := NewEventHandler(jobSvc, webhookSvc, metrics, "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, metrics, "secret")
 
 	_, err := jobSvc.CreateJob(context.Background(), service.CreateJobInput{
 		ProjectID:     "project-1",
@@ -103,6 +105,7 @@ func TestEventHandler_IngestGitHubWebhook_IdempotentDuplicateNoSecondBuild(t *te
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"after":"abc123",
+		"installation":{"id":999},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -113,13 +116,13 @@ func TestEventHandler_IngestGitHubWebhook_IdempotentDuplicateNoSecondBuild(t *te
 	sig := githubTestSignature("secret", body)
 
 	for i := range 2 {
-		req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+		req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 		req.Header.Set("X-GitHub-Event", "push")
 		req.Header.Set("X-GitHub-Delivery", "delivery-1")
 		req.Header.Set("X-Hub-Signature-256", sig)
 
 		res := httptest.NewRecorder()
-		h.IngestGitHubWebhook(res, req)
+		ingestTestGitHubWebhook(h, res, req)
 		if res.Code != http.StatusOK {
 			t.Fatalf("expected status %d on attempt %d, got %d body=%s", http.StatusOK, i+1, res.Code, res.Body.String())
 		}
@@ -164,16 +167,16 @@ func TestEventHandler_IngestGitHubWebhook_UnsupportedEventRecorded(t *testing.T)
 	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
 	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
-	h := NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
 
-	body := []byte(`{}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	body := []byte(`{"installation":{"id":999}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "pull_request")
 	req.Header.Set("X-GitHub-Delivery", "delivery-unsupported")
 	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
 
 	res := httptest.NewRecorder()
-	h.IngestGitHubWebhook(res, req)
+	ingestTestGitHubWebhook(h, res, req)
 	if res.Code != http.StatusAccepted {
 		t.Fatalf("expected status %d, got %d", http.StatusAccepted, res.Code)
 	}
@@ -187,17 +190,78 @@ func TestEventHandler_IngestGitHubWebhook_UnsupportedEventRecorded(t *testing.T)
 	}
 }
 
+func TestEventHandler_IngestGitHubWebhook_UnsupportedEventRequiresConnectionIdentity(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		body         []byte
+		resolution   webhooksvc.GitHubWebhookConnectionResolution
+		wantStatus   int
+		wantDelivery bool
+	}{
+		{name: "missing installation", body: []byte(`{}`), wantStatus: http.StatusBadRequest},
+		{name: "fractional installation", body: []byte(`{"installation":{"id":1.5}}`), wantStatus: http.StatusBadRequest},
+		{name: "unknown installation", body: []byte(`{"installation":{"id":999}}`), wantStatus: http.StatusOK},
+		{name: "disabled connection", body: []byte(`{"installation":{"id":999}}`), resolution: webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true}, wantStatus: http.StatusOK},
+		{name: "enabled connection", body: []byte(`{"installation":{"id":999}}`), resolution: webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true, Enabled: true}, wantStatus: http.StatusAccepted, wantDelivery: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
+			jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
+			h := NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc), observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{secret: "secret", resolution: testCase.resolution})
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(testCase.body))
+			req.Header.Set("X-GitHub-Event", "pull_request")
+			req.Header.Set("X-GitHub-Delivery", "delivery-unsupported-identity")
+			req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", testCase.body))
+			res := httptest.NewRecorder()
+			ingestTestGitHubWebhook(h, res, req)
+			if res.Code != testCase.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.wantStatus, res.Code, res.Body.String())
+			}
+			_, deliveryErr := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-unsupported-identity")
+			if testCase.wantDelivery && deliveryErr != nil {
+				t.Fatalf("expected delivery to be recorded, got %v", deliveryErr)
+			}
+			if !testCase.wantDelivery && deliveryErr == nil {
+				t.Fatal("invalid or unresolved connection identity must not claim a delivery")
+			}
+		})
+	}
+}
+
+func TestEventHandler_IngestGitHubWebhook_UnsupportedDuplicateReturnsOK(t *testing.T) {
+	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
+	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
+	h := newTestGitHubEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc), observability.NewNoopWebhookIngressMetrics(), "secret")
+	body := []byte(`{"installation":{"id":999}}`)
+	for attempt := range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+		req.Header.Set("X-GitHub-Event", "pull_request")
+		req.Header.Set("X-GitHub-Delivery", "delivery-unsupported-duplicate")
+		req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+		res := httptest.NewRecorder()
+		ingestTestGitHubWebhook(h, res, req)
+		wantStatus := http.StatusAccepted
+		if attempt == 1 {
+			wantStatus = http.StatusOK
+		}
+		if res.Code != wantStatus {
+			t.Fatalf("attempt %d: expected status %d, got %d body=%s", attempt+1, wantStatus, res.Code, res.Body.String())
+		}
+	}
+}
+
 func TestEventHandler_IngestGitHubWebhook_NoMatchRecorded(t *testing.T) {
 	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
 	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
 	metrics := observability.NewInMemoryWebhookIngressMetrics()
 	webhookSvc.SetMetrics(metrics)
-	h := NewEventHandler(jobSvc, webhookSvc, metrics, "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, metrics, "secret")
 
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"after":"abc123",
+		"installation":{"id":999},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -206,13 +270,13 @@ func TestEventHandler_IngestGitHubWebhook_NoMatchRecorded(t *testing.T) {
 		"sender":{"login":"octocat"}
 	}`)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
 	req.Header.Set("X-GitHub-Delivery", "delivery-no-match")
 	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
 
 	res := httptest.NewRecorder()
-	h.IngestGitHubWebhook(res, req)
+	ingestTestGitHubWebhook(h, res, req)
 	if res.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
 	}
@@ -236,12 +300,13 @@ func TestEventHandler_IngestGitHubWebhook_DeletePushIgnored(t *testing.T) {
 	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
 	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
-	h := NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
 
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"deleted":true,
 		"after":"",
+		"installation":{"id":999},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -250,13 +315,13 @@ func TestEventHandler_IngestGitHubWebhook_DeletePushIgnored(t *testing.T) {
 		"sender":{"login":"octocat"}
 	}`)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
 	req.Header.Set("X-GitHub-Delivery", "delivery-delete")
 	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
 
 	res := httptest.NewRecorder()
-	h.IngestGitHubWebhook(res, req)
+	ingestTestGitHubWebhook(h, res, req)
 	if res.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
 	}
@@ -277,11 +342,12 @@ func TestEventHandler_IngestGitHubWebhook_FailedProcessingRecorded(t *testing.T)
 	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
 	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), nil)
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
-	h := NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "secret")
 
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"after":"abc123",
+		"installation":{"id":999},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -289,13 +355,13 @@ func TestEventHandler_IngestGitHubWebhook_FailedProcessingRecorded(t *testing.T)
 		},
 		"sender":{"login":"octocat"}
 	}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
 	req.Header.Set("X-GitHub-Delivery", "delivery-failed")
 	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
 
 	res := httptest.NewRecorder()
-	h.IngestGitHubWebhook(res, req)
+	ingestTestGitHubWebhook(h, res, req)
 	if res.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, res.Code)
 	}
@@ -315,26 +381,37 @@ func TestEventHandler_IngestGitHubWebhook_InvalidSignatureRecorded(t *testing.T)
 	webhookSvc := webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc)
 	metrics := observability.NewInMemoryWebhookIngressMetrics()
 	webhookSvc.SetMetrics(metrics)
-	h := NewEventHandler(jobSvc, webhookSvc, metrics, "secret")
+	h := newTestGitHubEventHandler(jobSvc, webhookSvc, metrics, "secret")
 
-	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewBufferString(`{"ref":"refs/heads/main"}`))
+	body := validTestGitHubPushBody()
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	req.Header.Set("X-GitHub-Event", "push")
 	req.Header.Set("X-GitHub-Delivery", "delivery-invalid-signature")
 	req.Header.Set("X-Hub-Signature-256", "sha256=invalid")
 
 	res := httptest.NewRecorder()
-	h.IngestGitHubWebhook(res, req)
+	ingestTestGitHubWebhook(h, res, req)
 
 	if res.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, res.Code)
 	}
 
-	delivery, err := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-invalid-signature")
-	if err != nil {
-		t.Fatalf("expected ledger record, got %v", err)
+	_, err := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-invalid-signature")
+	if err == nil {
+		t.Fatal("invalid signature must not reserve a delivery ID")
 	}
-	if delivery.Status != domain.WebhookDeliveryStatusFailed {
-		t.Fatalf("expected failed status, got %q", delivery.Status)
+
+	validReq := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+	validReq.Header.Set("X-GitHub-Event", "push")
+	validReq.Header.Set("X-GitHub-Delivery", "delivery-invalid-signature")
+	validReq.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+	validRes := httptest.NewRecorder()
+	ingestTestGitHubWebhook(h, validRes, validReq)
+	if validRes.Code != http.StatusOK {
+		t.Fatalf("expected later valid delivery status %d, got %d body=%s", http.StatusOK, validRes.Code, validRes.Body.String())
+	}
+	if _, validErr := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-invalid-signature"); validErr != nil {
+		t.Fatalf("expected later valid delivery to be recorded, got %v", validErr)
 	}
 	if got := metrics.OutcomeCount("github", "push", observability.WebhookOutcomeInvalidSignature); got != 1 {
 		t.Fatalf("expected invalid_signature metric count 1, got %d", got)
@@ -344,10 +421,154 @@ func TestEventHandler_IngestGitHubWebhook_InvalidSignatureRecorded(t *testing.T)
 	}
 }
 
+func TestEventHandler_IngestGitHubWebhook_RegistrationFailuresDoNotClaimDelivery(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		resolver   testGitHubWebhookResolver
+		wantStatus int
+	}{
+		{name: "unknown registration", resolver: testGitHubWebhookResolver{registrationErr: webhooksvc.ErrGitHubWebhookRegistrationNotFound}, wantStatus: http.StatusNotFound},
+		{name: "secret unavailable", resolver: testGitHubWebhookResolver{registrationErr: webhooksvc.ErrGitHubWebhookSecretUnavailable}, wantStatus: http.StatusServiceUnavailable},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
+			jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
+			h := NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc), observability.NewNoopWebhookIngressMetrics(), testCase.resolver)
+			body := validTestGitHubPushBody()
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+			req.Header.Set("X-GitHub-Event", "push")
+			req.Header.Set("X-GitHub-Delivery", "delivery-registration-failure")
+			req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+			res := httptest.NewRecorder()
+			ingestTestGitHubWebhook(h, res, req)
+			if res.Code != testCase.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.wantStatus, res.Code, res.Body.String())
+			}
+			if _, err := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-registration-failure"); err == nil {
+				t.Fatal("registration failure must not claim a delivery")
+			}
+		})
+	}
+}
+
+func TestEventHandler_IngestGitHubWebhook_InvalidIdentityDoesNotClaimDelivery(t *testing.T) {
+	deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
+	jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
+	h := newTestGitHubEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc), observability.NewNoopWebhookIngressMetrics(), "secret")
+	body := []byte(`{"ref":"refs/heads/main","after":"abc123","repository":{"name":"backend","html_url":"https://github.com/example/backend","owner":{"login":"example"}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-GitHub-Delivery", "delivery-invalid-installation")
+	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+	res := httptest.NewRecorder()
+	ingestTestGitHubWebhook(h, res, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusBadRequest, res.Code, res.Body.String())
+	}
+	if _, err := deliveryRepo.GetByProviderDeliveryID(context.Background(), "github", "delivery-invalid-installation"); err == nil {
+		t.Fatal("malformed identity must not claim a delivery")
+	}
+}
+
+func TestEventHandler_IngestGitHubWebhook_UnknownAndDisabledConnectionsAreNoOps(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		resolution webhooksvc.GitHubWebhookConnectionResolution
+	}{
+		{name: "unknown installation", resolution: webhooksvc.GitHubWebhookConnectionResolution{}},
+		{name: "disabled connection", resolution: webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true, Enabled: false}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
+			jobSvc := service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))
+			h := NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(deliveryRepo, jobSvc), observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{secret: "secret", resolution: testCase.resolution})
+			body := validTestGitHubPushBody()
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+			req.Header.Set("X-GitHub-Event", "push")
+			req.Header.Set("X-GitHub-Delivery", "delivery-noop-"+testCase.name)
+			req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+			res := httptest.NewRecorder()
+			ingestTestGitHubWebhook(h, res, req)
+			if res.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, res.Code, res.Body.String())
+			}
+		})
+	}
+}
+
+func TestEventHandler_IngestGitHubWebhook_PropagatesConnectionID(t *testing.T) {
+	triggerer := &recordingHandlerWebhookTriggerer{}
+	deliverySvc := webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), triggerer)
+	h := NewEventHandler(nil, deliverySvc, observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{secret: "secret", resolution: webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true, Enabled: true}})
+	body := validTestGitHubPushBody()
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-GitHub-Delivery", "delivery-connection-id")
+	req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", body))
+	res := httptest.NewRecorder()
+	ingestTestGitHubWebhook(h, res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, res.Code, res.Body.String())
+	}
+	if triggerer.input.ConnectionID != "connection-1" || triggerer.input.InstallationID != "999" {
+		t.Fatalf("expected propagated connection identity, got %+v", triggerer.input)
+	}
+}
+
 func githubTestSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newTestGitHubEventHandler(jobSvc *service.JobService, deliverySvc *webhooksvc.DeliveryIngressService, metrics observability.WebhookIngressMetrics, secret string) *EventHandler {
+	return NewEventHandler(jobSvc, deliverySvc, metrics, testGitHubWebhookResolver{secret: secret, resolution: webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true, Enabled: true}})
+}
+
+func ingestTestGitHubWebhook(handler *EventHandler, recorder *httptest.ResponseRecorder, request *http.Request) {
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("registrationID", "registration-1")
+	handler.IngestGitHubWebhook(recorder, request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext)))
+}
+
+type testGitHubWebhookResolver struct {
+	secret          string
+	resolution      webhooksvc.GitHubWebhookConnectionResolution
+	registrationErr error
+	connectionErr   error
+}
+
+func (r testGitHubWebhookResolver) ResolveRegistrationSecret(_ context.Context, registrationID string) (string, error) {
+	if r.registrationErr != nil {
+		return "", r.registrationErr
+	}
+	if registrationID != "registration-1" {
+		return "", webhooksvc.ErrGitHubWebhookRegistrationNotFound
+	}
+	return r.secret, nil
+}
+
+func (r testGitHubWebhookResolver) ResolveConnection(_ context.Context, registrationID string, installationID string) (webhooksvc.GitHubWebhookConnectionResolution, error) {
+	if r.connectionErr != nil {
+		return webhooksvc.GitHubWebhookConnectionResolution{}, r.connectionErr
+	}
+	if registrationID != "registration-1" || installationID != "999" {
+		return webhooksvc.GitHubWebhookConnectionResolution{}, nil
+	}
+	return r.resolution, nil
+}
+
+func validTestGitHubPushBody() []byte {
+	return []byte(`{"ref":"refs/heads/main","after":"abc123","installation":{"id":999},"repository":{"name":"backend","html_url":"https://github.com/example/backend","owner":{"login":"example"}},"sender":{"login":"octocat"}}`)
+}
+
+type recordingHandlerWebhookTriggerer struct {
+	input webhooksvc.WebhookTriggerInput
+}
+
+func (t *recordingHandlerWebhookTriggerer) TriggerWebhookEvent(_ context.Context, input webhooksvc.WebhookTriggerInput) (webhooksvc.WebhookTriggerResult, error) {
+	t.input = input
+	return webhooksvc.WebhookTriggerResult{}, nil
 }
 
 func boolPtr(v bool) *bool    { return &v }

--- a/backend/internal/http/handler/event_handler_test.go
+++ b/backend/internal/http/handler/event_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -429,6 +430,7 @@ func TestEventHandler_IngestGitHubWebhook_RegistrationFailuresDoNotClaimDelivery
 	}{
 		{name: "unknown registration", resolver: testGitHubWebhookResolver{registrationErr: webhooksvc.ErrGitHubWebhookRegistrationNotFound}, wantStatus: http.StatusNotFound},
 		{name: "secret unavailable", resolver: testGitHubWebhookResolver{registrationErr: webhooksvc.ErrGitHubWebhookSecretUnavailable}, wantStatus: http.StatusServiceUnavailable},
+		{name: "empty secret", resolver: testGitHubWebhookResolver{}, wantStatus: http.StatusServiceUnavailable},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			deliveryRepo := repositorymemory.NewWebhookDeliveryRepository()
@@ -512,6 +514,82 @@ func TestEventHandler_IngestGitHubWebhook_PropagatesConnectionID(t *testing.T) {
 	}
 	if triggerer.input.ConnectionID != "connection-1" || triggerer.input.InstallationID != "999" {
 		t.Fatalf("expected propagated connection identity, got %+v", triggerer.input)
+	}
+}
+
+func TestEventHandler_IngestGitHubWebhook_RejectsInvalidIngressStates(t *testing.T) {
+	validBody := validTestGitHubPushBody()
+	for _, testCase := range []struct {
+		name       string
+		handler    *EventHandler
+		body       []byte
+		eventType  string
+		deliveryID string
+		withRoute  bool
+		wantStatus int
+	}{
+		{
+			name:       "missing registration route parameter",
+			handler:    newTestGitHubEventHandler(service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil)), webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))), observability.NewNoopWebhookIngressMetrics(), "secret"),
+			body:       validBody,
+			eventType:  "push",
+			deliveryID: "delivery-missing-route",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "missing event headers",
+			handler:    newTestGitHubEventHandler(service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil)), webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))), observability.NewNoopWebhookIngressMetrics(), "secret"),
+			body:       validBody,
+			withRoute:  true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "identity resolver missing",
+			handler:    NewEventHandler(nil, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), &recordingHandlerWebhookTriggerer{}), observability.NewNoopWebhookIngressMetrics(), nil),
+			body:       validBody,
+			eventType:  "push",
+			deliveryID: "delivery-missing-resolver",
+			withRoute:  true,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "connection resolution failure",
+			handler:    NewEventHandler(nil, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), &recordingHandlerWebhookTriggerer{}), observability.NewNoopWebhookIngressMetrics(), testGitHubWebhookResolver{secret: "secret", connectionErr: errors.New("database unavailable")}),
+			body:       validBody,
+			eventType:  "push",
+			deliveryID: "delivery-connection-failure",
+			withRoute:  true,
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "push payload invalid after identity validation",
+			handler:    newTestGitHubEventHandler(service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil)), webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), service.NewJobService(repositorymemory.NewJobRepository(), buildsvc.NewBuildService(repositorymemory.NewBuildRepository(), nil, nil))), observability.NewNoopWebhookIngressMetrics(), "secret"),
+			body:       []byte(`{"installation":{"id":999}}`),
+			eventType:  "push",
+			deliveryID: "delivery-invalid-push",
+			withRoute:  true,
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(testCase.body))
+			if testCase.eventType != "" {
+				req.Header.Set("X-GitHub-Event", testCase.eventType)
+			}
+			if testCase.deliveryID != "" {
+				req.Header.Set("X-GitHub-Delivery", testCase.deliveryID)
+			}
+			req.Header.Set("X-Hub-Signature-256", githubTestSignature("secret", testCase.body))
+			res := httptest.NewRecorder()
+			if testCase.withRoute {
+				ingestTestGitHubWebhook(testCase.handler, res, req)
+			} else {
+				testCase.handler.IngestGitHubWebhook(res, req)
+			}
+			if res.Code != testCase.wantStatus {
+				t.Fatalf("expected status %d, got %d body=%s", testCase.wantStatus, res.Code, res.Body.String())
+			}
+		})
 	}
 }
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -134,7 +134,7 @@ func NewRouter(buildHandler *handler.BuildHandler, artifactHandler *handler.Arti
 		})
 
 		r.Route("/webhooks", func(r chi.Router) {
-			r.Post("/github", eventHandler.IngestGitHubWebhook)
+			r.Post("/github/apps/{registrationID}", eventHandler.IngestGitHubWebhook)
 		})
 
 		r.Group(func(r chi.Router) {

--- a/backend/internal/http/router_test.go
+++ b/backend/internal/http/router_test.go
@@ -89,7 +89,7 @@ func TestNewRouter_HealthAndNotFound(t *testing.T) {
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository())
 	h.SetJobService(jobSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	tests := []struct {
@@ -129,7 +129,7 @@ func TestNewRouter_ArtifactRoutesPreferCatalogAndVersionTags(t *testing.T) {
 	buildHandler := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jobHandler := handler.NewJobHandler(jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	jobID := "job-1"
 	artifactRepo := &routeArtifactRepo{
 		records: []domain.ArtifactRecord{{
@@ -195,7 +195,7 @@ func TestNewRouter_ServerInfoAndWorkerRoutes(t *testing.T) {
 	buildHandler := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jobHandler := handler.NewJobHandler(jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	workerSvc := workersvc.NewVisibilityService(workerRepo, routerWorkerBuildBoundary{})
 	workerHandler := handler.NewWorkerHandler(workerSvc)
 
@@ -240,7 +240,7 @@ func TestNewRouter_SCMRoutes(t *testing.T) {
 	buildHandler := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jobHandler := handler.NewJobHandler(jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	scmHandler := handler.NewSCMHandler(service.NewSCMAdminService(repositorymemory.NewSCMConnectionRepository(), repositorymemory.NewSCMRepositoryRegistrationRepository()))
 
 	router := NewRouter(buildHandler, nil, jobHandler, nil, nil, nil, eventHandler, "", WithSCMHandler(scmHandler))
@@ -544,8 +544,8 @@ func TestNewRouter_HeaderModeHealthAndIngressBypassIdentityHeaders(t *testing.T)
 		t.Fatalf("expected push ingress status %d, got %d body=%s", http.StatusOK, pushRes.Code, pushRes.Body.String())
 	}
 
-	body := []byte(`{}`)
-	webhookReq := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	body := []byte(`{"installation":{"id":999}}`)
+	webhookReq := httptest.NewRequest(http.MethodPost, "/api/webhooks/github/apps/registration-1", bytes.NewReader(body))
 	webhookReq.Header.Set("X-GitHub-Event", "pull_request")
 	webhookReq.Header.Set("X-GitHub-Delivery", "delivery-router-test")
 	webhookReq.Header.Set("X-Hub-Signature-256", githubRouterTestSignature("github-secret", body))
@@ -553,6 +553,13 @@ func TestNewRouter_HeaderModeHealthAndIngressBypassIdentityHeaders(t *testing.T)
 	r.ServeHTTP(webhookRes, webhookReq)
 	if webhookRes.Code != http.StatusAccepted {
 		t.Fatalf("expected webhook ingress status %d, got %d body=%s", http.StatusAccepted, webhookRes.Code, webhookRes.Body.String())
+	}
+
+	legacyReq := httptest.NewRequest(http.MethodPost, "/api/webhooks/github", bytes.NewReader(body))
+	legacyRes := httptest.NewRecorder()
+	r.ServeHTTP(legacyRes, legacyReq)
+	if legacyRes.Code != http.StatusNotFound {
+		t.Fatalf("expected removed global webhook route status %d, got %d body=%s", http.StatusNotFound, legacyRes.Code, legacyRes.Body.String())
 	}
 }
 
@@ -704,7 +711,7 @@ func TestNewRouter_BuildRoutes(t *testing.T) {
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithArtifactTriggerDeliveryRepository(repositorymemory.NewArtifactTriggerDeliveryRepository())
 	h.SetJobService(jobSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/builds/", bytes.NewBufferString(`{"project_id":"11111111-1111-1111-1111-111111111111"}`))
@@ -811,7 +818,7 @@ func TestNewRouter_QueueBuild_WithTemplate_PersistsTemplateSteps(t *testing.T) {
 	h := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/builds/", bytes.NewBufferString(`{"project_id":"11111111-1111-1111-1111-111111111111"}`))
@@ -888,7 +895,7 @@ func newIdentityTestRouter(mode auth.Mode, pushEventSecret string, githubWebhook
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jobHandler := handler.NewJobHandler(jobSvc)
 	webhookSvc := webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), githubWebhookSecret)
+	eventHandler := handler.NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{secret: githubWebhookSecret})
 	userService := service.NewUserService(repositorymemory.NewUserRepository())
 	userHandler := handler.NewUserHandler(userService, mode)
 	authMiddleware := auth.Middleware(auth.MiddlewareConfig{Mode: mode}, userService)
@@ -911,6 +918,24 @@ func newIdentityTestRouter(mode auth.Mode, pushEventSecret string, githubWebhook
 	)
 }
 
+type routerTestGitHubWebhookResolver struct {
+	secret string
+}
+
+func (r routerTestGitHubWebhookResolver) ResolveRegistrationSecret(_ context.Context, registrationID string) (string, error) {
+	if registrationID != "registration-1" {
+		return "", webhooksvc.ErrGitHubWebhookRegistrationNotFound
+	}
+	return r.secret, nil
+}
+
+func (r routerTestGitHubWebhookResolver) ResolveConnection(_ context.Context, registrationID string, installationID string) (webhooksvc.GitHubWebhookConnectionResolution, error) {
+	if registrationID != "registration-1" || installationID != "999" {
+		return webhooksvc.GitHubWebhookConnectionResolution{}, nil
+	}
+	return webhooksvc.GitHubWebhookConnectionResolution{ConnectionID: "connection-1", Found: true, Enabled: true}, nil
+}
+
 func newOIDCTestRouter(t *testing.T) (http.Handler, *auth.CookieSessionManager) {
 	t.Helper()
 	buildRepo := repositorymemory.NewBuildRepository()
@@ -920,7 +945,7 @@ func newOIDCTestRouter(t *testing.T) (http.Handler, *auth.CookieSessionManager) 
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jobHandler := handler.NewJobHandler(jobSvc)
 	webhookSvc := webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), "")
+	eventHandler := handler.NewEventHandler(jobSvc, webhookSvc, observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	userRepo := repositorymemory.NewUserRepository()
 	if _, err := userRepo.Create(context.Background(), domain.User{ID: "user-1", Email: "user@example.com", GlobalRole: domain.GlobalRoleUser, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("create user failed: %v", err)
@@ -960,7 +985,7 @@ func newProjectMembershipTestRouter(t *testing.T, mode auth.Mode) http.Handler {
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithProjectRepository(projectRepo)
 	jobHandler := handler.NewJobHandler(jobSvc)
 	projectHandler := handler.NewProjectHandler(service.NewProjectService(projectRepo), jobSvc)
-	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "github-secret")
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{secret: "github-secret"})
 	userRepo := repositorymemory.NewUserRepository()
 	userService := service.NewUserService(userRepo)
 	membershipRepo := repositorymemory.NewProjectMembershipRepository(projectRepo, userRepo)
@@ -1087,7 +1112,7 @@ func newRBACTestRouter(t *testing.T) rbacRouterFixture {
 	jobHandler.SetAuthorization(auth.ModeHeader, membershipService)
 	projectHandler := handler.NewProjectHandler(projectService, jobSvc)
 	projectHandler.SetAuthorization(auth.ModeHeader, membershipService)
-	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eventHandler := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	authMiddleware := auth.Middleware(auth.MiddlewareConfig{Mode: auth.ModeHeader, APITokens: apiTokenService}, userService)
 
 	router := NewRouter(
@@ -1285,7 +1310,7 @@ func TestNewRouter_QueueBuild_UnknownTemplate_FallsBackToDefaultStep(t *testing.
 	h := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/builds/", bytes.NewBufferString(`{"project_id":"11111111-1111-1111-1111-111111111111"}`))
@@ -1357,7 +1382,7 @@ func TestNewRouter_JobRoutes(t *testing.T) {
 	h := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	createBody := `{"project_id":"project-1","name":"backend-ci","repository_url":"https://github.com/example/backend.git","default_ref":"main","pipeline_yaml":"version: 1\nsteps:\n  - name: test\n    run: go test ./...\n","enabled":true}`
@@ -1410,7 +1435,7 @@ func TestNewRouter_PushEventRoute(t *testing.T) {
 	h := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc)
 	jh := handler.NewJobHandler(jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, nil, nil, nil, eh, "")
 
 	createBody := `{"project_id":"project-1","name":"backend-ci","repository_url":"https://github.com/example/backend.git","default_ref":"main","push_enabled":true,"push_branch":"main","pipeline_yaml":"version: 1\nsteps:\n  - name: test\n    run: go test ./...\n","enabled":true}`
@@ -1439,7 +1464,7 @@ func TestNewRouter_ProjectRoutes(t *testing.T) {
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithProjectRepository(projectRepo)
 	jh := handler.NewJobHandler(jobSvc)
 	ph := handler.NewProjectHandler(service.NewProjectService(projectRepo), jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, jh, ph, nil, nil, eh, "")
 
 	createReq := httptest.NewRequest(http.MethodPost, "/api/projects/", bytes.NewBufferString(`{"name":"Platform","slug":"platform"}`))
@@ -1496,7 +1521,7 @@ func TestNewRouter_ProjectDuplicateSlugReturnsConflict(t *testing.T) {
 	h := handler.NewBuildHandler(buildSvc)
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithProjectRepository(projectRepo)
 	ph := handler.NewProjectHandler(service.NewProjectService(projectRepo), jobSvc)
-	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), "")
+	eh := handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{})
 	r := NewRouter(h, nil, handler.NewJobHandler(jobSvc), ph, nil, nil, eh, "")
 
 	body := `{"name":"Platform","slug":"platform"}`
@@ -1523,7 +1548,7 @@ func TestNewRouter_ProjectDeleteDefaultReturnsConflict(t *testing.T) {
 	jobSvc := service.NewJobService(jobRepo, buildSvc).WithProjectRepository(projectRepo)
 	projectSvc := service.NewProjectService(projectRepo)
 	ph := handler.NewProjectHandler(projectSvc, jobSvc)
-	r := NewRouter(handler.NewBuildHandler(buildSvc), nil, handler.NewJobHandler(jobSvc), ph, nil, nil, handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), ""), "")
+	r := NewRouter(handler.NewBuildHandler(buildSvc), nil, handler.NewJobHandler(jobSvc), ph, nil, nil, handler.NewEventHandler(jobSvc, webhooksvc.NewDeliveryIngressService(repositorymemory.NewWebhookDeliveryRepository(), jobSvc), observability.NewNoopWebhookIngressMetrics(), routerTestGitHubWebhookResolver{}), "")
 
 	_, err := projectRepo.Create(httptest.NewRequest(http.MethodGet, "/", nil).Context(), domain.Project{
 		ID:   "00000000-0000-0000-0000-000000000001",

--- a/backend/internal/repository/memory/scm_connection_repository.go
+++ b/backend/internal/repository/memory/scm_connection_repository.go
@@ -108,6 +108,17 @@ func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(_ contex
 	return domain.SCMConnectionDetail{Connection: connection, GitHubAppRegistration: &registration, GitHubAppInstallation: &installation}, nil
 }
 
+func (r *SCMConnectionRepository) GetGitHubAppInstallationConnection(_ context.Context, registrationID string, installationID string) (domain.SCMConnectionDetail, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	connectionID, ok := r.installationIndex[installationIndexKey(registrationID, installationID)]
+	if !ok {
+		return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+	}
+	return r.detailLocked(connectionID), nil
+}
+
 func (r *SCMConnectionRepository) List(_ context.Context) ([]domain.SCMConnectionDetail, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/backend/internal/repository/memory/scm_connection_repository_test.go
+++ b/backend/internal/repository/memory/scm_connection_repository_test.go
@@ -166,6 +166,51 @@ func TestSCMConnectionRepository_ReusesMatchingGitHubAppRegistrationAndScopesIns
 	}
 }
 
+func TestSCMConnectionRepository_GetGitHubAppInstallationConnectionScopesByRegistration(t *testing.T) {
+	repo := NewSCMConnectionRepository()
+	now := time.Now().UTC()
+	firstRegistration := testGitHubAppRegistration(now, "registration-1")
+	secondRegistration := testGitHubAppRegistration(now, "registration-2")
+	secondRegistration.AppID = "54321"
+	secondRegistration.APIBaseURL = "https://ghe.example/api/v3"
+	secondRegistration.WebBaseURL = "https://ghe.example"
+	for _, registration := range []domain.GitHubAppRegistration{firstRegistration, secondRegistration} {
+		if _, err := repo.CreateGitHubAppRegistration(context.Background(), registration); err != nil {
+			t.Fatalf("create registration %q: %v", registration.ID, err)
+		}
+	}
+
+	first := testGitHubConnectionDetail(now, "connection-1", firstRegistration, "999", "octo")
+	second := testGitHubConnectionDetail(now, "connection-2", secondRegistration, "999", "acme")
+	second.Connection.APIBaseURL = secondRegistration.APIBaseURL
+	second.Connection.WebBaseURL = secondRegistration.WebBaseURL
+	second.Connection.DeploymentKind = domain.SCMDeploymentKindSelfHosted
+	for _, detail := range []domain.SCMConnectionDetail{first, second} {
+		if _, err := repo.CreateGitHubAppInstallationConnection(context.Background(), detail); err != nil {
+			t.Fatalf("create connection %q: %v", detail.Connection.ID, err)
+		}
+	}
+
+	found, findErr := repo.GetGitHubAppInstallationConnection(context.Background(), "registration-1", "999")
+	if findErr != nil {
+		t.Fatalf("find connection: %v", findErr)
+	}
+	if found.Connection.ID != "connection-1" {
+		t.Fatalf("expected connection-1, got %q", found.Connection.ID)
+	}
+	other, otherErr := repo.GetGitHubAppInstallationConnection(context.Background(), "registration-2", "999")
+	if otherErr != nil {
+		t.Fatalf("find second connection: %v", otherErr)
+	}
+	if other.Connection.ID != "connection-2" {
+		t.Fatalf("expected connection-2, got %q", other.Connection.ID)
+	}
+	_, missingErr := repo.GetGitHubAppInstallationConnection(context.Background(), "missing-registration", "999")
+	if !errors.Is(missingErr, repository.ErrSCMConnectionNotFound) {
+		t.Fatalf("expected scoped lookup not found, got %v", missingErr)
+	}
+}
+
 func testGitHubAppRegistration(now time.Time, registrationID string) domain.GitHubAppRegistration {
 	return domain.GitHubAppRegistration{ID: registrationID, AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "secret/github/private-key", WebhookSecretRef: "secret/github/webhook", CreatedAt: now, UpdatedAt: now}
 }

--- a/backend/internal/repository/postgres/scm_connection_repository.go
+++ b/backend/internal/repository/postgres/scm_connection_repository.go
@@ -171,6 +171,24 @@ func (r *SCMConnectionRepository) CreateGitHubAppInstallationConnection(ctx cont
 	return domain.SCMConnectionDetail{Connection: detail.Connection, GitHubAppRegistration: &registration, GitHubAppInstallation: &installation}, nil
 }
 
+func (r *SCMConnectionRepository) GetGitHubAppInstallationConnection(ctx context.Context, registrationID string, installationID string) (domain.SCMConnectionDetail, error) {
+	const query = `
+		SELECT ` + scmConnectionColumns + `
+		FROM github_app_installations gi
+		JOIN scm_connections c ON c.id = gi.connection_id
+		JOIN github_app_registrations ga ON ga.id = gi.app_registration_id
+		WHERE gi.app_registration_id = $1 AND gi.installation_id = $2
+	`
+	item, err := scanSCMConnectionDetail(r.db.QueryRowContext(ctx, query, registrationID, installationID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+		}
+		return domain.SCMConnectionDetail{}, err
+	}
+	return item, nil
+}
+
 func (r *SCMConnectionRepository) List(ctx context.Context) ([]domain.SCMConnectionDetail, error) {
 	const query = `
 		SELECT ` + scmConnectionColumns + `

--- a/backend/internal/repository/postgres/scm_connection_repository_test.go
+++ b/backend/internal/repository/postgres/scm_connection_repository_test.go
@@ -223,6 +223,39 @@ func TestSCMConnectionRepository_GetListAndSetEnabled(t *testing.T) {
 	}
 }
 
+func TestSCMConnectionRepository_GetGitHubAppInstallationConnectionScopesByRegistration(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSCMConnectionRepository(db)
+	now := time.Now().UTC()
+	mock.ExpectQuery(`FROM github_app_installations gi.*WHERE gi.app_registration_id = \$1 AND gi.installation_id = \$2`).
+		WithArgs("registration-1", "999").
+		WillReturnRows(scmConnectionDetailTestRows(now))
+	found, findErr := repo.GetGitHubAppInstallationConnection(context.Background(), "registration-1", "999")
+	if findErr != nil {
+		t.Fatalf("find connection: %v", findErr)
+	}
+	if found.Connection.ID != "connection-1" || found.GitHubAppInstallation == nil || found.GitHubAppInstallation.AppRegistrationID != "registration-1" {
+		t.Fatalf("unexpected connection detail: %+v", found)
+	}
+
+	mock.ExpectQuery(`FROM github_app_installations gi.*WHERE gi.app_registration_id = \$1 AND gi.installation_id = \$2`).
+		WithArgs("registration-2", "999").
+		WillReturnError(sql.ErrNoRows)
+	_, missingErr := repo.GetGitHubAppInstallationConnection(context.Background(), "registration-2", "999")
+	if missingErr != repository.ErrSCMConnectionNotFound {
+		t.Fatalf("expected scoped not found error, got %v", missingErr)
+	}
+
+	if expectationsErr := mock.ExpectationsWereMet(); expectationsErr != nil {
+		t.Fatalf("unmet expectations: %v", expectationsErr)
+	}
+}
+
 func testPostgresGitHubConnectionDetail(now time.Time) domain.SCMConnectionDetail {
 	registration := testPostgresGitHubAppRegistration(now)
 	return domain.SCMConnectionDetail{

--- a/backend/internal/repository/scm_connection_repository.go
+++ b/backend/internal/repository/scm_connection_repository.go
@@ -19,6 +19,7 @@ type SCMConnectionRepository interface {
 	ListGitHubAppRegistrations(ctx context.Context) ([]domain.GitHubAppRegistration, error)
 	GetGitHubAppRegistrationByID(ctx context.Context, id string) (domain.GitHubAppRegistration, error)
 	CreateGitHubAppInstallationConnection(ctx context.Context, detail domain.SCMConnectionDetail) (domain.SCMConnectionDetail, error)
+	GetGitHubAppInstallationConnection(ctx context.Context, registrationID string, installationID string) (domain.SCMConnectionDetail, error)
 	List(ctx context.Context) ([]domain.SCMConnectionDetail, error)
 	GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
 	SetEnabled(ctx context.Context, id string, enabled bool, updatedAt time.Time) (domain.SCMConnectionDetail, error)

--- a/backend/internal/service/scm_admin_service_test.go
+++ b/backend/internal/service/scm_admin_service_test.go
@@ -857,6 +857,10 @@ func (f *fakeSCMConnectionRepositoryForMismatch) CreateGitHubAppInstallationConn
 	return domain.SCMConnectionDetail{}, nil
 }
 
+func (f *fakeSCMConnectionRepositoryForMismatch) GetGitHubAppInstallationConnection(context.Context, string, string) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+}
+
 func (f *fakeSCMConnectionRepositoryForMismatch) List(context.Context) ([]domain.SCMConnectionDetail, error) {
 	return nil, nil
 }

--- a/backend/internal/service/webhook/github_connection_resolver.go
+++ b/backend/internal/service/webhook/github_connection_resolver.go
@@ -1,0 +1,83 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+)
+
+var ErrGitHubWebhookRegistrationNotFound = errors.New("github webhook registration not found")
+var ErrGitHubWebhookSecretUnavailable = errors.New("github webhook secret is unavailable")
+var ErrGitHubWebhookConnectionIncompatible = errors.New("github webhook connection is incompatible")
+
+type GitHubWebhookConnectionResolver interface {
+	ResolveRegistrationSecret(ctx context.Context, registrationID string) (string, error)
+	ResolveConnection(ctx context.Context, registrationID string, installationID string) (GitHubWebhookConnectionResolution, error)
+}
+
+type GitHubWebhookConnectionResolution struct {
+	ConnectionID string
+	Found        bool
+	Enabled      bool
+}
+
+type githubWebhookConnectionRepository interface {
+	GetGitHubAppRegistrationByID(ctx context.Context, id string) (domain.GitHubAppRegistration, error)
+	GetGitHubAppInstallationConnection(ctx context.Context, registrationID string, installationID string) (domain.SCMConnectionDetail, error)
+}
+
+type githubWebhookSecretResolver interface {
+	Resolve(ctx context.Context, ref string) (string, error)
+}
+
+type GitHubConnectionResolver struct {
+	connections githubWebhookConnectionRepository
+	secrets     githubWebhookSecretResolver
+}
+
+func NewGitHubConnectionResolver(connections githubWebhookConnectionRepository, secrets githubWebhookSecretResolver) *GitHubConnectionResolver {
+	return &GitHubConnectionResolver{connections: connections, secrets: secrets}
+}
+
+func (r *GitHubConnectionResolver) ResolveRegistrationSecret(ctx context.Context, registrationID string) (string, error) {
+	if r == nil || r.connections == nil {
+		return "", ErrGitHubWebhookRegistrationNotFound
+	}
+	registration, err := r.connections.GetGitHubAppRegistrationByID(ctx, strings.TrimSpace(registrationID))
+	if err != nil {
+		if errors.Is(err, repository.ErrSCMGitHubAppRegistrationNotFound) {
+			return "", ErrGitHubWebhookRegistrationNotFound
+		}
+		return "", err
+	}
+	if r.secrets == nil || strings.TrimSpace(registration.WebhookSecretRef) == "" {
+		return "", ErrGitHubWebhookSecretUnavailable
+	}
+	secret, err := r.secrets.Resolve(ctx, registration.WebhookSecretRef)
+	if err != nil || strings.TrimSpace(secret) == "" {
+		return "", ErrGitHubWebhookSecretUnavailable
+	}
+	return secret, nil
+}
+
+func (r *GitHubConnectionResolver) ResolveConnection(ctx context.Context, registrationID string, installationID string) (GitHubWebhookConnectionResolution, error) {
+	if r == nil || r.connections == nil {
+		return GitHubWebhookConnectionResolution{}, ErrGitHubWebhookConnectionIncompatible
+	}
+	registrationID = strings.TrimSpace(registrationID)
+	installationID = strings.TrimSpace(installationID)
+	detail, err := r.connections.GetGitHubAppInstallationConnection(ctx, registrationID, installationID)
+	if err != nil {
+		if errors.Is(err, repository.ErrSCMConnectionNotFound) {
+			return GitHubWebhookConnectionResolution{}, nil
+		}
+		return GitHubWebhookConnectionResolution{}, err
+	}
+	if detail.Connection.Provider != domain.SCMProviderGitHub || detail.GitHubAppRegistration == nil || detail.GitHubAppInstallation == nil || detail.GitHubAppRegistration.ID != registrationID || detail.GitHubAppInstallation.AppRegistrationID != registrationID || detail.GitHubAppInstallation.InstallationID != installationID {
+		return GitHubWebhookConnectionResolution{}, ErrGitHubWebhookConnectionIncompatible
+	}
+	return GitHubWebhookConnectionResolution{ConnectionID: detail.Connection.ID, Found: true, Enabled: detail.Connection.Enabled}, nil
+}

--- a/backend/internal/service/webhook/github_connection_resolver_test.go
+++ b/backend/internal/service/webhook/github_connection_resolver_test.go
@@ -88,6 +88,43 @@ func TestGitHubConnectionResolver_HidesSecretResolutionFailure(t *testing.T) {
 	}
 }
 
+func TestGitHubConnectionResolver_ResolveConnectionRejectsIncompatibleDetails(t *testing.T) {
+	now := time.Now().UTC()
+	registration := testWebhookGitHubRegistration(now, "registration-a", "secret-a")
+	detail := testWebhookGitHubConnection(now, "connection-a", registration, "999")
+	detail.GitHubAppInstallation.InstallationID = "different"
+	resolver := NewGitHubConnectionResolver(&fakeWebhookConnectionRepository{registration: registration, detail: detail}, fakeWebhookSecretResolver{})
+
+	_, resolveErr := resolver.ResolveConnection(context.Background(), " registration-a ", " 999 ")
+	if !errors.Is(resolveErr, ErrGitHubWebhookConnectionIncompatible) {
+		t.Fatalf("expected incompatible connection error, got %v", resolveErr)
+	}
+}
+
+func TestGitHubConnectionResolver_ResolveConnectionPropagatesRepositoryFailures(t *testing.T) {
+	repositoryErr := errors.New("database unavailable")
+	resolver := NewGitHubConnectionResolver(&fakeWebhookConnectionRepository{connectionErr: repositoryErr}, fakeWebhookSecretResolver{})
+
+	_, resolveErr := resolver.ResolveConnection(context.Background(), "registration-a", "999")
+	if !errors.Is(resolveErr, repositoryErr) {
+		t.Fatalf("expected repository error %v, got %v", repositoryErr, resolveErr)
+	}
+}
+
+func TestGitHubConnectionResolver_RequiresRegistrationAndSecretConfiguration(t *testing.T) {
+	if _, err := (*GitHubConnectionResolver)(nil).ResolveRegistrationSecret(context.Background(), "registration-a"); !errors.Is(err, ErrGitHubWebhookRegistrationNotFound) {
+		t.Fatalf("expected nil resolver registration error, got %v", err)
+	}
+	if _, err := (*GitHubConnectionResolver)(nil).ResolveConnection(context.Background(), "registration-a", "999"); !errors.Is(err, ErrGitHubWebhookConnectionIncompatible) {
+		t.Fatalf("expected nil resolver connection error, got %v", err)
+	}
+
+	resolver := NewGitHubConnectionResolver(&fakeWebhookConnectionRepository{registration: domain.GitHubAppRegistration{ID: "registration-a"}}, fakeWebhookSecretResolver{})
+	if _, err := resolver.ResolveRegistrationSecret(context.Background(), "registration-a"); !errors.Is(err, ErrGitHubWebhookSecretUnavailable) {
+		t.Fatalf("expected missing secret reference error, got %v", err)
+	}
+}
+
 type fakeWebhookSecretResolver struct {
 	values map[string]string
 	err    error
@@ -101,7 +138,9 @@ func (r fakeWebhookSecretResolver) Resolve(_ context.Context, ref string) (strin
 }
 
 type fakeWebhookConnectionRepository struct {
-	registration domain.GitHubAppRegistration
+	registration  domain.GitHubAppRegistration
+	detail        domain.SCMConnectionDetail
+	connectionErr error
 }
 
 func (r *fakeWebhookConnectionRepository) GetGitHubAppRegistrationByID(_ context.Context, id string) (domain.GitHubAppRegistration, error) {
@@ -111,7 +150,13 @@ func (r *fakeWebhookConnectionRepository) GetGitHubAppRegistrationByID(_ context
 	return r.registration, nil
 }
 
-func (r *fakeWebhookConnectionRepository) GetGitHubAppInstallationConnection(context.Context, string, string) (domain.SCMConnectionDetail, error) {
+func (r *fakeWebhookConnectionRepository) GetGitHubAppInstallationConnection(_ context.Context, _ string, _ string) (domain.SCMConnectionDetail, error) {
+	if r.connectionErr != nil {
+		return domain.SCMConnectionDetail{}, r.connectionErr
+	}
+	if r.detail.Connection.ID != "" {
+		return r.detail, nil
+	}
 	return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
 }
 

--- a/backend/internal/service/webhook/github_connection_resolver_test.go
+++ b/backend/internal/service/webhook/github_connection_resolver_test.go
@@ -1,0 +1,128 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+	memoryrepo "github.com/radiation/coyote-ci/backend/internal/repository/memory"
+)
+
+func TestGitHubConnectionResolver_ResolvesRegistrationSecretAndExactConnection(t *testing.T) {
+	now := time.Now().UTC()
+	connections := memoryrepo.NewSCMConnectionRepository()
+	registrationA := testWebhookGitHubRegistration(now, "registration-a", "secret-a")
+	registrationB := testWebhookGitHubRegistration(now, "registration-b", "secret-b")
+	registrationB.AppID = "54321"
+	registrationB.APIBaseURL = "https://ghe.example/api/v3"
+	registrationB.WebBaseURL = "https://ghe.example"
+	for _, registration := range []domain.GitHubAppRegistration{registrationA, registrationB} {
+		if _, err := connections.CreateGitHubAppRegistration(context.Background(), registration); err != nil {
+			t.Fatalf("create registration %q: %v", registration.ID, err)
+		}
+	}
+	connectionA := testWebhookGitHubConnection(now, "connection-a", registrationA, "999")
+	connectionB := testWebhookGitHubConnection(now, "connection-b", registrationB, "999")
+	connectionB.Connection.APIBaseURL = registrationB.APIBaseURL
+	connectionB.Connection.WebBaseURL = registrationB.WebBaseURL
+	connectionB.Connection.DeploymentKind = domain.SCMDeploymentKindSelfHosted
+	for _, detail := range []domain.SCMConnectionDetail{connectionA, connectionB} {
+		if _, err := connections.CreateGitHubAppInstallationConnection(context.Background(), detail); err != nil {
+			t.Fatalf("create connection %q: %v", detail.Connection.ID, err)
+		}
+	}
+
+	resolver := NewGitHubConnectionResolver(connections, fakeWebhookSecretResolver{values: map[string]string{"secret-a": "webhook-a", "secret-b": "webhook-b"}})
+	secret, secretErr := resolver.ResolveRegistrationSecret(context.Background(), "registration-a")
+	if secretErr != nil || secret != "webhook-a" {
+		t.Fatalf("expected registration-a secret, got secret=%q err=%v", secret, secretErr)
+	}
+	resolved, resolveErr := resolver.ResolveConnection(context.Background(), "registration-a", "999")
+	if resolveErr != nil {
+		t.Fatalf("resolve connection: %v", resolveErr)
+	}
+	if !resolved.Found || resolved.ConnectionID != "connection-a" || !resolved.Enabled {
+		t.Fatalf("expected enabled connection-a, got %+v", resolved)
+	}
+}
+
+func TestGitHubConnectionResolver_UnknownAndDisabledConnectionsAreNoOpCandidates(t *testing.T) {
+	now := time.Now().UTC()
+	connections := memoryrepo.NewSCMConnectionRepository()
+	registration := testWebhookGitHubRegistration(now, "registration-a", "secret-a")
+	if _, err := connections.CreateGitHubAppRegistration(context.Background(), registration); err != nil {
+		t.Fatalf("create registration: %v", err)
+	}
+	detail := testWebhookGitHubConnection(now, "connection-a", registration, "999")
+	if _, err := connections.CreateGitHubAppInstallationConnection(context.Background(), detail); err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+	if _, err := connections.SetEnabled(context.Background(), "connection-a", false, now); err != nil {
+		t.Fatalf("disable connection: %v", err)
+	}
+
+	resolver := NewGitHubConnectionResolver(connections, fakeWebhookSecretResolver{values: map[string]string{"secret-a": "webhook-a"}})
+	disabled, disabledErr := resolver.ResolveConnection(context.Background(), "registration-a", "999")
+	if disabledErr != nil || !disabled.Found || disabled.Enabled {
+		t.Fatalf("expected disabled match, got result=%+v err=%v", disabled, disabledErr)
+	}
+	unknown, unknownErr := resolver.ResolveConnection(context.Background(), "registration-a", "missing")
+	if unknownErr != nil || unknown.Found {
+		t.Fatalf("expected unknown connection no-op candidate, got result=%+v err=%v", unknown, unknownErr)
+	}
+}
+
+func TestGitHubConnectionResolver_HidesSecretResolutionFailure(t *testing.T) {
+	connections := &fakeWebhookConnectionRepository{registration: domain.GitHubAppRegistration{ID: "registration-a", WebhookSecretRef: "secret-a"}}
+	resolver := NewGitHubConnectionResolver(connections, fakeWebhookSecretResolver{err: errors.New("secret-a is missing")})
+	_, err := resolver.ResolveRegistrationSecret(context.Background(), "registration-a")
+	if !errors.Is(err, ErrGitHubWebhookSecretUnavailable) || err.Error() != ErrGitHubWebhookSecretUnavailable.Error() {
+		t.Fatalf("expected masked secret resolution error, got %v", err)
+	}
+	_, err = resolver.ResolveRegistrationSecret(context.Background(), "missing")
+	if !errors.Is(err, ErrGitHubWebhookRegistrationNotFound) {
+		t.Fatalf("expected registration not found, got %v", err)
+	}
+}
+
+type fakeWebhookSecretResolver struct {
+	values map[string]string
+	err    error
+}
+
+func (r fakeWebhookSecretResolver) Resolve(_ context.Context, ref string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.values[ref], nil
+}
+
+type fakeWebhookConnectionRepository struct {
+	registration domain.GitHubAppRegistration
+}
+
+func (r *fakeWebhookConnectionRepository) GetGitHubAppRegistrationByID(_ context.Context, id string) (domain.GitHubAppRegistration, error) {
+	if id != r.registration.ID {
+		return domain.GitHubAppRegistration{}, repository.ErrSCMGitHubAppRegistrationNotFound
+	}
+	return r.registration, nil
+}
+
+func (r *fakeWebhookConnectionRepository) GetGitHubAppInstallationConnection(context.Context, string, string) (domain.SCMConnectionDetail, error) {
+	return domain.SCMConnectionDetail{}, repository.ErrSCMConnectionNotFound
+}
+
+func testWebhookGitHubRegistration(now time.Time, id string, secretRef string) domain.GitHubAppRegistration {
+	return domain.GitHubAppRegistration{ID: id, AppID: "12345", APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", PrivateKeySecretRef: "private-key", WebhookSecretRef: secretRef, CreatedAt: now, UpdatedAt: now}
+}
+
+func testWebhookGitHubConnection(now time.Time, connectionID string, registration domain.GitHubAppRegistration, installationID string) domain.SCMConnectionDetail {
+	return domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: connectionID, Provider: domain.SCMProviderGitHub, DisplayName: connectionID, DeploymentKind: domain.SCMDeploymentKindCloud, APIBaseURL: "https://api.github.com", WebBaseURL: "https://github.com", Enabled: true, HealthStatus: domain.SCMConnectionHealthStatusUnknown, CreatedAt: now, UpdatedAt: now},
+		GitHubAppRegistration: &registration,
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: connectionID, AppRegistrationID: registration.ID, InstallationID: installationID, AccountLogin: "octo", AccountType: "organization", AccountID: "42", CreatedAt: now, UpdatedAt: now},
+	}
+}

--- a/backend/internal/service/webhook/ingress.go
+++ b/backend/internal/service/webhook/ingress.go
@@ -104,6 +104,15 @@ func (s *DeliveryIngressService) MarkUnsupported(ctx context.Context, delivery d
 	return s.updateDelivery(ctx, delivery, domain.WebhookDeliveryStatusUnsupported, reasonPtr)
 }
 
+func (s *DeliveryIngressService) MarkVerifiedNoMatch(ctx context.Context, delivery domain.WebhookDelivery, reason string, trigger WebhookTriggerInput) (domain.WebhookDelivery, error) {
+	delivery = applyDeliveryTriggerMetadata(delivery, trigger)
+	verified, err := s.updateDelivery(ctx, delivery, domain.WebhookDeliveryStatusVerified, nil)
+	if err != nil {
+		return domain.WebhookDelivery{}, err
+	}
+	return s.updateDelivery(ctx, verified, domain.WebhookDeliveryStatusIgnoredNoMatch, optionalDeliveryString(reason))
+}
+
 func (s *DeliveryIngressService) ProcessVerifiedEvent(ctx context.Context, delivery domain.WebhookDelivery, trigger WebhookTriggerInput) (DeliveryIngressResult, error) {
 	if s.deliveryRepo == nil {
 		return DeliveryIngressResult{}, ErrDeliveryRepoNotConfigured

--- a/backend/internal/service/webhook/ingress.go
+++ b/backend/internal/service/webhook/ingress.go
@@ -104,15 +104,6 @@ func (s *DeliveryIngressService) MarkUnsupported(ctx context.Context, delivery d
 	return s.updateDelivery(ctx, delivery, domain.WebhookDeliveryStatusUnsupported, reasonPtr)
 }
 
-func (s *DeliveryIngressService) MarkVerifiedNoMatch(ctx context.Context, delivery domain.WebhookDelivery, reason string, trigger WebhookTriggerInput) (domain.WebhookDelivery, error) {
-	delivery = applyDeliveryTriggerMetadata(delivery, trigger)
-	verified, err := s.updateDelivery(ctx, delivery, domain.WebhookDeliveryStatusVerified, nil)
-	if err != nil {
-		return domain.WebhookDelivery{}, err
-	}
-	return s.updateDelivery(ctx, verified, domain.WebhookDeliveryStatusIgnoredNoMatch, optionalDeliveryString(reason))
-}
-
 func (s *DeliveryIngressService) ProcessVerifiedEvent(ctx context.Context, delivery domain.WebhookDelivery, trigger WebhookTriggerInput) (DeliveryIngressResult, error) {
 	if s.deliveryRepo == nil {
 		return DeliveryIngressResult{}, ErrDeliveryRepoNotConfigured

--- a/backend/internal/service/webhook/ingress_test.go
+++ b/backend/internal/service/webhook/ingress_test.go
@@ -113,6 +113,24 @@ func TestDeliveryIngressService_ProcessVerifiedEvent_TriggerFailureMarksFailed(t
 	}
 }
 
+func TestDeliveryIngressService_MarkUnsupportedRecordsTriggerMetadata(t *testing.T) {
+	ctx := context.Background()
+	deliveryRepo := memoryrepo.NewWebhookDeliveryRepository()
+	service := NewDeliveryIngressService(deliveryRepo, &recordingWebhookTriggerer{})
+	delivery := seedReceivedDelivery(t, ctx, deliveryRepo)
+
+	updated, markErr := service.MarkUnsupported(ctx, delivery, "unsupported event", sampleWebhookTrigger())
+	if markErr != nil {
+		t.Fatalf("mark unsupported: %v", markErr)
+	}
+	if updated.Status != domain.WebhookDeliveryStatusUnsupported {
+		t.Fatalf("expected unsupported status, got %q", updated.Status)
+	}
+	if readOptionalDeliveryString(updated.Reason) != "unsupported event" || readOptionalDeliveryString(updated.EventType) != "push" {
+		t.Fatalf("expected unsupported metadata, got %+v", updated)
+	}
+}
+
 func seedReceivedDelivery(t *testing.T, ctx context.Context, repo *memoryrepo.WebhookDeliveryRepository) domain.WebhookDelivery {
 	t.Helper()
 	delivery, createErr := repo.Create(ctx, domain.WebhookDelivery{

--- a/backend/internal/service/webhook/types.go
+++ b/backend/internal/service/webhook/types.go
@@ -8,6 +8,7 @@ type WebhookMatchedBuild struct {
 }
 
 type WebhookTriggerInput struct {
+	ConnectionID    string
 	SCMProvider     string
 	EventType       string
 	RepositoryOwner string
@@ -21,6 +22,7 @@ type WebhookTriggerInput struct {
 	CommitSHA       string
 	DeliveryID      string
 	Actor           string
+	InstallationID  string
 }
 
 type WebhookTriggerResult struct {

--- a/backend/internal/webhook/github/push.go
+++ b/backend/internal/webhook/github/push.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
@@ -21,6 +22,7 @@ type PushEvent struct {
 	RepositoryOwner string
 	RepositoryName  string
 	RepositoryURL   string
+	InstallationID  string
 	RawRef          string
 	Ref             string
 	RefType         string
@@ -29,6 +31,10 @@ type PushEvent struct {
 	CommitSHA       string
 	DeliveryID      string
 	Actor           string
+}
+
+type AppEnvelope struct {
+	InstallationID string
 }
 
 func VerifySignature(secret string, payload []byte, signatureHeader string) bool {
@@ -48,6 +54,11 @@ func ParsePushEvent(headers http.Header, body []byte) (PushEvent, error) {
 	eventType := strings.ToLower(strings.TrimSpace(headers.Get("X-GitHub-Event")))
 	if eventType != "push" {
 		return PushEvent{}, ErrUnsupportedEvent
+	}
+
+	envelope, envelopeErr := ParseAppEnvelope(body)
+	if envelopeErr != nil {
+		return PushEvent{}, envelopeErr
 	}
 
 	var payload struct {
@@ -88,7 +99,6 @@ func ParsePushEvent(headers http.Header, body []byte) (PushEvent, error) {
 	if repositoryURL == "" {
 		repositoryURL = strings.TrimSpace(payload.Repository.URL)
 	}
-
 	normalizedRef := domain.NormalizeWebhookRef(payload.Ref, payload.Deleted)
 
 	commitSHA := strings.TrimSpace(payload.After)
@@ -105,6 +115,7 @@ func ParsePushEvent(headers http.Header, body []byte) (PushEvent, error) {
 		RepositoryOwner: repositoryOwner,
 		RepositoryName:  repositoryName,
 		RepositoryURL:   repositoryURL,
+		InstallationID:  envelope.InstallationID,
 		RawRef:          normalizedRef.RawRef,
 		Ref:             normalizedRef.RefName,
 		RefType:         string(normalizedRef.RefType),
@@ -114,4 +125,32 @@ func ParsePushEvent(headers http.Header, body []byte) (PushEvent, error) {
 		DeliveryID:      strings.TrimSpace(headers.Get("X-GitHub-Delivery")),
 		Actor:           strings.TrimSpace(payload.Sender.Login),
 	}, nil
+}
+
+func ParseAppEnvelope(body []byte) (AppEnvelope, error) {
+	var payload struct {
+		Installation struct {
+			ID json.RawMessage `json:"id"`
+		} `json:"installation"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return AppEnvelope{}, ErrInvalidPayload
+	}
+	installationID, err := parseInstallationID(payload.Installation.ID)
+	if err != nil {
+		return AppEnvelope{}, ErrInvalidPayload
+	}
+	return AppEnvelope{InstallationID: installationID}, nil
+}
+
+func parseInstallationID(raw json.RawMessage) (string, error) {
+	value := strings.TrimSpace(string(raw))
+	if value == "" || strings.HasPrefix(value, `"`) {
+		return "", ErrInvalidPayload
+	}
+	installationID, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || installationID <= 0 {
+		return "", ErrInvalidPayload
+	}
+	return strconv.FormatInt(installationID, 10), nil
 }

--- a/backend/internal/webhook/github/push_test.go
+++ b/backend/internal/webhook/github/push_test.go
@@ -176,3 +176,25 @@ func TestParsePushEvent_RejectsInvalidInstallationID(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAppEnvelope(t *testing.T) {
+	envelope, parseErr := ParseAppEnvelope([]byte(`{"installation":{"id":1234567890123456789}}`))
+	if parseErr != nil {
+		t.Fatalf("parse envelope: %v", parseErr)
+	}
+	if envelope.InstallationID != "1234567890123456789" {
+		t.Fatalf("expected precise installation ID, got %q", envelope.InstallationID)
+	}
+
+	for _, body := range [][]byte{
+		[]byte(`{}`),
+		[]byte(`{"installation":{"id":0}}`),
+		[]byte(`{"installation":{"id":1.5}}`),
+		[]byte(`{"installation":{"id":"123"}}`),
+		[]byte(`{`),
+	} {
+		if _, err := ParseAppEnvelope(body); err != ErrInvalidPayload {
+			t.Fatalf("expected invalid payload for %s, got %v", body, err)
+		}
+	}
+}

--- a/backend/internal/webhook/github/push_test.go
+++ b/backend/internal/webhook/github/push_test.go
@@ -32,6 +32,7 @@ func TestParsePushEvent(t *testing.T) {
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"after":"abc123",
+		"installation":{"id":1234567890123456789},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -56,6 +57,9 @@ func TestParsePushEvent(t *testing.T) {
 	if event.CommitSHA != "abc123" {
 		t.Fatalf("unexpected commit sha: %s", event.CommitSHA)
 	}
+	if event.InstallationID != "1234567890123456789" {
+		t.Fatalf("expected precise installation id, got %q", event.InstallationID)
+	}
 }
 
 func TestParsePushEvent_TagRef(t *testing.T) {
@@ -65,6 +69,7 @@ func TestParsePushEvent_TagRef(t *testing.T) {
 	body := []byte(`{
 		"ref":"refs/tags/v1.2.3",
 		"after":"abc123",
+		"installation":{"id":123},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -89,6 +94,7 @@ func TestParsePushEvent_UnknownRef(t *testing.T) {
 	body := []byte(`{
 		"ref":"custom/ref/path",
 		"after":"abc123",
+		"installation":{"id":123},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -114,6 +120,7 @@ func TestParsePushEvent_DeletePushAllowedWithoutCommit(t *testing.T) {
 		"ref":"refs/heads/main",
 		"deleted":true,
 		"after":"",
+		"installation":{"id":123},
 		"repository":{
 			"name":"backend",
 			"html_url":"https://github.com/example/backend",
@@ -141,5 +148,31 @@ func TestParsePushEvent_UnsupportedEvent(t *testing.T) {
 	}
 	if err != ErrUnsupportedEvent {
 		t.Fatalf("expected ErrUnsupportedEvent, got %v", err)
+	}
+}
+
+func TestParsePushEvent_RejectsInvalidInstallationID(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-GitHub-Event", "push")
+	missingInstallationBody := []byte(`{"ref":"refs/heads/main","after":"abc123","repository":{"name":"backend","html_url":"https://github.com/example/backend","owner":{"login":"example"}}}`)
+	if _, err := ParsePushEvent(headers, missingInstallationBody); err != ErrInvalidPayload {
+		t.Fatalf("expected missing installation to be invalid, got %v", err)
+	}
+	for _, installation := range []string{
+		`{}`,
+		`null`,
+		`{"id":0}`,
+		`{"id":-1}`,
+		`{"id":1.5}`,
+		`{"id":"123"}`,
+		`{"id":true}`,
+	} {
+		t.Run(installation, func(t *testing.T) {
+			body := []byte(`{"ref":"refs/heads/main","after":"abc123","installation":` + installation + `,"repository":{"name":"backend","html_url":"https://github.com/example/backend","owner":{"login":"example"}}}`)
+			_, err := ParsePushEvent(headers, body)
+			if err != ErrInvalidPayload {
+				t.Fatalf("expected invalid payload for installation=%s, got %v", installation, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR makes GitHub App webhook ingress connection-aware.

Coyote now authenticates each incoming GitHub App webhook against the exact reusable GitHub App registration that owns the callback, resolves the payload’s installation to the corresponding SCM connection, and propagates that connection identity into the webhook processing flow.

This establishes the prerequisite identity chain for the next repository-aware routing slice:

`GitHub App registration → installation connection → registered repository → jobs`

Current URL-based job routing remains intentionally unchanged in this PR.

## Webhook Route

The global callback:

`POST /api/webhooks/github`

has been replaced with:

`POST /api/webhooks/github/apps/{registrationID}`

The route identifies the reusable GitHub App registration. The payload’s `installation.id` then identifies the exact installation connection associated with that registration.

This supports one GitHub App registration being reused across multiple GitHub installations without conflating their SCM connections.

## Connection-Aware Authentication

For each webhook, Coyote now:

1. Resolves the route-selected GitHub App registration.
2. Resolves its `webhook_secret_ref` through the existing secret resolver.
3. Verifies `X-Hub-Signature-256` using that registration-specific secret.
4. Parses and validates the GitHub App `installation.id`.
5. Resolves the exact SCM connection using the registration ID and provider installation ID.
6. Propagates the resolved Coyote `connection_id` and installation identity into the webhook trigger input.
7. Claims the delivery ID only after authentication and identity validation succeed.

Resolved webhook secrets are not logged or returned through API errors.

## Signature and Idempotency Ordering

Webhook delivery registration now occurs after signature and installation identity validation.

This prevents an invalidly signed request from claiming a delivery ID and suppressing a later legitimate delivery using the same ID.

The following requests do not create or claim webhook delivery records:

* unknown GitHub App registration;
* unavailable webhook secret;
* invalid signature;
* missing or malformed installation identity;
* unknown installation connection;
* disabled installation connection.

Authenticated duplicate deliveries continue returning `200` without creating another build.

## Common GitHub App Identity

Installation identity is now parsed before event-type branching.

Both supported push events and unsupported GitHub events must therefore be attributable to an exact, enabled SCM connection before they are recorded or accepted for processing.

Unsupported events now behave as follows:

* A valid registration, signature, installation, and enabled connection is recorded and returns `202`.
* An unknown installation returns an authenticated `200` no-op.
* A disabled connection returns an authenticated `200` no-op.
* Missing or malformed installation identity returns `400` without creating a delivery record.
* A duplicate supported or unsupported delivery returns `200` without repeated processing.

## HTTP Behavior

* Unknown registration: `404`
* Webhook secret unavailable: `503`
* Invalid signature: `401`
* Missing or malformed installation ID: `400`
* Unknown authenticated installation: `200` no-op
* Disabled authenticated connection: `200` no-op
* Unsupported authenticated event: `202`
* Authenticated duplicate delivery: `200`
* Enabled resolved connection: existing webhook processing response

## Internal Changes

This PR adds:

* registration-scoped GitHub webhook ingress;
* per-registration webhook-secret resolution;
* precise positive-integer parsing for `installation.id`;
* SCM connection lookup by GitHub App registration ID and installation ID;
* connection identity propagation through webhook processing;
* signature-before-idempotency ordering;
* focused connection-isolation and unsupported-event coverage.

The old resolver-less `EventHandler` constructor and setter path were removed. There is now one construction path, and it requires the GitHub webhook connection resolver.

## Validation

Focused tests cover:

* registration-specific secret selection;
* invalid-signature delivery behavior;
* precise installation-ID parsing;
* exact registration and installation connection resolution;
* cross-registration isolation;
* unknown and disabled connection no-op behavior;
* supported and unsupported event handling;
* duplicate delivery behavior;
* required resolver construction;
* updated router behavior.

Swagger/OpenAPI artifacts were regenerated for the new callback route.

The normal pre-push checks pass once the generated Swagger artifacts are committed.

## Out of Scope

This PR does not change:

* repository-aware webhook routing;
* parsing or routing by GitHub `repository.id`;
* registered-repository lookup;
* job selection through `jobs.repository_id`;
* current URL-based job routing;
* pull-request event support;
* commit-status reporting;
* delivery-ledger schema;
* repository auto-registration;
* CLI or frontend behavior;
* pipeline or chained-job behavior.
