### PR TITLE
Add repository-aware authenticated checkout

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	docs "github.com/radiation/coyote-ci/backend/docs"
 	"github.com/radiation/coyote-ci/backend/internal/artifact"
 	"github.com/radiation/coyote-ci/backend/internal/auth"
+	"github.com/radiation/coyote-ci/backend/internal/domain"
 	apphttp "github.com/radiation/coyote-ci/backend/internal/http"
 	"github.com/radiation/coyote-ci/backend/internal/http/handler"
 	"github.com/radiation/coyote-ci/backend/internal/logs"
@@ -48,6 +49,20 @@ type scmStatusRuntime struct {
 	reporter      buildsvc.BuildSCMStatusReporter
 	reporterImpl  *buildsvc.SCMStatusReporter
 	recoveryDrain *buildsvc.SCMStatusRecoveryDrain
+}
+
+type checkoutResolverConnectionRepository interface {
+	GetByID(context.Context, string) (domain.SCMConnectionDetail, error)
+}
+
+type checkoutResolverRegistrationRepository interface {
+	GetByID(context.Context, string) (domain.SCMRepositoryRegistration, error)
+}
+
+func newRepositoryAwareCheckoutResolver(connections checkoutResolverConnectionRepository, registrations checkoutResolverRegistrationRepository) (*buildsvc.RepositoryAwareCheckoutResolver, error) {
+	return buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
+		Connections: connections, Registrations: registrations, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
+	})
 }
 
 // @title Coyote CI API
@@ -187,9 +202,7 @@ func main() {
 	}
 	logSink := logs.NewPostgresSink(db)
 	versionTagService := versiontagsvc.NewService(versionTagRepo).WithArtifactLabels(artifactLabelRepo)
-	checkoutResolver, checkoutResolverErr := buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
-		Connections: scmConnectionRepo, Registrations: scmRepositoryRegistrationRepo, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
-	})
+	checkoutResolver, checkoutResolverErr := newRepositoryAwareCheckoutResolver(scmConnectionRepo, scmRepositoryRegistrationRepo)
 	if checkoutResolverErr != nil {
 		log.Fatalf("failed to configure repository-aware checkout: %v", checkoutResolverErr)
 	}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -187,6 +187,12 @@ func main() {
 	}
 	logSink := logs.NewPostgresSink(db)
 	versionTagService := versiontagsvc.NewService(versionTagRepo).WithArtifactLabels(artifactLabelRepo)
+	checkoutResolver, checkoutResolverErr := buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
+		Connections: scmConnectionRepo, Registrations: scmRepositoryRegistrationRepo, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
+	})
+	if checkoutResolverErr != nil {
+		log.Fatalf("failed to configure repository-aware checkout: %v", checkoutResolverErr)
+	}
 	artifactService := artifactsvc.NewService(artifactRepo)
 	buildService := buildsvc.NewBuildServiceFromConfig(buildRepo, nil, logSink, buildsvc.BuildServiceConfig{
 		ExecutionJobRepo:      executionJobRepo,
@@ -195,6 +201,7 @@ func main() {
 		SCMStatusReporter:     scmStatusReporter,
 		SCMStatusDeliveryRepo: scmStatusDeliveryRepo,
 		RepoFetcher:           source.NewGitFetcher(),
+		RepositoryCheckout:    checkoutResolver,
 		ManagedImageRefresher: managedImageRefresher,
 		VersionTagger:         versionTagService,
 		ArtifactRepo:          artifactRepo,

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -135,3 +135,10 @@ func TestDefaultServerNotificationClaimOwner(t *testing.T) {
 		t.Fatalf("expected error fallback owner prefix, got %q", errorOwner)
 	}
 }
+
+func TestNewRepositoryAwareCheckoutResolver(t *testing.T) {
+	resolver, err := newRepositoryAwareCheckoutResolver(memoryrepo.NewSCMConnectionRepository(), memoryrepo.NewSCMRepositoryRegistrationRepository())
+	if err != nil || resolver == nil {
+		t.Fatalf("expected configured checkout resolver, resolver=%v err=%v", resolver, err)
+	}
+}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -21,6 +21,8 @@ import (
 	platformdb "github.com/radiation/coyote-ci/backend/internal/platform/db"
 	"github.com/radiation/coyote-ci/backend/internal/platform/dbopen"
 	platformemail "github.com/radiation/coyote-ci/backend/internal/platform/email"
+	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
+	platformsecret "github.com/radiation/coyote-ci/backend/internal/platform/secret"
 	platformslack "github.com/radiation/coyote-ci/backend/internal/platform/slack"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
 	repositorypostgres "github.com/radiation/coyote-ci/backend/internal/repository/postgres"
@@ -73,6 +75,8 @@ func main() {
 	jobManagedImageConfigRepo := repositorypostgres.NewJobManagedImageConfigRepository(db)
 	projectRepo := repositorypostgres.NewProjectRepository(db)
 	sourceCredentialRepo := repositorypostgres.NewSourceCredentialRepository(db)
+	scmConnectionRepo := repositorypostgres.NewSCMConnectionRepository(db)
+	scmRepositoryRegistrationRepo := repositorypostgres.NewSCMRepositoryRegistrationRepository(db)
 	userRepo := repositorypostgres.NewUserRepository(db)
 	versionTagRepo := repositorypostgres.NewVersionTagRepository(db)
 	artifactLabelRepo := repositorypostgres.NewArtifactLabelRepository(db)
@@ -109,12 +113,19 @@ func main() {
 	stepRunner := resolveStepRunner(cfg)
 	logSink := logs.NewPostgresSink(db)
 	versionTagService := newWorkerVersionTagService(versionTagRepo, artifactLabelRepo)
+	checkoutResolver, checkoutResolverErr := buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
+		Connections: scmConnectionRepo, Registrations: scmRepositoryRegistrationRepo, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
+	})
+	if checkoutResolverErr != nil {
+		log.Fatalf("failed to configure repository-aware checkout: %v", checkoutResolverErr)
+	}
 	buildService := buildsvc.NewBuildServiceFromConfig(buildRepo, stepRunner, logSink, buildsvc.BuildServiceConfig{
 		ExecutionJobRepo:    executionJobRepo,
 		ExecutionOutputRepo: executionJobOutputRepo,
 		BuildNotifier:       buildNotificationService,
 		DefaultImage:        cfg.ExecutionDefaultImage,
 		ExecutionWorkspace:  cfg.ExecutionWorkspaceRoot,
+		RepositoryCheckout:  checkoutResolver,
 		CacheStore:          cacheStore,
 		CacheEntryRepo:      cacheEntryRepo,
 		VersionTagger:       versionTagService,

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/radiation/coyote-ci/backend/internal/artifact"
 	cachepkg "github.com/radiation/coyote-ci/backend/internal/cache"
+	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/logs"
 	"github.com/radiation/coyote-ci/backend/internal/observability"
 	"github.com/radiation/coyote-ci/backend/internal/platform/config"
@@ -45,6 +46,20 @@ type workerIterationService interface {
 
 type workerStatusProvider interface {
 	RecoveryStats() workersvc.WorkerLeaseRecoveryStats
+}
+
+type checkoutResolverConnectionRepository interface {
+	GetByID(context.Context, string) (domain.SCMConnectionDetail, error)
+}
+
+type checkoutResolverRegistrationRepository interface {
+	GetByID(context.Context, string) (domain.SCMRepositoryRegistration, error)
+}
+
+func newRepositoryAwareCheckoutResolver(connections checkoutResolverConnectionRepository, registrations checkoutResolverRegistrationRepository) (*buildsvc.RepositoryAwareCheckoutResolver, error) {
+	return buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
+		Connections: connections, Registrations: registrations, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
+	})
 }
 
 func main() {
@@ -113,9 +128,7 @@ func main() {
 	stepRunner := resolveStepRunner(cfg)
 	logSink := logs.NewPostgresSink(db)
 	versionTagService := newWorkerVersionTagService(versionTagRepo, artifactLabelRepo)
-	checkoutResolver, checkoutResolverErr := buildsvc.NewRepositoryAwareCheckoutResolver(buildsvc.RepositoryAwareCheckoutResolverConfig{
-		Connections: scmConnectionRepo, Registrations: scmRepositoryRegistrationRepo, Secrets: platformsecret.NewEnvResolver(), GitHub: platformgithubapp.NewClient(nil),
-	})
+	checkoutResolver, checkoutResolverErr := newRepositoryAwareCheckoutResolver(scmConnectionRepo, scmRepositoryRegistrationRepo)
 	if checkoutResolverErr != nil {
 		log.Fatalf("failed to configure repository-aware checkout: %v", checkoutResolverErr)
 	}

--- a/backend/cmd/worker/main_test.go
+++ b/backend/cmd/worker/main_test.go
@@ -213,6 +213,13 @@ func TestDefaultWorkerID_FallsBackWhenHostnameFails(t *testing.T) {
 	}
 }
 
+func TestNewRepositoryAwareCheckoutResolver(t *testing.T) {
+	resolver, err := newRepositoryAwareCheckoutResolver(repositorymemory.NewSCMConnectionRepository(), repositorymemory.NewSCMRepositoryRegistrationRepository())
+	if err != nil || resolver == nil {
+		t.Fatalf("expected configured checkout resolver, resolver=%v err=%v", resolver, err)
+	}
+}
+
 func TestStartWorkerStatusServer_EmptyAddrIsNoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/backend/internal/platform/githubapp/client.go
+++ b/backend/internal/platform/githubapp/client.go
@@ -31,6 +31,7 @@ type InstallationTokenRequest struct {
 	InstallationID    string
 	APIBaseURL        string
 	PrivateKeyPEM     string
+	RepositoryIDs     []string
 }
 
 type InstallationToken struct {
@@ -91,13 +92,20 @@ type Client struct {
 	now         func() time.Time
 	refreshSkew time.Duration
 
-	mu    sync.Mutex
-	cache map[string]cachedInstallationToken
-	wait  map[string]chan struct{}
+	mu          sync.Mutex
+	cache       map[string]cachedInstallationToken
+	wait        map[string]chan struct{}
+	refreshWait map[string]*inFlightTokenRefresh
 }
 
 type cachedInstallationToken struct {
 	token InstallationToken
+}
+
+type inFlightTokenRefresh struct {
+	done  chan struct{}
+	token InstallationToken
+	err   error
 }
 
 func NewClient(httpClient *http.Client) *Client {
@@ -111,6 +119,7 @@ func NewClient(httpClient *http.Client) *Client {
 		refreshSkew: defaultTokenRefreshSkew,
 		cache:       map[string]cachedInstallationToken{},
 		wait:        map[string]chan struct{}{},
+		refreshWait: map[string]*inFlightTokenRefresh{},
 	}
 }
 
@@ -119,11 +128,68 @@ func (c *Client) GetInstallationToken(ctx context.Context, input InstallationTok
 	return token, err
 }
 
+// GetFreshInstallationToken exchanges a new token for exactly the supplied app,
+// installation, and repository scope. Concurrent refreshes for that scope share
+// one exchange; unrelated cached scopes remain untouched.
+func (c *Client) GetFreshInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, error) {
+	key := installationCacheKey(input)
+	for {
+		c.mu.Lock()
+		if refresh, ok := c.refreshWait[key]; ok {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return InstallationToken{}, ctx.Err()
+			case <-refresh.done:
+				return refresh.token, refresh.err
+			}
+		}
+		if waitCh, ok := c.wait[key]; ok {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return InstallationToken{}, ctx.Err()
+			case <-waitCh:
+				continue
+			}
+		}
+		refresh := &inFlightTokenRefresh{done: make(chan struct{})}
+		c.refreshWait[key] = refresh
+		c.mu.Unlock()
+
+		token, err := c.exchangeInstallationToken(ctx, input)
+
+		c.mu.Lock()
+		if err == nil {
+			c.cache[key] = cachedInstallationToken{token: token}
+		}
+		refresh.token = token
+		refresh.err = err
+		delete(c.refreshWait, key)
+		close(refresh.done)
+		c.mu.Unlock()
+
+		if err != nil {
+			return InstallationToken{}, err
+		}
+		return token, nil
+	}
+}
+
 func (c *Client) getInstallationToken(ctx context.Context, input InstallationTokenRequest) (InstallationToken, bool, error) {
 	key := installationCacheKey(input)
 	for {
 		now := c.now().UTC()
 		c.mu.Lock()
+		if refresh, ok := c.refreshWait[key]; ok {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return InstallationToken{}, false, ctx.Err()
+			case <-refresh.done:
+				continue
+			}
+		}
 		if entry, ok := c.cache[key]; ok && entry.token.Value != "" && now.Before(entry.token.ExpiresAt.Add(-c.refreshSkew)) {
 			token := entry.token
 			c.mu.Unlock()
@@ -226,7 +292,18 @@ func (c *Client) exchangeInstallationToken(ctx context.Context, input Installati
 		return InstallationToken{}, err
 	}
 	exchangeURL := strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "/app/installations/" + url.PathEscape(strings.TrimSpace(input.InstallationID)) + "/access_tokens"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, exchangeURL, bytes.NewBufferString("{}"))
+	repositoryIDs, err := numericRepositoryIDs(input.RepositoryIDs)
+	if err != nil {
+		return InstallationToken{}, ErrMalformedResponse
+	}
+	body := struct {
+		RepositoryIDs []int64 `json:"repository_ids,omitempty"`
+	}{RepositoryIDs: repositoryIDs}
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return InstallationToken{}, ErrMalformedResponse
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, exchangeURL, bytes.NewReader(bodyJSON))
 	if err != nil {
 		return InstallationToken{}, err
 	}
@@ -262,7 +339,37 @@ func (c *Client) exchangeInstallationToken(ctx context.Context, input Installati
 }
 
 func installationCacheKey(input InstallationTokenRequest) string {
-	return strings.TrimSpace(input.AppRegistrationID) + "|" + strings.TrimSpace(input.InstallationID) + "|" + strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/")
+	return strings.TrimSpace(input.AppRegistrationID) + "|" + strings.TrimSpace(input.InstallationID) + "|" + strings.TrimRight(strings.TrimSpace(input.APIBaseURL), "/") + "|" + strings.Join(normalizedRepositoryIDs(input.RepositoryIDs), ",")
+}
+
+func normalizedRepositoryIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		result = append(result, trimmed)
+	}
+	return result
+}
+
+func numericRepositoryIDs(values []string) ([]int64, error) {
+	normalized := normalizedRepositoryIDs(values)
+	result := make([]int64, 0, len(normalized))
+	for _, value := range normalized {
+		repositoryID, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || repositoryID <= 0 {
+			return nil, ErrMalformedResponse
+		}
+		result = append(result, repositoryID)
+	}
+	return result, nil
 }
 
 func (c *Client) invalidateCachedToken(input InstallationTokenRequest, failedToken InstallationToken) {

--- a/backend/internal/platform/githubapp/client.go
+++ b/backend/internal/platform/githubapp/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -356,6 +357,7 @@ func normalizedRepositoryIDs(values []string) []string {
 		seen[trimmed] = struct{}{}
 		result = append(result, trimmed)
 	}
+	sort.Strings(result)
 	return result
 }
 

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -743,6 +743,21 @@ func TestClient_TokenCacheKeyIsolation(t *testing.T) {
 	}
 }
 
+func TestInstallationCacheKey_NormalizesRepositoryRestrictionOrder(t *testing.T) {
+	base := InstallationTokenRequest{AppRegistrationID: "registration-1", InstallationID: "999", APIBaseURL: "https://api.github.com"}
+	first := base
+	first.RepositoryIDs = []string{" 200 ", "100", "200"}
+	second := base
+	second.RepositoryIDs = []string{"100", "200"}
+
+	if firstKey, secondKey := installationCacheKey(first), installationCacheKey(second); firstKey != secondKey {
+		t.Fatalf("expected equivalent repository restriction keys, got %q and %q", firstKey, secondKey)
+	}
+	if got := normalizedRepositoryIDs(first.RepositoryIDs); len(got) != 2 || got[0] != "100" || got[1] != "200" {
+		t.Fatalf("expected sorted unique repository IDs, got %#v", got)
+	}
+}
+
 func TestClient_GetFreshInstallationToken_BypassesOnlyExactScopedCacheEntry(t *testing.T) {
 	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
 	var callCount atomic.Int32

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -743,6 +743,191 @@ func TestClient_TokenCacheKeyIsolation(t *testing.T) {
 	}
 }
 
+func TestClient_GetFreshInstallationToken_BypassesOnlyExactScopedCacheEntry(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/999/access_tokens" {
+			http.NotFound(w, r)
+			return
+		}
+		var body struct {
+			RepositoryIDs []int64 `json:"repository_ids"`
+		}
+		if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil || len(body.RepositoryIDs) != 1 || body.RepositoryIDs[0] != 1001 {
+			t.Fatalf("expected numeric repository restriction [1001], body=%+v err=%v", body, decodeErr)
+		}
+		current := callCount.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "token-" + installationIDString(int64(current)), "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	unrelated := InstallationTokenRequest{AppRegistrationID: "registration-2", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1002"}}
+	client.cache[installationCacheKey(unrelated)] = cachedInstallationToken{token: InstallationToken{Value: "unrelated-token", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+
+	normal, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("normal token: %v", err)
+	}
+	fresh, err := client.GetFreshInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("fresh token: %v", err)
+	}
+	again, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil {
+		t.Fatalf("cached fresh token: %v", err)
+	}
+	if normal.Value == fresh.Value || fresh.Value != again.Value || callCount.Load() != 2 {
+		t.Fatalf("expected one normal exchange and one forced exchange, normal=%q fresh=%q cached=%q calls=%d", normal.Value, fresh.Value, again.Value, callCount.Load())
+	}
+	if entry := client.cache[installationCacheKey(unrelated)].token; entry.Value != "unrelated-token" {
+		t.Fatalf("expected unrelated cache entry to remain untouched, got %+v", entry)
+	}
+}
+
+func TestClient_GetFreshInstallationToken_ConcurrentRequestsShareOneExchange(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var callCount atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if callCount.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "fresh-token", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	results := make(chan InstallationToken, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			token, freshErr := client.GetFreshInstallationToken(context.Background(), request)
+			results <- token
+			errs <- freshErr
+		}()
+	}
+	<-started
+	close(release)
+	for range 2 {
+		if freshErr := <-errs; freshErr != nil {
+			t.Fatalf("fresh token: %v", freshErr)
+		}
+		if token := <-results; token.Value != "fresh-token" {
+			t.Fatalf("unexpected token: %+v", token)
+		}
+	}
+	if callCount.Load() != 1 {
+		t.Fatalf("expected one forced exchange, got %d", callCount.Load())
+	}
+}
+
+func TestClient_GetFreshInstallationToken_FailurePreservesCachedToken(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"bad credentials"}`))
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "cached-token", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+	if _, err := client.GetFreshInstallationToken(context.Background(), request); err != ErrAuthentication {
+		t.Fatalf("expected classified authentication error, got %v", err)
+	}
+	token, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil || token.Value != "cached-token" {
+		t.Fatalf("expected intact cached token after refresh failure, token=%+v err=%v", token, err)
+	}
+}
+
+func TestClient_GetFreshInstallationToken_ConcurrentFailureSharesRefreshErrorWithoutReturningStaleToken(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var exchangeCalls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exchangeCalls.Add(1)
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"bad credentials"}`))
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	client.cache[installationCacheKey(request)] = cachedInstallationToken{token: InstallationToken{Value: "stale-token", ExpiresAt: time.Now().Add(10 * time.Minute).UTC()}}
+
+	results := make(chan struct {
+		token InstallationToken
+		err   error
+	}, 3)
+	for range 3 {
+		go func() {
+			token, refreshErr := client.GetFreshInstallationToken(context.Background(), request)
+			results <- struct {
+				token InstallationToken
+				err   error
+			}{token: token, err: refreshErr}
+		}()
+	}
+	<-started
+	close(release)
+	for range 3 {
+		result := <-results
+		if result.err != ErrAuthentication || result.token.Value != "" {
+			t.Fatalf("expected shared refresh authentication error without token, result=%+v", result)
+		}
+	}
+	if exchangeCalls.Load() != 1 {
+		t.Fatalf("expected one forced refresh exchange, got %d", exchangeCalls.Load())
+	}
+	cached, err := client.GetInstallationToken(context.Background(), request)
+	if err != nil || cached.Value != "stale-token" {
+		t.Fatalf("expected ordinary lookup to retain stale cached token, token=%+v err=%v", cached, err)
+	}
+}
+
+func TestClient_GetFreshInstallationToken_WaitingCallerContextCancellation(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "fresh-token", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	leaderResult := make(chan error, 1)
+	go func() {
+		_, leaderErr := client.GetFreshInstallationToken(context.Background(), request)
+		leaderResult <- leaderErr
+	}()
+	<-started
+	waiterCtx, cancel := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	go func() {
+		_, waiterErr := client.GetFreshInstallationToken(waiterCtx, request)
+		waiterResult <- waiterErr
+	}()
+	cancel()
+	if waiterErr := <-waiterResult; waiterErr != context.Canceled {
+		t.Fatalf("expected waiting caller cancellation, got %v", waiterErr)
+	}
+	close(release)
+	if leaderErr := <-leaderResult; leaderErr != nil {
+		t.Fatalf("expected leader refresh success, got %v", leaderErr)
+	}
+}
+
 func TestClient_ResponseHelpers(t *testing.T) {
 	if got := readGitHubMessage(strings.NewReader(`{"message":"Bad Credentials"}`)); got != "bad credentials" {
 		t.Fatalf("expected lower-cased github message, got %q", got)

--- a/backend/internal/platform/githubapp/client_test.go
+++ b/backend/internal/platform/githubapp/client_test.go
@@ -758,6 +758,90 @@ func TestInstallationCacheKey_NormalizesRepositoryRestrictionOrder(t *testing.T)
 	}
 }
 
+func TestClient_GetInstallationToken_RejectsMalformedRepositoryRestriction(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	for _, repositoryIDs := range [][]string{{"not-a-number"}, {"0"}, {"-1"}} {
+		client := NewClient(nil)
+		_, err := client.GetInstallationToken(context.Background(), InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: "https://api.github.com", PrivateKeyPEM: privateKeyPEM, RepositoryIDs: repositoryIDs})
+		if err != ErrMalformedResponse {
+			t.Fatalf("expected malformed restriction %q to fail, got %v", repositoryIDs, err)
+		}
+	}
+}
+
+func TestClient_GetFreshInstallationToken_WaitsForNormalExchange(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": installationIDString(int64(calls.Load())), "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	normalResult := make(chan error, 1)
+	go func() { _, err := client.GetInstallationToken(context.Background(), request); normalResult <- err }()
+	<-started
+	freshResult := make(chan InstallationToken, 1)
+	freshErr := make(chan error, 1)
+	go func() {
+		token, err := client.GetFreshInstallationToken(context.Background(), request)
+		freshResult <- token
+		freshErr <- err
+	}()
+	close(release)
+	if err := <-normalResult; err != nil {
+		t.Fatalf("normal exchange: %v", err)
+	}
+	if err := <-freshErr; err != nil {
+		t.Fatalf("forced refresh: %v", err)
+	}
+	if token := <-freshResult; token.Value != "2" || calls.Load() != 2 {
+		t.Fatalf("expected forced exchange after normal exchange, token=%+v calls=%d", token, calls.Load())
+	}
+}
+
+func TestClient_GetInstallationToken_WaitsForFreshExchange(t *testing.T) {
+	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "fresh-token", "expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)})
+	}))
+	defer server.Close()
+	client := NewClient(server.Client())
+	request := InstallationTokenRequest{AppRegistrationID: "registration-1", AppID: "12345", InstallationID: "999", APIBaseURL: server.URL, PrivateKeyPEM: privateKeyPEM, RepositoryIDs: []string{"1001"}}
+	freshErr := make(chan error, 1)
+	go func() { _, err := client.GetFreshInstallationToken(context.Background(), request); freshErr <- err }()
+	<-started
+	normalResult := make(chan InstallationToken, 1)
+	normalErr := make(chan error, 1)
+	go func() {
+		token, err := client.GetInstallationToken(context.Background(), request)
+		normalResult <- token
+		normalErr <- err
+	}()
+	close(release)
+	if err := <-freshErr; err != nil {
+		t.Fatalf("fresh exchange: %v", err)
+	}
+	if err := <-normalErr; err != nil {
+		t.Fatalf("normal cache lookup: %v", err)
+	}
+	if token := <-normalResult; token.Value != "fresh-token" {
+		t.Fatalf("expected fresh cached token, got %+v", token)
+	}
+}
+
 func TestClient_GetFreshInstallationToken_BypassesOnlyExactScopedCacheEntry(t *testing.T) {
 	privateKeyPEM, _ := testRSAPrivateKeyPEM(t)
 	var callCount atomic.Int32

--- a/backend/internal/service/build/repo_create.go
+++ b/backend/internal/service/build/repo_create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	"github.com/radiation/coyote-ci/backend/internal/pipeline"
+	"github.com/radiation/coyote-ci/backend/internal/source"
 )
 
 // CreateRepoBuildInput is the service-level input for creating a build from a repository checkout.
@@ -56,7 +57,7 @@ func (s *BuildService) CreateBuildFromRepo(ctx context.Context, input CreateRepo
 		fetchTarget = strings.TrimSpace(input.Ref)
 	}
 
-	localPath, commitSHA, err := s.repoFetcher.Fetch(ctx, input.RepoURL, fetchTarget)
+	localPath, commitSHA, err := s.fetchRepositoryForBuildCreation(ctx, input, fetchTarget)
 	if err != nil {
 		return domain.Build{}, fmt.Errorf("fetching repo: %w", err)
 	}
@@ -186,4 +187,29 @@ func (s *BuildService) CreateBuildFromRepo(ctx context.Context, input CreateRepo
 		}
 	}
 	return queuedBuild, nil
+}
+
+func (s *BuildService) fetchRepositoryForBuildCreation(ctx context.Context, input CreateRepoBuildInput, ref string) (string, string, error) {
+	if input.RepositoryIdentity == nil {
+		return s.repoFetcher.Fetch(ctx, input.RepoURL, ref)
+	}
+	if s.repositoryCheckout == nil {
+		return "", "", ErrRepositoryCheckoutConnectionInvalid
+	}
+	checkout, err := s.repositoryCheckout.Resolve(ctx, *input.RepositoryIdentity)
+	if err != nil {
+		return "", "", err
+	}
+	authenticatedFetcher, ok := s.repoFetcher.(source.AuthenticatedRepoFetcher)
+	if !ok {
+		return "", "", ErrRepositoryCheckoutConnectionInvalid
+	}
+	var localPath string
+	var commitSHA string
+	err = checkout.RunWithCredentialRetry(ctx, func(credential source.HTTPSCredential) error {
+		var fetchErr error
+		localPath, commitSHA, fetchErr = authenticatedFetcher.FetchWithHTTPSCredential(ctx, checkout.RepositoryURL, ref, credential)
+		return fetchErr
+	})
+	return localPath, commitSHA, err
 }

--- a/backend/internal/service/build/repository_aware_checkout.go
+++ b/backend/internal/service/build/repository_aware_checkout.go
@@ -1,0 +1,151 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
+	"github.com/radiation/coyote-ci/backend/internal/source"
+)
+
+var ErrRepositoryCheckoutIdentityIncomplete = errors.New("repository checkout identity is incomplete")
+var ErrRepositoryCheckoutIdentityMismatch = errors.New("repository checkout identity does not match registered repository")
+var ErrRepositoryCheckoutConnectionDisabled = errors.New("scm connection is disabled for checkout")
+var ErrRepositoryCheckoutRepositoryDisabled = errors.New("registered repository is disabled for checkout")
+var ErrRepositoryCheckoutConnectionInvalid = errors.New("github app connection is invalid for checkout")
+var ErrRepositoryCheckoutPrivateKeyUnavailable = errors.New("github app private key is unavailable for checkout")
+var ErrRepositoryCheckoutRepositoryUnavailable = errors.New("repository is unavailable through the snapshotted connection")
+
+type repositoryCheckoutConnectionRepository interface {
+	GetByID(ctx context.Context, id string) (domain.SCMConnectionDetail, error)
+}
+
+type repositoryCheckoutRegistrationRepository interface {
+	GetByID(ctx context.Context, id string) (domain.SCMRepositoryRegistration, error)
+}
+
+type repositoryCheckoutSecretResolver interface {
+	Resolve(ctx context.Context, ref string) (string, error)
+}
+
+type repositoryCheckoutGitHubClient interface {
+	GetInstallationToken(ctx context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error)
+	GetFreshInstallationToken(ctx context.Context, input platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error)
+	GetRepositoryByID(ctx context.Context, input platformgithubapp.InstallationTokenRequest, repositoryID string) (platformgithubapp.Repository, error)
+}
+
+type RepositoryAwareCheckoutResolverConfig struct {
+	Connections   repositoryCheckoutConnectionRepository
+	Registrations repositoryCheckoutRegistrationRepository
+	Secrets       repositoryCheckoutSecretResolver
+	GitHub        repositoryCheckoutGitHubClient
+}
+
+type RepositoryAwareCheckoutResolver struct {
+	connections   repositoryCheckoutConnectionRepository
+	registrations repositoryCheckoutRegistrationRepository
+	secrets       repositoryCheckoutSecretResolver
+	github        repositoryCheckoutGitHubClient
+}
+
+type RepositoryAwareCheckout struct {
+	RepositoryURL     string
+	Credential        source.HTTPSCredential
+	refreshCredential func(context.Context) (source.HTTPSCredential, error)
+}
+
+func NewRepositoryAwareCheckoutResolver(cfg RepositoryAwareCheckoutResolverConfig) (*RepositoryAwareCheckoutResolver, error) {
+	if cfg.Connections == nil || cfg.Registrations == nil || cfg.Secrets == nil || cfg.GitHub == nil {
+		return nil, errors.New("repository-aware checkout resolver requires connection, registered repository, secret, and github app dependencies")
+	}
+	return &RepositoryAwareCheckoutResolver{connections: cfg.Connections, registrations: cfg.Registrations, secrets: cfg.Secrets, github: cfg.GitHub}, nil
+}
+
+func (r *RepositoryAwareCheckoutResolver) Resolve(ctx context.Context, snapshot domain.RepositoryIdentitySnapshot) (RepositoryAwareCheckout, error) {
+	if err := snapshot.Validate(); err != nil {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutIdentityIncomplete
+	}
+	registration, err := r.registrations.GetByID(ctx, snapshot.RegisteredRepositoryID)
+	if err != nil {
+		return RepositoryAwareCheckout{}, fmt.Errorf("registered repository: %w", err)
+	}
+	if registration.ID != snapshot.RegisteredRepositoryID || registration.ConnectionID != snapshot.SCMConnectionID || registration.ProviderRepositoryID != snapshot.ProviderRepositoryID {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutIdentityMismatch
+	}
+	if registration.Disabled {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutRepositoryDisabled
+	}
+	detail, err := r.connections.GetByID(ctx, snapshot.SCMConnectionID)
+	if err != nil {
+		return RepositoryAwareCheckout{}, fmt.Errorf("scm connection: %w", err)
+	}
+	if !detail.Connection.Enabled {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutConnectionDisabled
+	}
+	if detail.Connection.Provider != domain.SCMProviderGitHub || detail.GitHubAppRegistration == nil || detail.GitHubAppInstallation == nil {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutConnectionInvalid
+	}
+	app := detail.GitHubAppRegistration.Normalize()
+	installation := detail.GitHubAppInstallation.Normalize()
+	if app.ID == "" || app.AppID == "" || app.PrivateKeySecretRef == "" || app.APIBaseURL == "" || installation.InstallationID == "" || detail.Connection.APIBaseURL != app.APIBaseURL {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutConnectionInvalid
+	}
+	privateKey, err := r.secrets.Resolve(ctx, app.PrivateKeySecretRef)
+	if err != nil || strings.TrimSpace(privateKey) == "" {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutPrivateKeyUnavailable
+	}
+	request := platformgithubapp.InstallationTokenRequest{AppRegistrationID: app.ID, AppID: app.AppID, InstallationID: installation.InstallationID, APIBaseURL: app.APIBaseURL, PrivateKeyPEM: privateKey, RepositoryIDs: []string{snapshot.ProviderRepositoryID}}
+	providerRepository, err := r.github.GetRepositoryByID(ctx, request, snapshot.ProviderRepositoryID)
+	if err != nil {
+		return RepositoryAwareCheckout{}, classifyRepositoryCheckoutProviderError(err)
+	}
+	if strings.TrimSpace(providerRepository.ID) != snapshot.ProviderRepositoryID || strings.TrimSpace(providerRepository.CloneURL) == "" {
+		return RepositoryAwareCheckout{}, ErrRepositoryCheckoutIdentityMismatch
+	}
+	token, err := r.github.GetInstallationToken(ctx, request)
+	if err != nil {
+		return RepositoryAwareCheckout{}, classifyRepositoryCheckoutProviderError(err)
+	}
+	return RepositoryAwareCheckout{
+		RepositoryURL: strings.TrimSpace(providerRepository.CloneURL),
+		Credential:    source.HTTPSCredential{Username: "x-access-token", Password: token.Value},
+		refreshCredential: func(refreshCtx context.Context) (source.HTTPSCredential, error) {
+			freshToken, refreshErr := r.github.GetFreshInstallationToken(refreshCtx, request)
+			if refreshErr != nil {
+				return source.HTTPSCredential{}, classifyRepositoryCheckoutProviderError(refreshErr)
+			}
+			return source.HTTPSCredential{Username: "x-access-token", Password: freshToken.Value}, nil
+		},
+	}, nil
+}
+
+// RunWithCredentialRetry invokes operation once and retries exactly once with a
+// freshly exchanged credential only after an explicit authentication rejection.
+func (checkout RepositoryAwareCheckout) RunWithCredentialRetry(ctx context.Context, operation func(source.HTTPSCredential) error) error {
+	if operation == nil {
+		return errors.New("repository checkout operation is required")
+	}
+	operationErr := operation(checkout.Credential)
+	if !source.IsAuthenticationFailure(operationErr) || checkout.refreshCredential == nil {
+		return operationErr
+	}
+	freshCredential, refreshErr := checkout.refreshCredential(ctx)
+	if refreshErr != nil {
+		return refreshErr
+	}
+	return operation(freshCredential)
+}
+
+func classifyRepositoryCheckoutProviderError(err error) error {
+	switch {
+	case errors.Is(err, platformgithubapp.ErrRepositoryInaccessible), errors.Is(err, platformgithubapp.ErrInstallationUnavailable):
+		return ErrRepositoryCheckoutRepositoryUnavailable
+	case errors.Is(err, platformgithubapp.ErrPrivateKeyMissing), errors.Is(err, platformgithubapp.ErrPrivateKeyMalformed), errors.Is(err, platformgithubapp.ErrPrivateKeyNotRSA):
+		return ErrRepositoryCheckoutPrivateKeyUnavailable
+	default:
+		return err
+	}
+}

--- a/backend/internal/service/build/repository_aware_checkout_test.go
+++ b/backend/internal/service/build/repository_aware_checkout_test.go
@@ -386,6 +386,41 @@ func TestRepositoryAwareCheckoutResolver_UnmappedPipelineFetchDoesNotResolveOrRe
 	}
 }
 
+func TestRepositoryAwareCheckoutResolver_MappedPipelineFetchRejectsMissingCheckoutOrAuthenticatedFetcher(t *testing.T) {
+	identity := &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"}
+	service := NewBuildService(nil, nil, nil)
+	service.SetRepoFetcher(&fakeRepoFetcher{})
+	if _, _, err := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{RepositoryIdentity: identity}, "main"); !errors.Is(err, ErrRepositoryCheckoutConnectionInvalid) {
+		t.Fatalf("expected missing checkout resolver error, got %v", err)
+	}
+
+	resolver, resolverErr := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}})
+	if resolverErr != nil {
+		t.Fatalf("new resolver: %v", resolverErr)
+	}
+	service.SetRepositoryAwareCheckoutResolver(resolver)
+	if _, _, err := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{RepositoryIdentity: identity}, "main"); !errors.Is(err, ErrRepositoryCheckoutConnectionInvalid) {
+		t.Fatalf("expected missing authenticated fetcher error, got %v", err)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_MappedPipelineFetchReturnsTerminalFailure(t *testing.T) {
+	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}
+	resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: registrations, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: github})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	fetcher := &checkoutAuthenticatedFetcherFake{firstErr: errors.New("repository not found")}
+	service := NewBuildService(nil, nil, nil)
+	service.SetRepoFetcher(fetcher)
+	service.SetRepositoryAwareCheckoutResolver(resolver)
+	_, _, fetchErr := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{RepositoryIdentity: &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"}}, "main")
+	if fetchErr == nil || fetcher.calls != 1 || github.freshTokenCalls != 0 {
+		t.Fatalf("expected one terminal fetch failure without refresh, err=%v calls=%d refreshes=%d", fetchErr, fetcher.calls, github.freshTokenCalls)
+	}
+}
+
 func TestRepositoryAwareCheckoutResolver_MappedWorkspaceCloneUsesAuthenticatedRetry(t *testing.T) {
 	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
 	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}

--- a/backend/internal/service/build/repository_aware_checkout_test.go
+++ b/backend/internal/service/build/repository_aware_checkout_test.go
@@ -1,0 +1,292 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
+	"github.com/radiation/coyote-ci/backend/internal/repository"
+	"github.com/radiation/coyote-ci/backend/internal/source"
+)
+
+type checkoutRegistrationFake struct {
+	value domain.SCMRepositoryRegistration
+	err   error
+	calls int
+}
+
+func (f *checkoutRegistrationFake) GetByID(context.Context, string) (domain.SCMRepositoryRegistration, error) {
+	f.calls++
+	return f.value, f.err
+}
+
+type checkoutConnectionFake struct {
+	value domain.SCMConnectionDetail
+	err   error
+	calls int
+}
+
+func (f *checkoutConnectionFake) GetByID(context.Context, string) (domain.SCMConnectionDetail, error) {
+	f.calls++
+	return f.value, f.err
+}
+
+type checkoutSecretFake struct {
+	value string
+	err   error
+	calls int
+}
+
+func (f *checkoutSecretFake) Resolve(context.Context, string) (string, error) {
+	f.calls++
+	return f.value, f.err
+}
+
+type checkoutGitHubFake struct {
+	repository      platformgithubapp.Repository
+	repoErr         error
+	tokenErr        error
+	freshTokenErr   error
+	tokenCalls      int
+	freshTokenCalls int
+	repoCalls       int
+	request         platformgithubapp.InstallationTokenRequest
+}
+
+type checkoutAuthenticatedFetcherFake struct {
+	calls       int
+	credentials []source.HTTPSCredential
+	firstErr    error
+	localPath   string
+	commitSHA   string
+}
+
+func (f *checkoutAuthenticatedFetcherFake) Fetch(context.Context, string, string) (string, string, error) {
+	return "", "", errors.New("legacy fetch should not be called")
+}
+
+func (f *checkoutAuthenticatedFetcherFake) FetchWithHTTPSCredential(_ context.Context, _ string, _ string, credential source.HTTPSCredential) (string, string, error) {
+	f.calls++
+	f.credentials = append(f.credentials, credential)
+	if f.calls == 1 && f.firstErr != nil {
+		return "", "", f.firstErr
+	}
+	return f.localPath, f.commitSHA, nil
+}
+
+func (f *checkoutGitHubFake) GetInstallationToken(_ context.Context, request platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error) {
+	f.tokenCalls++
+	f.request = request
+	if f.tokenErr != nil {
+		return platformgithubapp.InstallationToken{}, f.tokenErr
+	}
+	return platformgithubapp.InstallationToken{Value: "secret-token"}, nil
+}
+
+func (f *checkoutGitHubFake) GetFreshInstallationToken(_ context.Context, request platformgithubapp.InstallationTokenRequest) (platformgithubapp.InstallationToken, error) {
+	f.freshTokenCalls++
+	f.request = request
+	if f.freshTokenErr != nil {
+		return platformgithubapp.InstallationToken{}, f.freshTokenErr
+	}
+	return platformgithubapp.InstallationToken{Value: "fresh-secret-token"}, nil
+}
+
+func (f *checkoutGitHubFake) GetRepositoryByID(_ context.Context, request platformgithubapp.InstallationTokenRequest, _ string) (platformgithubapp.Repository, error) {
+	f.repoCalls++
+	f.request = request
+	return f.repository, f.repoErr
+}
+
+func checkoutDetail(enabled bool) domain.SCMConnectionDetail {
+	return domain.SCMConnectionDetail{
+		Connection:            domain.SCMConnection{ID: "connection-a", Provider: domain.SCMProviderGitHub, APIBaseURL: "https://api.github.com", Enabled: enabled},
+		GitHubAppRegistration: &domain.GitHubAppRegistration{ID: "app-registration", AppID: "123", APIBaseURL: "https://api.github.com", PrivateKeySecretRef: "PRIVATE_KEY"},
+		GitHubAppInstallation: &domain.GitHubAppInstallation{ConnectionID: "connection-a", AppRegistrationID: "app-registration", InstallationID: "456"},
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_UsesExactSnapshottedIdentityAndCurrentCoordinates(t *testing.T) {
+	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100", CloneURL: "https://stale.example/old/repo.git"}}
+	connections := &checkoutConnectionFake{value: checkoutDetail(true)}
+	secrets := &checkoutSecretFake{value: "private-key"}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", Owner: "renamed", Name: "repository", FullName: "renamed/repository", CloneURL: "https://github.com/renamed/repository.git"}}
+	resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: connections, Registrations: registrations, Secrets: secrets, GitHub: github})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+
+	checkout, resolveErr := resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+	if resolveErr != nil {
+		t.Fatalf("resolve: %v", resolveErr)
+	}
+	if checkout.RepositoryURL != "https://github.com/renamed/repository.git" || checkout.Credential.Username != "x-access-token" || checkout.Credential.Password != "secret-token" {
+		t.Fatalf("unexpected checkout: %#v", checkout)
+	}
+	if len(github.request.RepositoryIDs) != 1 || github.request.RepositoryIDs[0] != "100" {
+		t.Fatalf("expected restricted token request, got %#v", github.request.RepositoryIDs)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_RejectsIdentityAndStateBeforeCredentials(t *testing.T) {
+	tests := []struct {
+		name         string
+		registration domain.SCMRepositoryRegistration
+		connection   domain.SCMConnectionDetail
+		wantErr      error
+	}{
+		{name: "mismatched connection", registration: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-b", ProviderRepositoryID: "100"}, connection: checkoutDetail(true), wantErr: ErrRepositoryCheckoutIdentityMismatch},
+		{name: "disabled repository", registration: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100", Disabled: true}, connection: checkoutDetail(true), wantErr: ErrRepositoryCheckoutRepositoryDisabled},
+		{name: "disabled connection", registration: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}, connection: checkoutDetail(false), wantErr: ErrRepositoryCheckoutConnectionDisabled},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			secrets := &checkoutSecretFake{value: "private-key"}
+			github := &checkoutGitHubFake{}
+			resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: testCase.connection}, Registrations: &checkoutRegistrationFake{value: testCase.registration}, Secrets: secrets, GitHub: github})
+			if err != nil {
+				t.Fatalf("new resolver: %v", err)
+			}
+			_, resolveErr := resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+			if !errors.Is(resolveErr, testCase.wantErr) {
+				t.Fatalf("expected %v, got %v", testCase.wantErr, resolveErr)
+			}
+			if secrets.calls != 0 || github.repoCalls != 0 || github.tokenCalls != 0 {
+				t.Fatalf("expected no credential use, secret=%d repo=%d token=%d", secrets.calls, github.repoCalls, github.tokenCalls)
+			}
+		})
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_RejectsProviderMismatchAndInaccessibleRepository(t *testing.T) {
+	registration := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	connection := &checkoutConnectionFake{value: checkoutDetail(true)}
+	secrets := &checkoutSecretFake{value: "private-key"}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "other", CloneURL: "https://github.com/other/repository.git"}}
+	resolver, _ := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: connection, Registrations: registration, Secrets: secrets, GitHub: github})
+	_, err := resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+	if !errors.Is(err, ErrRepositoryCheckoutIdentityMismatch) || github.tokenCalls != 0 {
+		t.Fatalf("expected identity mismatch before token, err=%v token_calls=%d", err, github.tokenCalls)
+	}
+
+	github.repository = platformgithubapp.Repository{}
+	github.repoErr = platformgithubapp.ErrRepositoryInaccessible
+	_, err = resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+	if !errors.Is(err, ErrRepositoryCheckoutRepositoryUnavailable) {
+		t.Fatalf("expected inaccessible repository error, got %v", err)
+	}
+
+	registration.err = repository.ErrSCMRepositoryRegistrationNotFound
+	_, err = resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+	if !errors.Is(err, repository.ErrSCMRepositoryRegistrationNotFound) {
+		t.Fatalf("expected missing registration, got %v", err)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_RetriesExactlyOnceWithFreshCredentialAfterAuthenticationFailure(t *testing.T) {
+	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	connections := &checkoutConnectionFake{value: checkoutDetail(true)}
+	secrets := &checkoutSecretFake{value: "private-key"}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}
+	resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: connections, Registrations: registrations, Secrets: secrets, GitHub: github})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	checkout, err := resolver.Resolve(context.Background(), domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	var credentials []source.HTTPSCredential
+	retryErr := checkout.RunWithCredentialRetry(context.Background(), func(credential source.HTTPSCredential) error {
+		credentials = append(credentials, credential)
+		if len(credentials) == 1 {
+			return errors.New("fatal: Authentication failed for https://github.com/acme/repository.git")
+		}
+		return nil
+	})
+	if retryErr != nil {
+		t.Fatalf("retry checkout: %v", retryErr)
+	}
+	if len(credentials) != 2 || credentials[0].Password != "secret-token" || credentials[1].Password != "fresh-secret-token" {
+		t.Fatalf("expected normal then fresh credentials, got %#v", credentials)
+	}
+	if github.freshTokenCalls != 1 || github.request.AppRegistrationID != "app-registration" || github.request.InstallationID != "456" || len(github.request.RepositoryIDs) != 1 || github.request.RepositoryIDs[0] != "100" {
+		t.Fatalf("expected one scoped refresh request, calls=%d request=%+v", github.freshTokenCalls, github.request)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_DoesNotRefreshNonAuthenticationFailure(t *testing.T) {
+	checkout := RepositoryAwareCheckout{
+		Credential: source.HTTPSCredential{Username: "x-access-token", Password: "secret-token"},
+		refreshCredential: func(context.Context) (source.HTTPSCredential, error) {
+			t.Fatal("refresh must not be called")
+			return source.HTTPSCredential{}, nil
+		},
+	}
+	for _, failure := range []string{"repository not found", "HTTP 404", "permission denied", "network timeout", "rate limit exceeded", "invalid ref", "clone failed"} {
+		t.Run(failure, func(t *testing.T) {
+			attempts := 0
+			err := checkout.RunWithCredentialRetry(context.Background(), func(source.HTTPSCredential) error {
+				attempts++
+				return errors.New(failure)
+			})
+			if err == nil || attempts != 1 {
+				t.Fatalf("expected one terminal attempt, err=%v attempts=%d", err, attempts)
+			}
+		})
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_SecondAuthenticationFailureStopsAfterTwoAttempts(t *testing.T) {
+	refreshes := 0
+	checkout := RepositoryAwareCheckout{
+		Credential: source.HTTPSCredential{Username: "x-access-token", Password: "secret-token"},
+		refreshCredential: func(context.Context) (source.HTTPSCredential, error) {
+			refreshes++
+			return source.HTTPSCredential{Username: "x-access-token", Password: "fresh-secret-token"}, nil
+		},
+	}
+	attempts := 0
+	err := checkout.RunWithCredentialRetry(context.Background(), func(source.HTTPSCredential) error {
+		attempts++
+		return errors.New("remote: bad credentials")
+	})
+	if err == nil || attempts != 2 || refreshes != 1 {
+		t.Fatalf("expected two attempts and one refresh, err=%v attempts=%d refreshes=%d", err, attempts, refreshes)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_MappedPipelineFetchUsesAuthenticationRefresh(t *testing.T) {
+	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	connections := &checkoutConnectionFake{value: checkoutDetail(true)}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}
+	resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: connections, Registrations: registrations, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: github})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	fetcher := &checkoutAuthenticatedFetcherFake{firstErr: errors.New("remote: bad credentials"), localPath: "/tmp/repository", commitSHA: "abc123"}
+	service := NewBuildService(nil, nil, nil)
+	service.SetRepoFetcher(fetcher)
+	service.SetRepositoryAwareCheckoutResolver(resolver)
+	localPath, commitSHA, fetchErr := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{
+		RepositoryIdentity: &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"},
+	}, "main")
+	if fetchErr != nil || localPath != "/tmp/repository" || commitSHA != "abc123" {
+		t.Fatalf("expected successful refreshed fetch, path=%q sha=%q err=%v", localPath, commitSHA, fetchErr)
+	}
+	if fetcher.calls != 2 || github.freshTokenCalls != 1 || len(fetcher.credentials) != 2 || fetcher.credentials[0].Password != "secret-token" || fetcher.credentials[1].Password != "fresh-secret-token" {
+		t.Fatalf("expected one refreshed API fetch, calls=%d refreshes=%d credentials=%#v", fetcher.calls, github.freshTokenCalls, fetcher.credentials)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_UnmappedPipelineFetchDoesNotResolveOrRefreshCredentials(t *testing.T) {
+	service := NewBuildService(nil, nil, nil)
+	fetcher := &fakeRepoFetcher{localPath: "/tmp/repository", commitSHA: "abc123"}
+	service.SetRepoFetcher(fetcher)
+	localPath, commitSHA, fetchErr := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{RepoURL: "https://example.test/repository.git"}, "main")
+	if fetchErr != nil || localPath != "/tmp/repository" || commitSHA != "abc123" || fetcher.calls != 1 {
+		t.Fatalf("expected legacy fetch without checkout resolution, path=%q sha=%q calls=%d err=%v", localPath, commitSHA, fetcher.calls, fetchErr)
+	}
+}

--- a/backend/internal/service/build/repository_aware_checkout_test.go
+++ b/backend/internal/service/build/repository_aware_checkout_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/radiation/coyote-ci/backend/internal/domain"
 	platformgithubapp "github.com/radiation/coyote-ci/backend/internal/platform/githubapp"
 	"github.com/radiation/coyote-ci/backend/internal/repository"
+	"github.com/radiation/coyote-ci/backend/internal/service/execution"
 	"github.com/radiation/coyote-ci/backend/internal/source"
 )
 
@@ -61,6 +62,31 @@ type checkoutAuthenticatedFetcherFake struct {
 	firstErr    error
 	localPath   string
 	commitSHA   string
+}
+
+type checkoutAuthenticatedWorkspaceResolverFake struct {
+	cloneCalls         int
+	authenticatedCalls int
+	credentials        []source.HTTPSCredential
+	firstErr           error
+}
+
+func (f *checkoutAuthenticatedWorkspaceResolverFake) CloneIntoWorkspace(context.Context, string, string) error {
+	f.cloneCalls++
+	return nil
+}
+
+func (f *checkoutAuthenticatedWorkspaceResolverFake) CloneIntoWorkspaceWithHTTPSCredential(_ context.Context, _ string, _ string, credential source.HTTPSCredential) error {
+	f.authenticatedCalls++
+	f.credentials = append(f.credentials, credential)
+	if f.authenticatedCalls == 1 && f.firstErr != nil {
+		return f.firstErr
+	}
+	return nil
+}
+
+func (f *checkoutAuthenticatedWorkspaceResolverFake) CheckoutWorkspaceSource(context.Context, string, source.WorkspaceSourceSpec) (string, error) {
+	return "commit", nil
 }
 
 func (f *checkoutAuthenticatedFetcherFake) Fetch(context.Context, string, string) (string, string, error) {
@@ -185,6 +211,57 @@ func TestRepositoryAwareCheckoutResolver_RejectsProviderMismatchAndInaccessibleR
 	}
 }
 
+func TestNewRepositoryAwareCheckoutResolver_RequiresAllDependencies(t *testing.T) {
+	if _, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{}); err == nil {
+		t.Fatal("expected missing dependency error")
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_ClassifiesConfigurationAndTokenFailures(t *testing.T) {
+	snapshot := domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"}
+	registration := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}
+
+	invalidDetail := checkoutDetail(true)
+	invalidDetail.GitHubAppRegistration = nil
+	resolver, _ := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: invalidDetail}, Registrations: registration, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: github})
+	if _, err := resolver.Resolve(context.Background(), snapshot); !errors.Is(err, ErrRepositoryCheckoutConnectionInvalid) {
+		t.Fatalf("expected invalid connection, got %v", err)
+	}
+
+	resolver, _ = NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: registration, Secrets: &checkoutSecretFake{}, GitHub: github})
+	if _, err := resolver.Resolve(context.Background(), snapshot); !errors.Is(err, ErrRepositoryCheckoutPrivateKeyUnavailable) {
+		t.Fatalf("expected unavailable key, got %v", err)
+	}
+
+	github.tokenErr = platformgithubapp.ErrInstallationUnavailable
+	resolver, _ = NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: registration, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: github})
+	if _, err := resolver.Resolve(context.Background(), snapshot); !errors.Is(err, ErrRepositoryCheckoutRepositoryUnavailable) {
+		t.Fatalf("expected unavailable repository for token failure, got %v", err)
+	}
+}
+
+func TestClassifyRepositoryCheckoutProviderError(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		input   error
+		wantErr error
+	}{
+		{name: "repository inaccessible", input: platformgithubapp.ErrRepositoryInaccessible, wantErr: ErrRepositoryCheckoutRepositoryUnavailable},
+		{name: "installation unavailable", input: platformgithubapp.ErrInstallationUnavailable, wantErr: ErrRepositoryCheckoutRepositoryUnavailable},
+		{name: "missing key", input: platformgithubapp.ErrPrivateKeyMissing, wantErr: ErrRepositoryCheckoutPrivateKeyUnavailable},
+		{name: "malformed key", input: platformgithubapp.ErrPrivateKeyMalformed, wantErr: ErrRepositoryCheckoutPrivateKeyUnavailable},
+		{name: "non rsa key", input: platformgithubapp.ErrPrivateKeyNotRSA, wantErr: ErrRepositoryCheckoutPrivateKeyUnavailable},
+		{name: "unclassified", input: platformgithubapp.ErrRateLimited, wantErr: platformgithubapp.ErrRateLimited},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := classifyRepositoryCheckoutProviderError(testCase.input); !errors.Is(got, testCase.wantErr) {
+				t.Fatalf("expected %v, got %v", testCase.wantErr, got)
+			}
+		})
+	}
+}
+
 func TestRepositoryAwareCheckoutResolver_RetriesExactlyOnceWithFreshCredentialAfterAuthenticationFailure(t *testing.T) {
 	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
 	connections := &checkoutConnectionFake{value: checkoutDetail(true)}
@@ -258,6 +335,24 @@ func TestRepositoryAwareCheckoutResolver_SecondAuthenticationFailureStopsAfterTw
 	}
 }
 
+func TestRepositoryAwareCheckoutResolver_ReturnsRefreshFailureAndRejectsNilOperation(t *testing.T) {
+	checkout := RepositoryAwareCheckout{
+		Credential: source.HTTPSCredential{Username: "x-access-token", Password: "secret-token"},
+		refreshCredential: func(context.Context) (source.HTTPSCredential, error) {
+			return source.HTTPSCredential{}, platformgithubapp.ErrInstallationUnavailable
+		},
+	}
+	if err := checkout.RunWithCredentialRetry(context.Background(), nil); err == nil {
+		t.Fatal("expected nil operation error")
+	}
+	err := checkout.RunWithCredentialRetry(context.Background(), func(source.HTTPSCredential) error {
+		return errors.New("remote: bad credentials")
+	})
+	if !errors.Is(err, platformgithubapp.ErrInstallationUnavailable) {
+		t.Fatalf("expected refresh failure, got %v", err)
+	}
+}
+
 func TestRepositoryAwareCheckoutResolver_MappedPipelineFetchUsesAuthenticationRefresh(t *testing.T) {
 	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
 	connections := &checkoutConnectionFake{value: checkoutDetail(true)}
@@ -288,5 +383,45 @@ func TestRepositoryAwareCheckoutResolver_UnmappedPipelineFetchDoesNotResolveOrRe
 	localPath, commitSHA, fetchErr := service.fetchRepositoryForBuildCreation(context.Background(), CreateRepoBuildInput{RepoURL: "https://example.test/repository.git"}, "main")
 	if fetchErr != nil || localPath != "/tmp/repository" || commitSHA != "abc123" || fetcher.calls != 1 {
 		t.Fatalf("expected legacy fetch without checkout resolution, path=%q sha=%q calls=%d err=%v", localPath, commitSHA, fetcher.calls, fetchErr)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_MappedWorkspaceCloneUsesAuthenticatedRetry(t *testing.T) {
+	registrations := &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}
+	github := &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}
+	resolver, err := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: registrations, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: github})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+	workspace := &checkoutAuthenticatedWorkspaceResolverFake{firstErr: errors.New("fatal: Authentication failed")}
+	service := NewBuildService(nil, nil, nil)
+	service.SetSourceResolver(workspace)
+	service.SetRepositoryAwareCheckoutResolver(resolver)
+	err = service.cloneBuildSourceIntoWorkspace(context.Background(), "/tmp/build", execution.ResolvedBuildSourceSpec{RepositoryURL: "https://stale.example/repository.git", Ref: "main", HasSource: true, RepositoryIdentity: &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"}})
+	if err != nil {
+		t.Fatalf("authenticated clone: %v", err)
+	}
+	if workspace.cloneCalls != 0 || workspace.authenticatedCalls != 2 || github.freshTokenCalls != 1 || len(workspace.credentials) != 2 || workspace.credentials[1].Password != "fresh-secret-token" {
+		t.Fatalf("expected authenticated retry, legacy=%d authenticated=%d refreshes=%d credentials=%#v", workspace.cloneCalls, workspace.authenticatedCalls, github.freshTokenCalls, workspace.credentials)
+	}
+}
+
+func TestRepositoryAwareCheckoutResolver_WorkspaceCloneRejectsMissingCheckoutOrAuthenticationSupport(t *testing.T) {
+	service := NewBuildService(nil, nil, nil)
+	legacyResolver := &fakeWorkspaceSourceResolver{}
+	service.SetSourceResolver(legacyResolver)
+	identity := &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: "repository-a", SCMConnectionID: "connection-a", ProviderRepositoryID: "100"}
+	spec := execution.ResolvedBuildSourceSpec{RepositoryURL: "https://example.test/repository.git", RepositoryIdentity: identity}
+	if err := service.cloneBuildSourceIntoWorkspace(context.Background(), "/tmp/build", spec); !errors.Is(err, ErrRepositoryCheckoutConnectionInvalid) {
+		t.Fatalf("expected missing checkout resolver error, got %v", err)
+	}
+
+	resolver, resolverErr := NewRepositoryAwareCheckoutResolver(RepositoryAwareCheckoutResolverConfig{Connections: &checkoutConnectionFake{value: checkoutDetail(true)}, Registrations: &checkoutRegistrationFake{value: domain.SCMRepositoryRegistration{ID: "repository-a", ConnectionID: "connection-a", ProviderRepositoryID: "100"}}, Secrets: &checkoutSecretFake{value: "private-key"}, GitHub: &checkoutGitHubFake{repository: platformgithubapp.Repository{ID: "100", CloneURL: "https://github.com/acme/repository.git"}}})
+	if resolverErr != nil {
+		t.Fatalf("new resolver: %v", resolverErr)
+	}
+	service.SetRepositoryAwareCheckoutResolver(resolver)
+	if err := service.cloneBuildSourceIntoWorkspace(context.Background(), "/tmp/build", spec); !errors.Is(err, ErrRepositoryCheckoutConnectionInvalid) {
+		t.Fatalf("expected missing authenticated resolver error, got %v", err)
 	}
 }

--- a/backend/internal/service/build/service.go
+++ b/backend/internal/service/build/service.go
@@ -61,6 +61,7 @@ type BuildService struct {
 	repoFetcher            source.RepoFetcher
 	managedImageRefresher  ManagedImageRefresher
 	sourceResolver         source.WorkspaceSourceResolver
+	repositoryCheckout     *RepositoryAwareCheckoutResolver
 	executionWorkspaceRoot string
 
 	artifactRepo              repository.ArtifactRepository
@@ -104,6 +105,7 @@ type BuildServiceConfig struct {
 	RepoFetcher               source.RepoFetcher
 	ManagedImageRefresher     ManagedImageRefresher
 	SourceResolver            source.WorkspaceSourceResolver
+	RepositoryCheckout        *RepositoryAwareCheckoutResolver
 	ArtifactRepo              repository.ArtifactRepository
 	ArtifactLabelRepo         repository.ArtifactLabelRepository
 	ArtifactResolver          *artifact.StoreResolver
@@ -129,6 +131,7 @@ func NewBuildServiceFromConfig(buildRepo repository.BuildRepository, stepRunner 
 	if cfg.SourceResolver != nil {
 		svc.sourceResolver = cfg.SourceResolver
 	}
+	svc.repositoryCheckout = cfg.RepositoryCheckout
 	svc.defaultExecutionImage = strings.TrimSpace(cfg.DefaultImage)
 	svc.executionWorkspaceRoot = buildNormalizeWorkspaceRoot(cfg.ExecutionWorkspace)
 	svc.versionTagger = cfg.VersionTagger
@@ -180,6 +183,10 @@ func (s *BuildService) SetRepoFetcher(fetcher source.RepoFetcher) {
 
 func (s *BuildService) SetSourceResolver(resolver source.WorkspaceSourceResolver) {
 	s.sourceResolver = resolver
+}
+
+func (s *BuildService) SetRepositoryAwareCheckoutResolver(resolver *RepositoryAwareCheckoutResolver) {
+	s.repositoryCheckout = resolver
 }
 
 func (s *BuildService) SetExecutionWorkspaceRoot(root string) {

--- a/backend/internal/service/build/source.go
+++ b/backend/internal/service/build/source.go
@@ -40,6 +40,9 @@ func buildSourceSpecFromBuild(build domain.Build) execution.ResolvedBuildSourceS
 			Ref:           buildReadOptionalString(build.Source.Ref),
 			CommitSHA:     buildReadOptionalString(build.Source.CommitSHA),
 		}
+		if build.RegisteredRepositoryID != nil && build.SCMConnectionID != nil && build.ProviderRepositoryID != nil {
+			result.RepositoryIdentity = &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: buildReadOptionalString(build.RegisteredRepositoryID), SCMConnectionID: buildReadOptionalString(build.SCMConnectionID), ProviderRepositoryID: buildReadOptionalString(build.ProviderRepositoryID)}
+		}
 		result.HasSource = result.RepositoryURL != ""
 		return result
 	}
@@ -48,6 +51,9 @@ func buildSourceSpecFromBuild(build domain.Build) execution.ResolvedBuildSourceS
 		RepositoryURL: buildReadOptionalString(build.RepoURL),
 		Ref:           buildReadOptionalString(build.Ref),
 		CommitSHA:     buildReadOptionalString(build.CommitSHA),
+	}
+	if build.RegisteredRepositoryID != nil && build.SCMConnectionID != nil && build.ProviderRepositoryID != nil {
+		result.RepositoryIdentity = &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: buildReadOptionalString(build.RegisteredRepositoryID), SCMConnectionID: buildReadOptionalString(build.SCMConnectionID), ProviderRepositoryID: buildReadOptionalString(build.ProviderRepositoryID)}
 	}
 	result.HasSource = result.RepositoryURL != ""
 	return result
@@ -134,7 +140,7 @@ func (s *BuildService) resolveBuildSourceInWorkspace(ctx context.Context, buildI
 	}
 
 	workspacePath := filepath.Join(workspaceRoot, strings.TrimSpace(buildID))
-	if err := s.sourceResolver.CloneIntoWorkspace(ctx, workspacePath, sourceSpec.RepositoryURL); err != nil {
+	if err := s.cloneBuildSourceIntoWorkspace(ctx, workspacePath, sourceSpec); err != nil {
 		return "", err
 	}
 
@@ -170,6 +176,26 @@ func (s *BuildService) resolveBuildSourceInWorkspace(ctx context.Context, buildI
 	s.notifySCMBuildStatus(ctx, build)
 
 	return trimmedResolvedCommit, nil
+}
+
+func (s *BuildService) cloneBuildSourceIntoWorkspace(ctx context.Context, workspacePath string, sourceSpec execution.ResolvedBuildSourceSpec) error {
+	if sourceSpec.RepositoryIdentity == nil {
+		return s.sourceResolver.CloneIntoWorkspace(ctx, workspacePath, sourceSpec.RepositoryURL)
+	}
+	if s.repositoryCheckout == nil {
+		return ErrRepositoryCheckoutConnectionInvalid
+	}
+	checkout, err := s.repositoryCheckout.Resolve(ctx, *sourceSpec.RepositoryIdentity)
+	if err != nil {
+		return err
+	}
+	authenticatedResolver, ok := s.sourceResolver.(source.AuthenticatedWorkspaceSourceResolver)
+	if !ok {
+		return ErrRepositoryCheckoutConnectionInvalid
+	}
+	return checkout.RunWithCredentialRetry(ctx, func(credential source.HTTPSCredential) error {
+		return authenticatedResolver.CloneIntoWorkspaceWithHTTPSCredential(ctx, workspacePath, checkout.RepositoryURL, credential)
+	})
 }
 
 func (s *BuildService) currentWorkspaceRoot() string {

--- a/backend/internal/service/execution/source_spec.go
+++ b/backend/internal/service/execution/source_spec.go
@@ -7,10 +7,11 @@ import (
 )
 
 type ResolvedBuildSourceSpec struct {
-	RepositoryURL string
-	Ref           string
-	CommitSHA     string
-	HasSource     bool
+	RepositoryURL      string
+	Ref                string
+	CommitSHA          string
+	RepositoryIdentity *domain.RepositoryIdentitySnapshot
+	HasSource          bool
 }
 
 func sourceSpecFromBuild(build domain.Build) ResolvedBuildSourceSpec {
@@ -20,6 +21,9 @@ func sourceSpecFromBuild(build domain.Build) ResolvedBuildSourceSpec {
 			Ref:           readOptionalString(build.Source.Ref),
 			CommitSHA:     readOptionalString(build.Source.CommitSHA),
 		}
+		if build.RegisteredRepositoryID != nil && build.SCMConnectionID != nil && build.ProviderRepositoryID != nil {
+			result.RepositoryIdentity = &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: strings.TrimSpace(*build.RegisteredRepositoryID), SCMConnectionID: strings.TrimSpace(*build.SCMConnectionID), ProviderRepositoryID: strings.TrimSpace(*build.ProviderRepositoryID)}
+		}
 		result.HasSource = result.RepositoryURL != ""
 		return result
 	}
@@ -28,6 +32,9 @@ func sourceSpecFromBuild(build domain.Build) ResolvedBuildSourceSpec {
 		RepositoryURL: readOptionalString(build.RepoURL),
 		Ref:           readOptionalString(build.Ref),
 		CommitSHA:     readOptionalString(build.CommitSHA),
+	}
+	if build.RegisteredRepositoryID != nil && build.SCMConnectionID != nil && build.ProviderRepositoryID != nil {
+		result.RepositoryIdentity = &domain.RepositoryIdentitySnapshot{RegisteredRepositoryID: strings.TrimSpace(*build.RegisteredRepositoryID), SCMConnectionID: strings.TrimSpace(*build.SCMConnectionID), ProviderRepositoryID: strings.TrimSpace(*build.ProviderRepositoryID)}
 	}
 	result.HasSource = result.RepositoryURL != ""
 	return result

--- a/backend/internal/service/execution/source_spec_test.go
+++ b/backend/internal/service/execution/source_spec_test.go
@@ -38,3 +38,17 @@ func TestSourceSpecFromBuild_OmitsPartialRepositoryIdentity(t *testing.T) {
 		t.Fatalf("expected source without incomplete identity, got %+v", spec)
 	}
 }
+
+func TestSourceSpecFromBuild_PreservesIdentityWithoutSourceSpec(t *testing.T) {
+	repositoryURL := "https://github.com/acme/repository.git"
+	ref := "main"
+	registeredRepositoryID := "repository-a"
+	connectionID := "connection-a"
+	providerRepositoryID := "100"
+	build := domain.Build{RepoURL: &repositoryURL, Ref: &ref, RegisteredRepositoryID: &registeredRepositoryID, SCMConnectionID: &connectionID, ProviderRepositoryID: &providerRepositoryID}
+
+	spec := sourceSpecFromBuild(build)
+	if !spec.HasSource || spec.RepositoryIdentity == nil || spec.RepositoryIdentity.ProviderRepositoryID != "100" {
+		t.Fatalf("expected legacy source fields and complete identity, got %+v", spec)
+	}
+}

--- a/backend/internal/service/execution/source_spec_test.go
+++ b/backend/internal/service/execution/source_spec_test.go
@@ -1,0 +1,40 @@
+package execution
+
+import (
+	"testing"
+
+	"github.com/radiation/coyote-ci/backend/internal/domain"
+)
+
+func TestSourceSpecFromBuild_PreservesCompleteRepositoryIdentity(t *testing.T) {
+	registeredRepositoryID := " repository-a "
+	connectionID := " connection-a "
+	providerRepositoryID := " 100 "
+	repositoryURL := " https://github.com/acme/repository.git "
+	ref := " main "
+	build := domain.Build{
+		Source:                 domain.NewSourceSpec(repositoryURL, ref, ""),
+		RegisteredRepositoryID: &registeredRepositoryID,
+		SCMConnectionID:        &connectionID,
+		ProviderRepositoryID:   &providerRepositoryID,
+	}
+
+	spec := sourceSpecFromBuild(build)
+	if !spec.HasSource || spec.RepositoryURL != "https://github.com/acme/repository.git" || spec.Ref != "main" {
+		t.Fatalf("unexpected source spec: %+v", spec)
+	}
+	if spec.RepositoryIdentity == nil || spec.RepositoryIdentity.RegisteredRepositoryID != "repository-a" || spec.RepositoryIdentity.SCMConnectionID != "connection-a" || spec.RepositoryIdentity.ProviderRepositoryID != "100" {
+		t.Fatalf("expected trimmed repository identity, got %+v", spec.RepositoryIdentity)
+	}
+}
+
+func TestSourceSpecFromBuild_OmitsPartialRepositoryIdentity(t *testing.T) {
+	repositoryURL := "https://github.com/acme/repository.git"
+	registeredRepositoryID := "repository-a"
+	build := domain.Build{RepoURL: &repositoryURL, RegisteredRepositoryID: &registeredRepositoryID}
+
+	spec := sourceSpecFromBuild(build)
+	if !spec.HasSource || spec.RepositoryIdentity != nil {
+		t.Fatalf("expected source without incomplete identity, got %+v", spec)
+	}
+}

--- a/backend/internal/source/fetcher.go
+++ b/backend/internal/source/fetcher.go
@@ -21,6 +21,12 @@ type RepoFetcher interface {
 	Fetch(ctx context.Context, repoURL string, ref string) (localPath string, commitSHA string, err error)
 }
 
+// AuthenticatedRepoFetcher is an optional extension for authenticated HTTPS repository fetches.
+type AuthenticatedRepoFetcher interface {
+	RepoFetcher
+	FetchWithHTTPSCredential(ctx context.Context, repoURL string, ref string, credential HTTPSCredential) (localPath string, commitSHA string, err error)
+}
+
 // GitFetcher implements RepoFetcher using the git CLI.
 type GitFetcher struct{}
 
@@ -29,6 +35,14 @@ func NewGitFetcher() *GitFetcher {
 }
 
 func (g *GitFetcher) Fetch(ctx context.Context, repoURL string, ref string) (string, string, error) {
+	return g.fetch(ctx, repoURL, ref, nil)
+}
+
+func (g *GitFetcher) FetchWithHTTPSCredential(ctx context.Context, repoURL string, ref string, credential HTTPSCredential) (string, string, error) {
+	return g.fetch(ctx, repoURL, ref, &credential)
+}
+
+func (g *GitFetcher) fetch(ctx context.Context, repoURL string, ref string, credential *HTTPSCredential) (string, string, error) {
 	repoURL = strings.TrimSpace(repoURL)
 	if repoURL == "" {
 		return "", "", errors.New("repo URL is required")
@@ -57,7 +71,11 @@ func (g *GitFetcher) Fetch(ctx context.Context, repoURL string, ref string) (str
 		}
 	}()
 
-	err = gitClone(ctx, repoURL, tmpDir)
+	if credential != nil {
+		err = gitCloneWithHTTPSCredential(ctx, repoURL, tmpDir, *credential)
+	} else {
+		err = gitClone(ctx, repoURL, tmpDir)
+	}
 	if err != nil {
 		return "", "", fmt.Errorf("cloning repo %s: %w", repoURL, err)
 	}
@@ -79,6 +97,87 @@ func (g *GitFetcher) Fetch(ctx context.Context, repoURL string, ref string) (str
 
 	cleanup = false
 	return tmpDir, strings.TrimSpace(commitSHA), nil
+}
+
+func gitCloneWithHTTPSCredential(ctx context.Context, repoURL string, dst string, credential HTTPSCredential) error {
+	username := strings.TrimSpace(credential.Username)
+	password := strings.TrimSpace(credential.Password)
+	if username == "" || password == "" {
+		return errors.New("https git credential is required")
+	}
+	askPassPath, err := createGitTokenAskPassScript()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(askPassPath) }()
+
+	cmd := exec.CommandContext(ctx, "git", "clone", "--", repoURL, dst)
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS="+askPassPath,
+		"COYOTE_GIT_ASKPASS_USERNAME="+username,
+		"COYOTE_GIT_ASKPASS_TOKEN="+password,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, redactGitSecret(string(out), password))
+	}
+	return nil
+}
+
+func createGitTokenAskPassScript() (string, error) {
+	file, err := os.CreateTemp("", "coyote-git-askpass-*")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	script := "#!/bin/sh\ncase \"$1\" in\n  *Username*|*username*) printenv COYOTE_GIT_ASKPASS_USERNAME ;;\n  *) printenv COYOTE_GIT_ASKPASS_TOKEN ;;\nesac\n"
+	if _, writeErr := file.WriteString(script); writeErr != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", writeErr
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		_ = os.Remove(path)
+		return "", closeErr
+	}
+	if chmodErr := os.Chmod(path, 0o700); chmodErr != nil {
+		_ = os.Remove(path)
+		return "", chmodErr
+	}
+	return path, nil
+}
+
+func redactGitSecret(value string, secret string) string {
+	return strings.ReplaceAll(value, strings.TrimSpace(secret), "[REDACTED]")
+}
+
+// IsAuthenticationFailure permits a credential refresh only for explicit,
+// sanitized Git authentication rejections. Ambiguous failures remain terminal.
+func IsAuthenticationFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, indicator := range []string{
+		"repository not found", "http 404", "404 not found", "permission denied",
+		"access denied", "repository access", "invalid ref", "invalid commit",
+		"malformed url", "no such host", "network is unreachable", "timeout",
+		"rate limit", "service unavailable",
+	} {
+		if strings.Contains(message, indicator) {
+			return false
+		}
+	}
+	for _, indicator := range []string{
+		"authentication failed", "bad credentials", "invalid credentials",
+		"credential rejected", "http 401", "401 unauthorized",
+	} {
+		if strings.Contains(message, indicator) {
+			return true
+		}
+	}
+	return false
 }
 
 func gitClone(ctx context.Context, repoURL string, dst string) error {

--- a/backend/internal/source/fetcher_test.go
+++ b/backend/internal/source/fetcher_test.go
@@ -141,6 +141,36 @@ func TestIsAuthenticationFailure_OnlyAcceptsExplicitCredentialRejection(t *testi
 	}
 }
 
+func TestGitFetcher_AuthenticatedInputValidation(t *testing.T) {
+	fetcher := NewGitFetcher()
+	for _, testCase := range []struct {
+		name       string
+		repository string
+		ref        string
+		credential HTTPSCredential
+	}{
+		{name: "missing username", repository: "https://github.com/acme/repository.git", ref: "main", credential: HTTPSCredential{Password: "token"}},
+		{name: "missing password", repository: "https://github.com/acme/repository.git", ref: "main", credential: HTTPSCredential{Username: "x-access-token"}},
+		{name: "empty URL", repository: " ", ref: "main", credential: HTTPSCredential{Username: "x-access-token", Password: "token"}},
+		{name: "option URL", repository: "-bad", ref: "main", credential: HTTPSCredential{Username: "x-access-token", Password: "token"}},
+		{name: "empty ref", repository: "https://github.com/acme/repository.git", ref: " ", credential: HTTPSCredential{Username: "x-access-token", Password: "token"}},
+		{name: "invalid ref", repository: "https://github.com/acme/repository.git", ref: "bad\\ref", credential: HTTPSCredential{Username: "x-access-token", Password: "token"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, _, err := fetcher.FetchWithHTTPSCredential(context.Background(), testCase.repository, testCase.ref, testCase.credential)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestGitCloneWithHTTPSCredential_RejectsMissingCredentials(t *testing.T) {
+	if err := gitCloneWithHTTPSCredential(context.Background(), "https://github.com/acme/repository.git", t.TempDir(), HTTPSCredential{}); err == nil {
+		t.Fatal("expected missing credential error")
+	}
+}
+
 func TestGitCloneWithHTTPSCredential_CleansUniqueAskpassAndRedactsToken(t *testing.T) {
 	binDir := t.TempDir()
 	markerPath := filepath.Join(t.TempDir(), "askpass-paths")

--- a/backend/internal/source/fetcher_test.go
+++ b/backend/internal/source/fetcher_test.go
@@ -2,9 +2,11 @@ package source
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -99,6 +101,62 @@ func TestGitFetcher_Fetch(t *testing.T) {
 			t.Fatal("expected error for invalid repo")
 		}
 	})
+}
+
+func TestIsAuthenticationFailure_OnlyAcceptsExplicitCredentialRejection(t *testing.T) {
+	for _, testCase := range []struct {
+		message string
+		want    bool
+	}{
+		{message: "fatal: Authentication failed", want: true},
+		{message: "remote: bad credentials", want: true},
+		{message: "HTTP 401 unauthorized", want: true},
+		{message: "repository not found", want: false},
+		{message: "HTTP 404", want: false},
+		{message: "permission denied", want: false},
+		{message: "network timeout", want: false},
+		{message: "rate limit exceeded", want: false},
+		{message: "invalid ref", want: false},
+		{message: "generic clone failure", want: false},
+	} {
+		t.Run(testCase.message, func(t *testing.T) {
+			if got := IsAuthenticationFailure(errors.New(testCase.message)); got != testCase.want {
+				t.Fatalf("expected %t, got %t", testCase.want, got)
+			}
+		})
+	}
+}
+
+func TestGitCloneWithHTTPSCredential_CleansUniqueAskpassAndRedactsToken(t *testing.T) {
+	binDir := t.TempDir()
+	markerPath := filepath.Join(t.TempDir(), "askpass-paths")
+	gitPath := filepath.Join(binDir, "git")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$GIT_ASKPASS\" >> \"$ASKPASS_MARKER\"\nprintf 'fatal: Authentication failed for %s\\n' \"$COYOTE_GIT_ASKPASS_TOKEN\" >&2\nexit 1\n"
+	if writeErr := os.WriteFile(gitPath, []byte(script), 0o700); writeErr != nil {
+		t.Fatalf("write fake git: %v", writeErr)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ASKPASS_MARKER", markerPath)
+
+	for _, token := range []string{"old-secret-token", "new-secret-token"} {
+		err := gitCloneWithHTTPSCredential(context.Background(), "https://github.com/acme/repository.git", t.TempDir(), HTTPSCredential{Username: "x-access-token", Password: token})
+		if err == nil || strings.Contains(err.Error(), token) || !IsAuthenticationFailure(err) {
+			t.Fatalf("expected sanitized authentication failure for %q, err=%v", token, err)
+		}
+	}
+	pathsData, readErr := os.ReadFile(markerPath)
+	if readErr != nil {
+		t.Fatalf("read captured askpass paths: %v", readErr)
+	}
+	paths := strings.Fields(string(pathsData))
+	if len(paths) != 2 || paths[0] == paths[1] {
+		t.Fatalf("expected unique askpass paths per attempt, got %q", paths)
+	}
+	for _, path := range paths {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("expected askpass path %q to be removed, err=%v", path, statErr)
+		}
+	}
 }
 
 func mustRun(t *testing.T, dir string, name string, args ...string) {

--- a/backend/internal/source/fetcher_test.go
+++ b/backend/internal/source/fetcher_test.go
@@ -171,6 +171,26 @@ func TestGitCloneWithHTTPSCredential_RejectsMissingCredentials(t *testing.T) {
 	}
 }
 
+func TestCreateGitTokenAskPassScript_IsExecutableAndRoutesCredentialPrompts(t *testing.T) {
+	path, err := createGitTokenAskPassScript()
+	if err != nil {
+		t.Fatalf("create askpass script: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	info, statErr := os.Stat(path)
+	if statErr != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("expected executable 0700 askpass script, info=%v err=%v", info, statErr)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read askpass script: %v", readErr)
+	}
+	if !strings.Contains(string(content), "COYOTE_GIT_ASKPASS_USERNAME") || !strings.Contains(string(content), "COYOTE_GIT_ASKPASS_TOKEN") {
+		t.Fatalf("expected askpass script to route username and token prompts, got %q", content)
+	}
+}
+
 func TestGitCloneWithHTTPSCredential_CleansUniqueAskpassAndRedactsToken(t *testing.T) {
 	binDir := t.TempDir()
 	markerPath := filepath.Join(t.TempDir(), "askpass-paths")

--- a/backend/internal/source/fetcher_test.go
+++ b/backend/internal/source/fetcher_test.go
@@ -76,6 +76,20 @@ func TestGitFetcher_Fetch(t *testing.T) {
 		}
 	})
 
+	t.Run("fetch with HTTPS credential", func(t *testing.T) {
+		localPath, commitSHA, fetchErr := fetcher.FetchWithHTTPSCredential(context.Background(), remoteDir, "main", HTTPSCredential{Username: "x-access-token", Password: "test-token"})
+		if fetchErr != nil {
+			localPath, commitSHA, fetchErr = fetcher.FetchWithHTTPSCredential(context.Background(), remoteDir, "master", HTTPSCredential{Username: "x-access-token", Password: "test-token"})
+		}
+		if fetchErr != nil {
+			t.Fatalf("authenticated fetch failed: %v", fetchErr)
+		}
+		defer func() { _ = os.RemoveAll(localPath) }()
+		if commitSHA != expectedSHA {
+			t.Fatalf("expected SHA %q, got %q", expectedSHA, commitSHA)
+		}
+	})
+
 	t.Run("fetch by remote feature branch", func(t *testing.T) {
 		localPath, commitSHA, err := fetcher.Fetch(context.Background(), remoteDir, "feature/repo-cloning")
 		if err != nil {

--- a/backend/internal/source/workspace_source_resolver.go
+++ b/backend/internal/source/workspace_source_resolver.go
@@ -24,10 +24,22 @@ type WorkspaceSourceSpec struct {
 	CommitSHA     string
 }
 
+// HTTPSCredential is used only for the lifetime of an authenticated Git operation.
+type HTTPSCredential struct {
+	Username string
+	Password string
+}
+
 // WorkspaceSourceResolver materializes source into an existing host workspace.
 type WorkspaceSourceResolver interface {
 	CloneIntoWorkspace(ctx context.Context, workspacePath string, repositoryURL string) error
 	CheckoutWorkspaceSource(ctx context.Context, workspacePath string, spec WorkspaceSourceSpec) (string, error)
+}
+
+// AuthenticatedWorkspaceSourceResolver is an optional extension for HTTPS Git authentication.
+type AuthenticatedWorkspaceSourceResolver interface {
+	WorkspaceSourceResolver
+	CloneIntoWorkspaceWithHTTPSCredential(ctx context.Context, workspacePath string, repositoryURL string, credential HTTPSCredential) error
 }
 
 // GitWorkspaceSourceResolver uses git CLI to populate and pin workspace source.
@@ -38,18 +50,31 @@ func NewGitWorkspaceSourceResolver() *GitWorkspaceSourceResolver {
 }
 
 func (r *GitWorkspaceSourceResolver) CloneIntoWorkspace(ctx context.Context, workspacePath string, repositoryURL string) error {
+	return r.cloneIntoWorkspace(ctx, workspacePath, repositoryURL, nil)
+}
+
+func (r *GitWorkspaceSourceResolver) CloneIntoWorkspaceWithHTTPSCredential(ctx context.Context, workspacePath string, repositoryURL string, credential HTTPSCredential) error {
+	return r.cloneIntoWorkspace(ctx, workspacePath, repositoryURL, &credential)
+}
+
+func (r *GitWorkspaceSourceResolver) cloneIntoWorkspace(ctx context.Context, workspacePath string, repositoryURL string, credential *HTTPSCredential) error {
 	cleanWorkspacePath, repoURL, err := normalizeCloneInputs(workspacePath, repositoryURL)
 	if err != nil {
 		return err
 	}
 
-	if err := ensureWorkspaceDirectory(cleanWorkspacePath); err != nil {
-		return fmt.Errorf("%w: preparing workspace path: %v", ErrCloneFailed, err)
+	if prepareErr := ensureWorkspaceDirectory(cleanWorkspacePath); prepareErr != nil {
+		return fmt.Errorf("%w: preparing workspace path: %v", ErrCloneFailed, prepareErr)
 	}
-	if err := clearWorkspaceDirectoryContents(cleanWorkspacePath); err != nil {
-		return fmt.Errorf("%w: resetting workspace contents: %v", ErrCloneFailed, err)
+	if resetErr := clearWorkspaceDirectoryContents(cleanWorkspacePath); resetErr != nil {
+		return fmt.Errorf("%w: resetting workspace contents: %v", ErrCloneFailed, resetErr)
 	}
-	if err := gitClone(ctx, repoURL, cleanWorkspacePath); err != nil {
+	if credential != nil {
+		err = gitCloneWithHTTPSCredential(ctx, repoURL, cleanWorkspacePath, *credential)
+	} else {
+		err = gitClone(ctx, repoURL, cleanWorkspacePath)
+	}
+	if err != nil {
 		return fmt.Errorf("%w: %v", ErrCloneFailed, err)
 	}
 

--- a/backend/internal/source/workspace_source_resolver_test.go
+++ b/backend/internal/source/workspace_source_resolver_test.go
@@ -70,6 +70,16 @@ func TestGitWorkspaceSourceResolver_CloneAndCheckout(t *testing.T) {
 			t.Fatalf("expected main sha %q, got %q", mainSHA, resolved)
 		}
 	})
+
+	t.Run("authenticated clone", func(t *testing.T) {
+		if cloneErr := resolver.CloneIntoWorkspaceWithHTTPSCredential(context.Background(), workspacePath, remoteDir, HTTPSCredential{Username: "x-access-token", Password: "test-token"}); cloneErr != nil {
+			t.Fatalf("authenticated clone failed: %v", cloneErr)
+		}
+		resolved, checkoutErr := resolver.CheckoutWorkspaceSource(context.Background(), workspacePath, WorkspaceSourceSpec{RepositoryURL: remoteDir, Ref: "feature/source-phase"})
+		if checkoutErr != nil || resolved != featureSHA {
+			t.Fatalf("authenticated checkout resolved=%q err=%v", resolved, checkoutErr)
+		}
+	})
 }
 
 func TestGitWorkspaceSourceResolver_CloneIntoWorkspace_PreservesWorkspaceDirectoryInode(t *testing.T) {

--- a/backend/internal/source/workspace_source_resolver_test.go
+++ b/backend/internal/source/workspace_source_resolver_test.go
@@ -146,4 +146,15 @@ func TestGitWorkspaceSourceResolver_Failures(t *testing.T) {
 	if err := resolver.CloneIntoWorkspace(context.Background(), workspacePath, "/no/such/repo"); !errors.Is(err, ErrCloneFailed) {
 		t.Fatalf("expected ErrCloneFailed, got %v", err)
 	}
+
+	if err := resolver.CloneIntoWorkspaceWithHTTPSCredential(context.Background(), workspacePath, "https://github.com/acme/repository.git", HTTPSCredential{}); !errors.Is(err, ErrCloneFailed) {
+		t.Fatalf("expected authenticated clone credential failure, got %v", err)
+	}
+
+	if _, _, err := normalizeCloneInputs("relative", "https://github.com/acme/repository.git"); !errors.Is(err, ErrWorkspacePathRequired) {
+		t.Fatalf("expected relative workspace rejection, got %v", err)
+	}
+	if _, _, err := normalizeCloneInputs(workspacePath, "-invalid"); !errors.Is(err, ErrRepositoryURLRequired) {
+		t.Fatalf("expected option URL rejection, got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Adds repository-aware authenticated checkout for builds backed by registered GitHub repositories.

Mapped repositories now resolve checkout credentials through their snapshotted SCM connection and provider repository identity rather than relying on a stored clone URL alone. The build service validates the current registration and connection state, retrieves the repository’s current clone URL from GitHub, exchanges a repository-restricted GitHub App installation token, and uses that credential for both worker checkout and API-time pipeline fetches.

The implementation also adds a narrowly scoped credential-refresh path. When Git explicitly rejects an installation token, checkout retries exactly once with a newly exchanged token for the same app registration, installation, API base URL, and repository restriction.

## What Changed

### Repository-aware checkout

* Added `RepositoryAwareCheckoutResolver` to validate and resolve:

  * the snapshotted registered repository ID
  * SCM connection ID
  * provider repository ID
  * current repository and connection enabled state
  * GitHub App registration and installation configuration
  * the configured private-key secret
* Verifies that the snapshot still matches the registered repository before accessing credentials.
* Retrieves the repository’s current clone URL from GitHub by immutable provider repository ID, allowing checkout to continue after repository renames or transfers.
* Requests installation tokens restricted to the mapped repository.
* Fails closed when the repository identity, connection, provider configuration, secret, or authenticated source capability is unavailable.

### Build integration

* Wired repository-aware checkout into both the API server and worker.
* Propagated the repository identity snapshot into resolved build source specifications.
* Updated worker workspace checkout to use authenticated repository-aware cloning for mapped repositories.
* Updated API-time repository fetches used during build creation to use the same repository-aware resolution and retry behavior.
* Preserved the existing unauthenticated fetch path for legacy or unmapped repositories.

### Credential refresh

* Added `GetFreshInstallationToken` to force a new GitHub App installation-token exchange without clearing unrelated cache entries.
* Token cache and refresh scope now include:

  * app registration
  * installation
  * API base URL
  * normalized repository restrictions
* Concurrent refreshes for the same scope are coalesced into one exchange.
* Ordinary cached-token behavior remains unchanged.
* A failed forced refresh preserves the previously cached token entry.

### Git credential handling

* Added authenticated HTTPS extensions for repository fetch and workspace clone operations.
* Uses a unique temporary `GIT_ASKPASS` script for each Git attempt.
* Passes credentials through environment variables rather than embedding them in repository URLs or command arguments.
* Disables interactive Git prompting.
* Removes temporary askpass material after each attempt.
* Redacts token values from captured Git errors.

### Retry classification

Checkout retries once only for explicit credential rejection, including:

* authentication failed
* bad or invalid credentials
* credential rejected
* HTTP 401

The following remain terminal and do not trigger token refresh:

* repository unavailable or not found
* HTTP 404
* authorization or permission denial
* invalid refs
* network and timeout failures
* rate limits
* generic Git failures

## Testing

Added coverage for:

* exact repository-identity validation
* repository and connection enabled-state enforcement
* repository rename handling through current provider coordinates
* repository-restricted installation-token requests
* provider and registration mismatches
* inaccessible repositories
* authenticated worker checkout
* authenticated API-time fetch
* exactly-once credential retry
* non-authentication failures remaining terminal
* successful concurrent token-refresh coalescing
* failed refresh preserving the existing cache entry
* unique askpass paths
* askpass cleanup
* token redaction from Git errors
* preservation of legacy unmapped-fetch behavior

Validation completed successfully:

* GitHub App package statement coverage: **85.2%**
* Build package statement coverage: **86.6%**
* Source package statement coverage: **77.1%**

The source package aggregate includes pre-existing Git and ref helpers outside this change. New authentication-classification, askpass-cleanup, and redaction branches have direct test coverage.

## Compatibility

* No database migrations
* No API or protocol changes
* No Swagger changes
* No changes to legacy unmapped repository fetch behavior
* Existing unrelated user changes were preserved
